### PR TITLE
add "clever version"

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -603,6 +603,13 @@ function run () {
     args: [args.alias],
   }, unlink);
 
+  // VERSION COMMAND
+  const version = lazyRequireFunctionWithApi('../src/commands/version.js');
+  const versionCommand = cliparse.command('version', {
+    description: 'Display the version',
+    args: [],
+  }, version);
+
   // WEBHOOKS COMMAND
   const addWebhookCommand = cliparse.command('add', {
     description: 'Register webhook to be called when events happen',
@@ -653,6 +660,7 @@ function run () {
       sshCommand,
       statusCommand,
       stopCommand,
+      versionCommand,
       webhooksCommand,
     ],
   });

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Logger = require('../logger.js');
+const { version: package_version } = require('../../package');
+
+function version () {
+  Logger.println(package_version);
+}
+
+module.exports = version;


### PR DESCRIPTION
Currently, we have `--version` but we do not have a `version` subcommand which is quite common in projets using subcommands like us