### PR TITLE
Display `realId` of the add-on

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -68,9 +68,9 @@ var create = addon.create = function(api, params) {
 
   s_result.onValue(function(r) {
     if(linkTo) {
-      Logger.println("Addon " + name + " successfully created and linked to the application");
+      Logger.println("Addon " + name + " (" + r.realId +") successfully created and linked to the application");
     } else {
-      Logger.println("Addon " + name + " successfully created");
+      Logger.println("Addon " + name + " (" + r.realId +") successfully created");
     }
   });
   s_result.onError(Logger.error);

--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -35,7 +35,7 @@ var list = service.list = function(api, params) {
       }
       if(dependencies.addons !== null) {
         Logger.println("Addons:");
-        Logger.println(dependencies.addons.map(function(x) { return (x.isLinked ? "* " : "  ") + x.name; }).join('\n'));
+        Logger.println(dependencies.addons.map(function(x) { return (x.isLinked ? "* " : "  ") + x.name + " (" + x.realId + ")"; }).join('\n'));
       }
     });
 


### PR DESCRIPTION
Display `realId` of the add-on when calling `clever service`: because when I call `clever env`, I can't get an environment variable for the linked fs-bucket of an application.
It's useful if you want to generate a `bucket.json` file.

Display `realId` of the add-on when calling `clever addon create ...` (same reason)