### PR TITLE
Replace FPM with node modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,12 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
       "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
     },
+    "ar-async": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ar-async/-/ar-async-0.1.4.tgz",
+      "integrity": "sha1-kvdtYlMjrA0qLeuJnCexD8nOoOA=",
+      "dev": true
+    },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
@@ -187,7 +193,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
           "dev": true
         }
       }
@@ -4491,7 +4497,7 @@
     "cliparse": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/cliparse/-/cliparse-0.3.0.tgz",
-      "integrity": "sha512-xG9x+XuOLcKv9pqmbKyWvUuSl7KC2ZDG7ktJSyPRAIxEr4eQSABJw470n9gMIlP5h6RY2uYZCiOpSf8xyIwdvw==",
+      "integrity": "sha1-FatxTajWtPFqYH+lXstLGm9xbQc=",
       "requires": {
         "bluebird": "3.5.0",
         "lodash": "4.17.4",
@@ -4517,7 +4523,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4787,6 +4793,15 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "error-ex": {
@@ -5102,7 +5117,7 @@
     "fs-extra": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
@@ -5207,6 +5222,45 @@
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-expand": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/glob-expand/-/glob-expand-0.1.0.tgz",
+      "integrity": "sha1-+rNWBjkewYFwPB8KonqHzQW/mjA=",
+      "dev": true,
+      "requires": {
+        "glob": "4.4.2",
+        "lodash": "1.2.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.2.tgz",
+          "integrity": "sha1-Pvk+KX7glsG5s/+x0hAlx4q2BUg=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "lodash": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz",
+          "integrity": "sha1-7UexbkbwaytAMJto6RY8F+k+owQ=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        }
       }
     },
     "globals": {
@@ -6318,7 +6372,7 @@
     "moment": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+      "integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
     },
     "ms": {
       "version": "2.0.0",
@@ -6345,10 +6399,40 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
     },
+    "natives": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.2.tgz",
+      "integrity": "sha512-5bRASydE1gu6zPOenLN043++J8xj1Ob7ArkfdYO3JN4DF5rDmG7bMoiybkTyD+GnXQEMixVeDHMzuqm6kpBmiA==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "nobin-debian-installer": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/nobin-debian-installer/-/nobin-debian-installer-0.0.10.tgz",
+      "integrity": "sha1-OGQF9EWKveg1HunOVYoNfDN7jCg=",
+      "dev": true,
+      "requires": {
+        "ar-async": "0.1.4",
+        "async": "2.6.0",
+        "debug": "2.6.8",
+        "glob-expand": "0.1.0",
+        "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
     },
     "node-fetch": {
       "version": "2.1.1",
@@ -6560,7 +6644,7 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
       "dev": true
     },
     "parse-json": {
@@ -6675,7 +6759,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -6712,7 +6796,7 @@
         "resolve": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+          "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
@@ -6761,7 +6845,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -6798,7 +6882,7 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
           "dev": true
         },
         "supports-color": {
@@ -7031,6 +7115,160 @@
         "inherits": "2.0.3"
       }
     },
+    "rpm-builder": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rpm-builder/-/rpm-builder-0.7.0.tgz",
+      "integrity": "sha512-GDPlrKAYrw05ODxJATqU+KXNqcMxyYCdu6PNVCxDaR7JMz87dPZVRdSLKw4kwPxZ9soYHgK5kvRzpha3FAeYoA==",
+      "dev": true,
+      "requires": {
+        "chalk": "0.5.1",
+        "dateformat": "2.2.0",
+        "fs-extra": "0.16.5",
+        "globby": "1.2.0",
+        "lodash": "4.17.4",
+        "shortid": "2.2.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "0.16.5",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+          "integrity": "sha1-GtZh+myGyWCM0bSe/G/Og0k5p1A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "3.0.11",
+            "jsonfile": "2.4.0",
+            "rimraf": "2.6.1"
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "globby": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+          "integrity": "sha1-x8l60cxvhZSBHaHrgpBqhSukfaQ=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "async": "0.9.2",
+            "glob": "4.5.3",
+            "object-assign": "2.1.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "dev": true,
+          "requires": {
+            "natives": "1.1.2"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -7114,6 +7352,12 @@
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
       }
+    },
+    "shortid": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
+      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -7371,6 +7615,18 @@
             "util-deprecate": "1.0.2"
           }
         }
+      }
+    },
+    "tar-stream": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "dev": true,
+      "requires": {
+        "bl": "1.0.3",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.0.6",
+        "xtend": "4.0.1"
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "grunt-mocha-test": "^0.13.2",
     "mocha": "^3.1.0",
     "pkg": "^4.2.0",
-    "shelljs": "^0.7.0"
+    "shelljs": "^0.7.0",
+    "rpm-builder": "^0.7.0",
+    "nobin-debian-installer": "^0.0.10"
   },
   "scripts": {
     "test": "grunt test"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -10,13 +10,12 @@ RUN apt-get update -qqy && \
         g++ \
         curl \
         git \
-        ruby \
-        ruby-dev gcc \
         libffi-dev \
-        make \
         libc-dev \
-        rpm && \
-    gem install --no-ri --no-rdoc fpm
+        libssl-dev \
+        zip \
+        make \
+        rpm
 
 ADD https://nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz /tmp/node.tar.gz
 RUN cd /usr/local && \

--- a/scripts/clever-wrapper.sh
+++ b/scripts/clever-wrapper.sh
@@ -1,3 +1,3 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 PATH="$PATH:/usr/lib/clever-tools-bin/" /usr/lib/clever-tools-bin/clever "$@"

--- a/scripts/deb/postinstall.sh
+++ b/scripts/deb/postinstall.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+mv /usr/bin/clever-wrapper.sh /usr/bin/clever
+chmod 755 /usr/bin/clever
+chmod 755 /usr/lib/clever-tools-bin/clever

--- a/scripts/deb/postuninstall.sh
+++ b/scripts/deb/postuninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+rm -f /usr/bin/clever
+rm -fr /usr/lib/clever-tools-bin

--- a/scripts/deb/preinstall.sh
+++ b/scripts/deb/preinstall.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+mkdir -p /usr/lib/clever-tools-bin/

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
`FPM` is a great tool but depends on `Ruby` which is not actually the stack.

**ATTENTION** `rpm` binary still mandatory (there is no way to create `.rpm` without `rpm` binary)

```bash
apt-get install rpm
yum install rpm-build
```

Replace `FPM` which two node modules, one for `rpm` other for `deb`.

How to build using `Dockerfile`

```bash
cd scripts/
docker build --no-cache -t clever-tools-builder .
cd ..
docker run -it --rm -v $(pwd):/ws -w ws clever-tools-builder bash
npm rebuild
npm i
node scripts/build-release.js
```

In addition, I take as much as possible information from `package.json` like _app name_, _license_, etc to be _DRY_

Related to #213