### PR TITLE
WIP: Logs deploymentId

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -229,6 +229,10 @@ function run() {
     metavar: "search",
     description: "Fetch logs matching this pattern"
   });
+  var deploymentIdOption = cliparse.option("deployment-id", {
+    metavar: "deployment_id",
+    description: "Fetch logs for a given deployment"
+  });
   var listAllNotificationsOption = cliparse.flag("list-all", {
     description: "List all notifications for your user or for an organisation with the `--org` option"
   });
@@ -372,7 +376,8 @@ function run() {
       aliasOption,
       beforeOption,
       afterOption,
-      searchOption
+      searchOption,
+      deploymentIdOption
     ]
   }, logs);
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var path = require("path");
 
 var _ = require("lodash");

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -14,11 +14,12 @@ var appLogs = module.exports = function(api, params) {
   var before = params.options.before;
   var after = params.options.after;
   const search = params.options.search;
+  const deploymentId = params.options["deployment-id"];
 
   var s_appData = AppConfig.getAppData(alias);
 
   var s_logs = s_appData.flatMapLatest(function(app_data) {
-    return Log.getAppLogs(api, app_data.app_id, null, before, after, search);
+    return Log.getAppLogs(api, app_data.app_id, null, before, after, search, deploymentId);
   });
 
   s_logs.onValue(Logger.println);

--- a/src/models/log.js
+++ b/src/models/log.js
@@ -87,7 +87,7 @@ Log.getContinuousLogs = function(api, appId, before, after, search, deploymentId
     Logger.warn("Websocket has been closed, reconnecting…");
     var newAfter = after.getTime() > endTimestamp.getTime() ? after : endTimestamp;
     return Bacon.later(1500, null).flatMapLatest(function() {
-      return Log.getContinuousLogs(api, appId, before, newAfter);
+      return Log.getContinuousLogs(api, appId, before, newAfter, search, deploymentId);
     });
   });
 


### PR DESCRIPTION
Allow to only fetch logs for a given deployment with `clever logs --deployment-id`

Only display logs for the current deployment in `clever deploy` and `clever restart`

Fixes #42 

Also fixes #130 as it changes the way deployment events are filtered