### PR TITLE
scripts: explicitely use bash

### DIFF
--- a/scripts/install-autocomplete.sh
+++ b/scripts/install-autocomplete.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/uninstall-autocomplete.sh
+++ b/scripts/uninstall-autocomplete.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
We use a lot of bashisms, hence do not try to use any posix shell.
sh is dash on ubuntu, which doesn't support half the things we use.

fixes #26

Signed-off-by: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>