### PR TITLE
Update clever-client to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "baconjs": "^0.7.83",
     "bluebird": "^3.1.1",
-    "clever-client": "^0.3.0",
+    "clever-client": "^0.3.1",
     "cliparse": "^0.2.6",
     "colors": "^1.1.2",
     "common-env": "^5.4.0",


### PR DESCRIPTION
No more node-expat compilation with clever-client 0.3.1