### PR TITLE
Better error message when ssh-agent isn't aware of the ssh key

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -46,6 +46,8 @@ var deploy = module.exports = function(api, params) {
       } else {
         return new Bacon.Error(error);
       }
+    } else if(error.message && error.message.trim() === "error authenticating:"){
+      return new Bacon.Error(error.message.trim() + " Did you add your ssh key ?");
     } else {
       return new Bacon.Error(error);
     }


### PR DESCRIPTION
If the ssh-agent is running but the ssh key wasn't added with ssh-add, the error message will be "Error authenticating:" without more details.