### PR TITLE
Try to create a git remote when linking an application. Fixes #32

### DIFF
--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -14,9 +14,14 @@ var link = module.exports = function(api, params) {
 
   var s_app = Application.linkRepo(api, appId, alias);
 
-  s_app.onValue(function(app) {
+  var s_appWithRemote = s_app.flatMapLatest(function(app) {
+    return Git.createRemote(app.alias, app.deploy_url)
+              .flatMapLatest(function() { return app; });
+  });
+
+  s_appWithRemote.onValue(function() {
     Logger.println("Your application has been successfully linked!");
   });
 
-  s_app.onError(Logger.error);
+  s_appWithRemote.onError(Logger.error);
 };

--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -60,7 +60,9 @@ AppConfiguration.addLinkedApplication = function(appData, alias) {
     return config;
   });
 
-  return s_newConfig.flatMapLatest(AppConfiguration.persistConfig);
+  return s_newConfig
+    .flatMapLatest(AppConfiguration.persistConfig)
+    .flatMapLatest(function() { return appEntry });
 };
 
 AppConfiguration.removeLinkedApplication = function(alias) {

--- a/src/models/git.js
+++ b/src/models/git.js
@@ -89,8 +89,10 @@ module.exports = function(repositoryPath) {
     var s_existingRemote = Git.getRemote(name);
 
     var s_existingValidRemote = s_existingRemote.skipErrors().flatMapLatest(function(remote) {
-      Logger.debug("Check that the current \"" + name + "\" remote point to the right URL…");
-      return remote.url() == url ? Bacon.once(remote) : new Bacon.Error("The \"" + name + "\" remote already exist and does not point to " + url);
+      Logger.debug("Checking that the current \"" + name + "\" remote point to the right URL…");
+      return remote.url() == url
+        ? Bacon.once(remote)
+        : new Bacon.Error("The \"" + name + "\" remote already exists and does not point to " + url);
     });
 
     // Create a remote only if it does not already exist


### PR DESCRIPTION
Poke @Keruspe 

My ideal solution would be to make the remote not mandatory. If it's there, it's cool to have it for tracking purposes, but if it's not it should not prevent the user from deploying.
For now, it's better than nothing.