### PR TITLE
remove datadog tcp creation drain, add new datadog http drain creation

### DIFF
--- a/src/models/drain.js
+++ b/src/models/drain.js
@@ -14,7 +14,8 @@ const DRAIN_TYPES = [
   { id: 'TCPSyslog' },
   { id: 'UDPSyslog' },
   { id: 'HTTP', credentials: 'OPTIONAL' },
-  { id: 'ElasticSearch', credentials: 'MANDATORY' }
+  { id: 'ElasticSearch', credentials: 'MANDATORY' },
+  { id: 'DatadogHTTP' },
 ];
 
 const makeJsonRequest = function (api, verb, url, queryParams, body) {

--- a/src/models/drain.js
+++ b/src/models/drain.js
@@ -14,8 +14,7 @@ const DRAIN_TYPES = [
   { id: 'TCPSyslog' },
   { id: 'UDPSyslog' },
   { id: 'HTTP', credentials: 'OPTIONAL' },
-  { id: 'ElasticSearch', credentials: 'MANDATORY' },
-  { id: 'Datadog', datadogAPIKey: 'MANDATORY' },
+  { id: 'ElasticSearch', credentials: 'MANDATORY' }
 ];
 
 const makeJsonRequest = function (api, verb, url, queryParams, body) {
@@ -74,12 +73,6 @@ function create (api, appId, drainTargetURL, drainTargetType, drainTargetCredent
         username: drainTargetCredentials.username || '',
         password: drainTargetCredentials.password || '',
       };
-    }
-    if (drainTargetType === 'Datadog') {
-      if (drainTargetConfig.apiKey == null) {
-        return Bacon.once(new Bacon.Error(`APIKey is mandatory on for this drain type.`));
-      }
-      body.APIKey = drainTargetConfig.apiKey;
     }
     return makeJsonRequest(api, 'POST', `/logs/${appId}/drains`, {}, body);
   }


### PR DESCRIPTION
We keep the management of them, but creation is now unavailable.