### PR TITLE
WIP: Fix match of target string when it is "organisation".

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -288,7 +288,7 @@ function run () {
     }),
     noUpdateNotifier: cliparse.flag('no-update-notifier', { description: `Don't notify available updates for clever-tools` }),
     emailNotificationTarget: cliparse.option('notify', {
-      metavar: '<email_address>|<user_id>|organisation',
+      metavar: '<email_address>|<user_id>|"organisation"',
       description: 'Notify a user, a specific email address or the whole organisation (multiple values allowed, comma separated)',
       required: true,
       parser: Parsers.commaSeparated,

--- a/src/commands/notify-email.js
+++ b/src/commands/notify-email.js
@@ -52,7 +52,7 @@ function getEmailNotificationTargets (notifTargets) {
       if (el.startsWith('user_')) {
         return { type: 'userid', target: el };
       }
-      if (el === 'organisation') {
+      if (el.toLowerCase() === 'organisation') {
         return { type: 'organisation' };
       }
     })


### PR DESCRIPTION
`clever notify-email add --help` reads:

```
Usage: clever notify-email add --notify <EMAIL_ADDRESS>|<USER_ID>|ORGANISATION NAME
```

So people write "ORGANISATION". The code was only allowing for "organisation" (lowercase).

This PR fixes it.

Also, the help text is weird and people may read `"organisation name"` instead of `"…|organisation" name`