### PR TITLE
drop support for node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4.7"
   - "6.9"
   - "7.5"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clever cloud"
   ],
   "engines": {
-    "node": ">=0.12.7 <8"
+    "node": ">=4 <8"
   },
   "author": "Rodolphe Belouin <rodolphe.belouin@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
deprecated since january 2017
nodegit doesn't provide binaries for node 0.12 anymore
more and more deps are complaining that they expect >=4
this speeds up travis checks a lot