### PR TITLE
Import environment variables from a JSON value

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -131,6 +131,7 @@ function run () {
       aliases: ['f'],
       description: 'Display access logs continuously (ignores before/until, after/since)',
     }),
+    importJSON: cliparse.flag('json', { description: 'Import env variables from a JSON value' }),
     addonId: cliparse.option('addon', { metavar: 'addon_id', description: 'Addon ID' }),
     after: cliparse.option('after', {
       metavar: 'after',
@@ -495,6 +496,7 @@ function run () {
   }, env('rm'));
   const envImportCommand = cliparse.command('import', {
     description: 'Load environment variables from STDIN\n(WARNING: this deletes all current variables and replace them with the new list loaded from STDIN)',
+    options: [opts.importJSON]
   }, env('importEnv'));
   const envImportVarsCommand = cliparse.command('import-vars', {
     description: 'Add or update environment variables named <variable-names> (comma separated), taking their values from the current environment',

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -58,10 +58,11 @@ async function rm (params) {
 };
 
 async function importEnv (params) {
-  const { alias } = params.options;
+  const { alias, json } = params.options;
+  const format = json ? 'json' : 'env';
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
 
-  const vars = await variables.readVariablesFromStdin();
+  const vars = await variables.readVariablesFromStdin(format);
   await application.updateAllEnvVars({ id: ownerId, appId }, vars).then(sendToApi);
 
   Logger.println('Environment variables have been set');

--- a/src/models/variables.js
+++ b/src/models/variables.js
@@ -27,9 +27,22 @@ function readStdin () {
   });
 }
 
-async function readVariablesFromStdin () {
+function parseFromJSON (rawStdin) {
+  try {
+    const json = JSON.parse(rawStdin);
+    // The JSON structure is not checked before sending it to the API.
+    // In the case of an error, the API call will fail and an error will
+    // be logged. It could be possible to add a check here to improve the
+    // UX a bit (but we'd have to make sure it's consistent with what the
+    // API checks).
+    return json;
+  }
+  catch (e) {
+    throw new Error('Error when parsing json', e);
+  }
+}
 
-  const rawStdin = await readStdin();
+function parseEnvLines (rawStdin) {
   const { variables, errors } = parseRaw(rawStdin);
 
   if (errors.length !== 0) {
@@ -55,6 +68,20 @@ async function readVariablesFromStdin () {
   }
 
   return toNameValueObject(variables);
+}
+
+async function readVariablesFromStdin (format = 'env') {
+
+  const rawStdin = await readStdin();
+
+  switch (format) {
+    case 'env':
+      return parseEnvLines(rawStdin);
+    case 'json':
+      return parseFromJSON(rawStdin);
+    default:
+      throw new Error("Unrecognized environment input format. Available formats are 'env' and 'json'");
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
# Context

In automated environments, the `env`-like format requires manual generation and is error-prone.
Reading directly a JSON value allows easier plugging in CI setups, as well as eliminating corner cases (empty vars, multiline vars, etc).

# Changes

This PR adds a `--json` flag to `clever env import`, allowing to read values in JSON format.

# Questions

For symmetry, I could add json support in `clever env export` as well