### PR TITLE
Add the ability to set dedicated build instances flavors

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -225,6 +225,11 @@ function run () {
         return cliparse.autocomplete.words(Application('listAvailableFlavors')());
       },
     }),
+    buildFlavor: cliparse.option('build-flavor', {
+      metavar: 'buildflavor',
+      parser: Parsers.buildFlavor,
+      description: 'The size of the build instance, or `disabled` if you want to disable dedicated build instances'
+    }),
     maxInstances: cliparse.option('max-instances', {
       metavar: 'maxinstances',
       parser: Parsers.instances,
@@ -569,7 +574,7 @@ function run () {
   const scale = lazyRequireFunctionWithApi('../src/commands/scale.js');
   const scaleCommand = cliparse.command('scale', {
     description: 'Change scalability of an application',
-    options: [opts.alias, opts.flavor, opts.minFlavor, opts.maxFlavor, opts.instances, opts.minInstances, opts.maxInstances],
+    options: [opts.alias, opts.flavor, opts.minFlavor, opts.maxFlavor, opts.instances, opts.minInstances, opts.maxInstances, opts.buildFlavor],
   }, scale);
 
   // SERVICE COMMANDS

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -12,6 +12,13 @@ function flavor (flavor) {
   return cliparse.parsers.error('Invalid value: ' + flavor);
 }
 
+function buildFlavor (flavorOrDisabled) {
+  if (flavorOrDisabled === 'disabled') {
+    return cliparse.parsers.success(flavorOrDisabled);
+  }
+  return flavor(flavorOrDisabled);
+}
+
 function instances (instances) {
   const parsedInstances = parseInt(instances, 10);
   if (isNaN(parsedInstances)) {
@@ -59,6 +66,7 @@ function addonIdOrName (string) {
 }
 
 module.exports = {
+  buildFlavor,
   flavor,
   instances,
   date,


### PR DESCRIPTION
As discussed in #331, here's is a candidate implementation. Since we weren't sure on the UI part, I've split the change in two commits:

- one for the model part
- one for the UI part

Regardless of the UI, the model part _both_:
- toggles the `dedicatedBuildInstances` setting
- sets `buildFlavor`

This reflects the console UI where the two settings are somehow tied. It could be done with two orthogonal flags, but I fear it would be counter intuitive to be able to set a build flavor while keeping dedicated build instances disabled.