### PR TITLE
Fix clever service link-app #320

### DIFF
--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -45,7 +45,7 @@ function list (api, params) {
 }
 
 function linkApp (api, params) {
-  const { alias } = params.options.alias;
+  const { alias } = params.options;
   const [appIdOrName] = params.args;
 
   const s_result = AppConfig.getAppData(alias)


### PR DESCRIPTION
Fix application alias parameter when using 'service link-app'.