### PR TITLE
Avoid useless loading of nodegit

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,12 +1,10 @@
 var _ = require("lodash");
 var path = require("path");
 var Bacon = require("baconjs");
-var nodegit = require("nodegit");
 
 var Logger = require("../logger.js");
 
 var Application = require("../models/application.js");
-var Git = require("../models/git.js")(path.resolve("."));
 
 var create = module.exports = function(api, params) {
   var name = params.args[0];

--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -1,13 +1,11 @@
 var _ = require("lodash");
 var path = require("path");
 var Bacon = require("baconjs");
-var nodegit = require("nodegit");
 
 var Logger = require("../logger.js");
 
 var AppConfig = require("../models/app_configuration.js");
 var Domain = require("../models/domain.js");
-var Git = require("../models/git.js")(path.resolve("."));
 
 var domain = module.exports;
 

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -1,12 +1,10 @@
 var _ = require("lodash");
 var path = require("path");
 var Bacon = require("baconjs");
-var nodegit = require("nodegit");
 
 var Logger = require("../logger.js");
 
 var Application = require("../models/application.js");
-var Git = require("../models/git.js")(path.resolve("."));
 
 var link = module.exports = function(api, params) {
   var appIdOrName = params.args[0];

--- a/src/commands/notifications.js
+++ b/src/commands/notifications.js
@@ -1,7 +1,6 @@
 var _ = require("lodash");
 var path = require("path");
 var Bacon = require("baconjs");
-var nodegit = require("nodegit");
 var colors = require("colors");
 
 var Logger = require("../logger.js");

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -6,7 +6,6 @@ var colors = require("colors");
 
 var AppConfig = require("../models/app_configuration.js");
 var Application = require("../models/application.js");
-var Git = require("../models/git.js")(path.resolve("."));
 var Log = require("../models/log.js");
 
 var Logger = require("../logger.js");

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -5,7 +5,6 @@ var Bacon = require("baconjs");
 
 var AppConfig = require("../models/app_configuration.js");
 var Application = require("../models/application.js");
-var Git = require("../models/git.js")(path.resolve("."));
 var Log = require("../models/log.js");
 
 var Logger = require("../logger.js");


### PR DESCRIPTION
Explicit require of nodegit when we don't need it forces us to have nodegit properly built on our target platform (which can be tricky) even when we don't actually use it (we don't use `clever deploy` but instead direct git push).

I'm not sure if
 - that make sense
 - that actually fixes my problem
 - the resulting archive is loadable (couldn't find a way to test it)

Please advice :pray: 