### PR TITLE
Only use console.log & console.error

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,36 +1,33 @@
-var _ = require("lodash");
+'use strict'
 
-var processApiError = function(error) {
-  if(error.id && error.message) {
-    var line = error.message + " [" + error.id + "]";
-    if(error.fields) {
-      line += "\n" + Object.keys(error.fields).map(function(field) {
-        return field + ": " + error.fields[field];
-      }).join("\n");
+const _ = require('lodash')
+
+const processApiError = function (error) {
+  if (error.id == null || error.message == null) {
+    return error
+  }
+  const fields = _.map(error.fields, (msg, field) => `${field}: ${msg}`)
+  return [`${error.message} [${error.id}]`, ...fields].join('\n')
+}
+
+const Logger = _(['debug', 'info', 'warn', 'error'])
+  .map((severity) => {
+    if (process.env['CLEVER_QUIET'] || !process.env['CLEVER_VERBOSE'] && (severity === 'debug' || severity === 'info')) {
+      return [severity, _.noop]
     }
-    return line;
-  } else {
-    return error;
-  }
-};
-
-// For each severity, print "[SEVERITY] <message>"
-var Logger = _.reduce(["debug", "info", "warn", "error"], function(logger, severity) {
-  var f = console[severity] || console.log;
-  if(!process.env["CLEVER_QUIET"] && (process.env["CLEVER_VERBOSE"] || (severity !== "debug" && severity !== "info"))) {
-    logger[severity] = _.flowRight(_.partial(f.bind(console), "[" + severity.toUpperCase() + "]"), processApiError);
-  } else {
-    logger[severity] = function() {};
-  }
-  return logger;
-}, module.exports);
+    const consoleFn = (severity === 'error') ? console.error : console.log
+    return [severity, (error) => consoleFn(`[${severity.toUpperCase()}]`, processApiError(error))]
+  })
+  .fromPairs()
+  .value()
 
 // No decoration for Logger.println
-Logger.println = console.log.bind(console.log);
+Logger.println = console.log
 
 // No decoration for Logger.printErrorLine
-Logger.printErrorLine = console.error.bind(console.error);
+Logger.printErrorLine = console.error
 
 // Only exported for testing, shouldn't be used directly
-Logger.processApiError = processApiError;
+Logger.processApiError = processApiError
 
+module.exports = Logger


### PR DESCRIPTION
This fixes remove usage of `console.debug` and `console.warn` to use `console.log` for everything except for errors (where we use `console.error`).

I also took the liberty to refactor some sutffs:

* Add `use_strict`
* Use some ES6+ goodies like spread, const or arrow functions
* Remove bind calls since `console` is a namespace like `Math` or `JSON`

More infos on the "autobind" behaviour:

* https://bugs.chromium.org/p/chromium/issues/detail?id=167911
* https://bugs.webkit.org/show_bug.cgi?id=157286
* https://github.com/whatwg/console/issues/3#issuecomment-254363388
* https://console.spec.whatwg.org/#console-namespace
* https://wpt.fyi/console

FYI, it works on Chrome, Node, Safari, FF but not yet in Edge.

Fixes #134.