### PR TITLE
 Display unspecified name in bold red for `clever login` and `clever  profile`

### DIFF
--- a/src/commands/activity.js
+++ b/src/commands/activity.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const Bacon = require('baconjs');
-const colors = require('colors');
+const colors = require('colors/safe');
 const moment = require('moment');
 
 const Activity = require('../models/activity.js');

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const { URL } = require('url');
 
 const Bacon = require('baconjs');
-const colors = require('colors');
+const colors = require('colors/safe');
 const request = require('request');
 
 const handleCommandStream = require('../command-stream-handler');

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -77,7 +77,10 @@ function login (api, params) {
       if (isInteractiveLogin) {
         return initApi()
           .flatMapLatest((api) => User.getCurrent(api))
-          .flatMapLatest(({ name, email }) => Logger.println(`Login successful as ${name} <${email}>`));
+          .flatMapLatest(({ name, email }) => {
+            const formattedName = name || colors.red.bold('[unspecified name]');
+            return Logger.println(`Login successful as ${formattedName} <${email}>`);
+          });
       }
     });
 

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const colors = require('colors/safe');
+
 const handleCommandStream = require('../command-stream-handler');
 const Logger = require('../logger.js');
 const User = require('../models/user.js');
@@ -9,8 +11,9 @@ function profile (api) {
   const s_currentUser = User.getCurrent(api)
     .map(({ name, email, preferredMFA }) => {
       const has2FA = (preferredMFA != null && preferredMFA !== 'NONE') ? 'yes' : 'no';
+      const formattedName = name || colors.red.bold('[not specified]');
       Logger.println('You\'re currently logged in as:');
-      Logger.println('Name:           ', name);
+      Logger.println('Name:           ', formattedName);
       Logger.println('Email:          ', email);
       Logger.println('Two factor auth:', has2FA);
     });


### PR DESCRIPTION
Fixes #278 