### PR TITLE
nodegit: bump to 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.11.0",
-    "nodegit": "0.6.3",
+    "nodegit": "0.13.1",
     "request": "^2.67.0",
     "shelljs": "^0.5.3",
     "unidecode": "^0.1.8",

--- a/src/models/git.js
+++ b/src/models/git.js
@@ -97,8 +97,9 @@ module.exports = function(repositoryPath) {
     var s_newRemote = s_existingRemote.errors().flatMapError(function() {
       Logger.debug("Create a \"" + name + "\" remote pointing to " + url);
       return Git.getRepository().flatMapLatest(function(repository) {
-        Bacon.fromPromise(nodegit.Remote.create(repository, name, url));
         Logger.debug("Created remote " + name);
+        return Bacon.fromPromise(nodegit.Remote.create(repository, name, url));
+      }).flatMapLatest(function(){
         return Git.getRemote(name);
       });
     });


### PR DESCRIPTION
This adds support for node 6 and don't seem to impact other things despite the breaking changes.

Also, nodegit will follow node versions, meaning that all LTS will be covered and 0.x branches support will be dropped. 

#52 should be fine after this PR