### PR TITLE
Implement `clever open`

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -73,6 +73,7 @@ var activity = lazyRequiref("../src/commands/activity.js");
 var addon = lazyRequire("../src/commands/addon.js");
 var list = lazyRequiref("../src/commands/list.js");
 var scale = lazyRequiref("../src/commands/scale.js");
+var open = lazyRequiref("../src/commands/open.js");
 
 var Application = lr("../src/models/application.js");
 
@@ -470,6 +471,13 @@ function run() {
     ]
   }, scale);
 
+  //OPEN COMMAND
+  var openCommand = cliparse.command("open", {
+    description: "Open an application in the browser",
+    options: [ aliasOption ]
+  }, open);
+
+
   // CLI PARSER
   var cliParser = cliparse.cli({
     name: "clever",
@@ -492,7 +500,8 @@ function run() {
       activityCommand,
       addonCommands,
       listCommand,
-      scaleCommand
+      scaleCommand,
+      openCommand
     ]
   });
 

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,0 +1,23 @@
+var _ = require("lodash");
+
+var AppConfiguration = require("../models/app_configuration.js");
+var Domain = require("../models/domain.js");
+var OpenBrowser = require("../open-browser.js");
+
+var Logger = require("../logger.js");
+
+var open = module.exports = function(api, params) {
+  var alias = params.options.alias;
+  var s_appData = AppConfiguration.getAppData(alias);
+  var s_vhost = s_appData.flatMapLatest(function(appData) {
+    return Domain.getBest(api, appData.app_id, appData.orga_id);
+  });
+
+  var s_open = s_vhost.flatMapLatest(function(vhost) {
+    Logger.println("Opening the application in your browser");
+    return OpenBrowser.openPage("http://" + vhost.fqdn);
+  });
+
+  s_open.onValue();
+  s_open.onError(Logger.error);
+};

--- a/src/models/domain.js
+++ b/src/models/domain.js
@@ -15,13 +15,13 @@ Domain.list = function(api, appId, orgaId) {
 };
 
 Domain.create = function(api, fqdn, appId, orgaId) {
-  var params = orgaId ? [orgaId, appId, fqdn] : [appId, fqdn];
+  var params = orgaId ? [orgaId, appId, encodeURIComponent(fqdn)] : [appId, encodeURIComponent(fqdn)];
 
   return api.owner(orgaId).applications._.vhosts._.put().withParams(params).send();
 };
 
 Domain.remove = function(api, fqdn, appId, orgaId) {
-  var params = orgaId ? [orgaId, appId, fqdn] : [appId, fqdn];
+  var params = orgaId ? [orgaId, appId, encodeURIComponent(fqdn)] : [appId, encodeURIComponent(fqdn)];
 
   return api.owner(orgaId).applications._.vhosts._.delete().withParams(params).send();
 };

--- a/src/open-browser.js
+++ b/src/open-browser.js
@@ -1,0 +1,59 @@
+var exec = require("child_process").exec;
+var nodeUrl = require("url");
+
+var _ = require("lodash");
+var Bacon = require("baconjs");
+
+var Logger = require("./logger.js");
+
+var OpenBrowser = module.exports;
+
+OpenBrowser.getCommand = function(url) {
+  Logger.debug("Get the right command to open a tab in a browser…")
+
+  try {
+    var parsed = nodeUrl.parse(url);
+    if(parsed.protocol === null || parsed.hostname === null) {
+      return new Bacon.Error("Invalid url provided");
+    }
+  } catch {
+    return new Bacon.Error("Invalid url provided");
+  }
+
+  switch(process.platform) {
+    case "darwin":
+      return Bacon.constant("open " + url);
+    case "linux":
+      return Bacon.constant("xdg-open " + url);
+    case "win32":
+      return Bacon.constant("start " + url);
+    default:
+      return new Bacon.Error("Unsupported platform: " + process.platform);
+  }
+}
+
+OpenBrowser.run = function(command) {
+  return Bacon.fromBinder(function(sink) {
+    Logger.debug("Opening browser")
+    exec(command, function(error, stdout, stderr) {
+      // Don't consider output in stderr as a blocking error because of
+      // firefox
+      if(error) {
+        sink(new Bacon.Error(error));
+      } else {
+        sink(stdout);
+      }
+      sink(new Bacon.End());
+    });
+
+    return function(){};
+  });
+}
+
+OpenBrowser.openPage = function(url) {
+  var s_command = OpenBrowser.getCommand(url);
+
+  return s_command.flatMapLatest(function(command) {
+    return OpenBrowser.run(command);
+  });
+}


### PR DESCRIPTION
Fixes #43 
Extracts the browser opening logic from clever login in a more reusable module.
Fixes an issue with domain names and path_begin filtering.