### PR TITLE
open-browser: spawn browser instead of exec

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -65,6 +65,15 @@ var login = module.exports = function(api, params) {
     .flatMapLatest(writeLoginConfig)
     .map(conf.CONFIGURATION_FILE + " has been updated.");
 
-  result.onValue(Logger.println);
-  result.onError(Logger.error);
+  // Force process exit, otherwhise, it will be kept alive
+  // because of the spawn() call (in src/open-browser.js)
+  result.onValue(function(message){
+    Logger.println(message);
+    process.exit(0);
+  });
+
+  result.onError(function(error){
+    Logger.error(error);
+    process.exit(1);
+  });
 };

--- a/src/open-browser.js
+++ b/src/open-browser.js
@@ -16,7 +16,7 @@ OpenBrowser.getCommand = function(url) {
     if(parsed.protocol === null || parsed.hostname === null) {
       return new Bacon.Error("Invalid url provided");
     }
-  } catch {
+  } catch(e) {
     return new Bacon.Error("Invalid url provided");
   }
 


### PR DESCRIPTION
If the browser is not yet opened, exec will wait until the browser is
closed to receive data and ask for tokens.

spawn allow to start the browser if not already opened and it stays alive
after clever-tools is closed