### PR TITLE
Handle image variant in instance types list.

### DIFF
--- a/src/models/application.js
+++ b/src/models/application.js
@@ -59,7 +59,7 @@ Application.getInstanceType = function(api, type) {
 
   return s_types.flatMapLatest(function(types) {
     var matchingTypes = _.filter(types, function(instanceType) {
-      return instanceType.type == type;
+      return instanceType.type == type || (instanceType.variant && instanceType.variant.slug == type);
     });
 
     var instanceType = _.sortBy(matchingTypes, "version").reverse()[0];


### PR DESCRIPTION
The API response to GET /products/instances will change a bit and include a new field:
```json
"variant": {
    "id": "<uuid>",
    "slug": "variant-slug",
    "name": "Variant Name"
}
```
We need to change how to check the instance availability when creating an application: we need to not only check the instance type but also the variant slug.
