### PR TITLE
Fix libssl package name for apt based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Command Line Interface for Clever Cloud.
 
 ```
 # openssl-dev is needed
-apt-get install openssl-dev# on apt systems
+apt-get install libssl-dev # on apt systems
 
 npm install -g clever-tools
 


### PR DESCRIPTION
Current README suggests installing `openssl-dev`.
I couldn find any package with its name:

See for instance:

- [debian search](https://packages.debian.org/search?keywords=openssl-dev&searchon=names&suite=stable&section=all)

- [user not finding it in a severfault post](https://serverfault.com/questions/249340/install-openssl-dev-on-ubuntu-server)

The proper package should be `libssl-dev` (see [package presentation](https://packages.debian.org/stretch/libssl-dev)).