### PR TITLE
Implement service dependencies management with `clever service`

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -6,105 +6,85 @@ var Logger = require("../logger.js");
 
 var AppConfig = require("../models/app_configuration.js");
 var Addon = require("../models/addon.js");
+var Organisation = require("../models/organisation.js");
 
 var colors = require("colors");
 
 var addon = module.exports;
 
 var list = addon.list = function(api, params) {
-  var alias = params.options.alias;
-  var showAll = params.options["show-all"];
+  var orgaIdOrName = params.options.org;
+  var s_orgaId = Organisation.getId(api, orgaIdOrName);
 
-  var s_appData = AppConfig.getAppData(alias);
-
-  var s_addon = s_appData.flatMap(function(appData) {
-    return Addon.list(api, appData.app_id, appData.org_id, showAll);
+  var s_addons = s_orgaId.flatMapLatest(function(orgaId) {
+    return Addon.list(api, orgaId);
   });
 
-  s_addon.onValue(function(addons) {
+  s_addons.onValue(function(addons) {
     var nameWidth = Math.max.apply(null,   _(addons).map("name").filter().map("length").value());
     var planWidth = Math.max.apply(null,   _(addons).map("plan").map("name").map("length").value());
     var regionWidth = Math.max.apply(null, _(addons).map("region").map("length").value());
     var typeWidth = Math.max.apply(null,   _(addons).map("provider").map("name").map("length").value());
 
-    var renderLine = function(addon, showLinked) {
-      return (showLinked && addon.isLinked ? '* ' : '  ') +
-        '[' + _.padEnd(addon.plan.name, planWidth) + ' ' +
-              _.padEnd(addon.provider.name, typeWidth) + '] ' +
-              _.padEnd(addon.region, regionWidth) + ' ' +
-              _.padEnd(addon.name, nameWidth).bold.green + ' ' +
-              addon.id;
+    var renderLine = function(addon) {
+      return '[' + _.padEnd(addon.plan.name, planWidth) + ' ' +
+                   _.padEnd(addon.provider.name, typeWidth) + '] ' +
+                   _.padEnd(addon.region, regionWidth) + ' ' +
+                   _.padEnd(addon.name, nameWidth).bold.green + ' ' +
+                   addon.id;
     };
 
-    Logger.println(addons.map(function(addon) {
-      return renderLine(addon, showAll);
-    }).join('\n'));
+    Logger.println(
+      addons.map(renderLine)
+            .join('\n'));
   });
 
-  s_addon.onError(Logger.error);
+  s_addons.onError(Logger.error);
 };
 
 var create = addon.create = function(api, params) {
   var providerName = params.args[0];
   var name = params.args[1];
-  var alias = params.options.alias;
+  var linkTo = params.options.link;
   var plan = params.options.plan;
   var region = params.options.region;
   var skipConfirmation = params.options.yes;
+  var orgaIdOrName = params.options.org;
 
-  var s_appData = AppConfig.getAppData(alias);
-  var s_result = s_appData.flatMap(function(appData) {
-    return Addon.create(api, appData.app_id, appData.org_id, name, providerName, plan, region, skipConfirmation);
+  var s_orgaId = Organisation.getId(api, orgaIdOrName);
+
+  var s_result = s_orgaId.flatMapLatest(function(orgaId) {
+    if(linkTo) {
+      return AppConfig.getAppData(linkTo).flatMapLatest(function(appData) {
+        if(orgaIdOrName && appData.orgaId !== orgaId) {
+          Logger.warn("The specified application does not belong to the specified organisation. Ignoring the `--org` option");
+        }
+        return Addon.createAndLink(api, name, providerName, plan, region, skipConfirmation, appData);
+      });
+    } else {
+      return Addon.create(api, orgaId, name, providerName, plan, region, skipConfirmation);
+    }
   });
 
   s_result.onValue(function(r) {
-    Logger.println("Addon " + name + " sucessfully created and linked to the application");
-  });
-  s_result.onError(Logger.error);
-};
-
-var link = addon.link = function(api, params) {
-  var alias = params.options.alias;
-  var addonIdOrName = params.args[0];
-
-  var s_appData = AppConfig.getAppData(alias);
-
-  var s_result = s_appData.flatMap(function(appData) {
-    return Addon.link(api, appData.app_id, appData.org_id, addonIdOrName);
-  });
-
-  s_result.onValue(function() {
-    Logger.println("Addon " + (addonIdOrName.addon_id || addonIdOrName.addon_name) + " sucessfully linked");
-  });
-  s_result.onError(Logger.error);
-};
-
-var unlink = addon.unlink = function(api, params) {
-  var alias = params.options.alias;
-  var addonIdOrName = params.args[0];
-
-  var s_appData = AppConfig.getAppData(alias);
-
-  var s_result = s_appData.flatMap(function(appData) {
-    return Addon.unlink(api, appData.app_id, appData.org_id, addonIdOrName);
-  });
-
-  s_result.onValue(function() {
-    Logger.println("Addon " + (addonIdOrName.addon_id || addonIdOrName.addon_name) + " sucessfully unlinked");
+    if(linkTo) {
+      Logger.println("Addon " + name + " sucessfully created and linked to the application");
+    } else {
+      Logger.println("Addon " + name + " sucessfully created");
+    }
   });
   s_result.onError(Logger.error);
 };
 
 var adelete = addon.delete = function(api, params) {
-  var alias = params.options.alias;
   var skipConfirmation = params.options.yes;
   var addonIdOrName = params.args[0];
+  var orgaIdOrName = params.options.org;
 
-  var s_appData = AppConfig.getAppData(alias);
+  var s_orgaId = Organisation.getId(api, orgaIdOrName);
 
-
-  var s_result = s_appData.flatMap(function(appData) {
-    return Addon.delete(api, appData.org_id, addonIdOrName, skipConfirmation);
+  var s_result = s_orgaId.flatMap(function(orgaId) {
+    return Addon.delete(api, orgaId, addonIdOrName, skipConfirmation);
   });
 
   s_result.onValue(function() {
@@ -114,14 +94,12 @@ var adelete = addon.delete = function(api, params) {
 };
 
 var rename = addon.rename = function(api, params) {
-  var alias = params.options.alias;
   var addonIdOrName = params.args[0];
   var newName = params.args[1];
+  var orgaIdOrName = params.options.org;
 
-  var s_appData = AppConfig.getAppData(alias);
-
-  var s_result = s_appData.flatMap(function(appData) {
-    return Addon.rename(api, appData.org_id, addonIdOrName, newName);
+  var s_result = Organisation.getId(api, orgaIdOrName).flatMap(function(orgaId) {
+    return Addon.rename(api, orgaId, addonIdOrName, newName);
   });
 
   s_result.onValue(function() {

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -10,7 +10,7 @@ var open = module.exports = function(api, params) {
   var alias = params.options.alias;
   var s_appData = AppConfiguration.getAppData(alias);
   var s_vhost = s_appData.flatMapLatest(function(appData) {
-    return Domain.getBest(api, appData.app_id, appData.orga_id);
+    return Domain.getBest(api, appData.app_id, appData.org_id);
   });
 
   var s_open = s_vhost.flatMapLatest(function(vhost) {

--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -1,0 +1,45 @@
+var _ = require("lodash");
+var Bacon = require("baconjs");
+
+var Logger = require("../logger.js");
+
+var AppConfig = require("../models/app_configuration.js");
+var Application = require("../models/application.js");
+var Addon = require("../models/addon.js");
+
+var service = module.exports;
+
+var list = service.list = function(api, params) {
+  var alias = params.options.alias;
+  var showAll = params.options["show-all"];
+  var onlyApps = params.options["only-apps"];
+  var onlyAddons = params.options["only-addons"];
+
+  if(onlyApps && onlyAddons) {
+    Logger.error("--only-apps and --only-addons are mutually exclusive");
+    process.exit(1);
+  } else {
+    var s_appData = AppConfig.getAppData(alias);
+
+    var s_dependencies = s_appData.flatMap(function(appData) {
+      return Bacon.combineTemplate({
+        apps: !onlyAddons ? Application.listDependencies(api, appData.app_id, appData.org_id, showAll) : null,
+        addons: !onlyApps ? Addon.list(api, appData.app_id, appData.org_id, showAll) : null
+      });
+    });
+
+    s_dependencies.onValue(function(dependencies) {
+      if(dependencies.apps !== null) {
+        Logger.println("Applications:");
+        Logger.println(dependencies.apps.map(function(x) { return "  " + x.name; }).join('\n'));
+      }
+      if(dependencies.addons !== null) {
+        Logger.println("Addons:");
+        Logger.println(dependencies.addons.map(function(x) { return "  " + x.name; }).join('\n'));
+      }
+    });
+
+    s_dependencies.onError(Logger.error);
+  }
+
+};

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -220,3 +220,13 @@ Application.setScalability = function(api, appId, orgaId, scalabilityParameters)
     return api.owner(orgaId).applications._.put().withParams(params).send(JSON.stringify(instance));
   })
 };
+
+Application.listDependencies = function(api, appId, orgaId, showAll) {
+  if(!showAll) {
+    var params = orgaId ? [orgaId, appId] : [appId];
+    return api.owner(orgaId).applications._.dependencies.get().withParams(params).send();
+  } else {
+    var params = orgaId ? [orgaId] : [];
+    return api.owner(orgaId).applications.get().withParams(params).send();
+  }
+}


### PR DESCRIPTION
Harmonize addon management under `clever addon`. Addon management does not
accept `--alias` since addon management is organisation-wide.

`clever addon` commands now all take a `--org` option to specify the
organisation. Only `clever addon create` takes a `--link` option (akin to
`--alias`).