### PR TITLE
Add `--json` option to `clever env` and `clever published-config`

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -3,13 +3,13 @@
 
 // These need to be set before Logger and other stuffs
 if (process.argv.includes('-v') || process.argv.includes('--verbose')) {
-  process.env['CLEVER_VERBOSE'] = '1';
+  process.env.CLEVER_VERBOSE = '1';
 }
 
 // These need to be set before Logger and other stuffs
 // Don't log anything in autocomplete mode
 if (process.argv.includes('--autocomplete-index')) {
-  process.env['CLEVER_QUIET'] = '1';
+  process.env.CLEVER_QUIET = '1';
 }
 
 const cliparse = require('cliparse');
@@ -199,12 +199,12 @@ function run () {
     }),
     forceDeploy: cliparse.flag('force', {
       aliases: ['f'],
-      description: `Force deploy even if it's not fast-forwardable`,
+      description: 'Force deploy even if it\'s not fast-forwardable',
     }),
     webhookFormat: cliparse.option('format', {
       metavar: 'format',
       default: 'raw',
-      description: `Format of the body sent to the webhook ('raw', 'slack', 'gitter', or 'flowdock')`,
+      description: 'Format of the body sent to the webhook (\'raw\', \'slack\', \'gitter\', or \'flowdock\')',
     }),
     github: cliparse.option('github', {
       metavar: 'OWNER/REPO',
@@ -258,7 +258,7 @@ function run () {
       parser: Parsers.instances,
       description: 'The minimum number of parallels instances',
     }),
-    noUpdateNotifier: cliparse.flag('no-update-notifier', { description: `Don't notify available updates for clever-tools` }),
+    noUpdateNotifier: cliparse.flag('no-update-notifier', { description: 'Don\'t notify available updates for clever-tools' }),
     emailNotificationTarget: cliparse.option('notify', {
       metavar: '<email_address>|<user_id>|"organisation"',
       description: 'Notify a user, a specific email address or the whole organisation (multiple values allowed, comma separated)',
@@ -285,7 +285,7 @@ function run () {
       description: 'Addon plan, depends on the provider',
       complete: Addon('completePlan'),
     }),
-    quiet: cliparse.flag('quiet', { aliases: ['q'], description: `Don't show logs during deployment` }),
+    quiet: cliparse.flag('quiet', { aliases: ['q'], description: 'Don\'t show logs during deployment' }),
     addonRegion: cliparse.option('region', {
       aliases: ['r'],
       default: 'eu',
@@ -297,7 +297,7 @@ function run () {
       aliases: ['r'],
       default: 'par',
       metavar: 'zone',
-      description: `Region, can be 'par' for Paris or 'mtl' for Montreal`,
+      description: 'Region, can be \'par\' for Paris or \'mtl\' for Montreal',
       complete: Application('listAvailableZones'),
     }),
     search: cliparse.option('search', {

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -496,14 +496,14 @@ function run () {
   const envImportCommand = cliparse.command('import', {
     description: 'Load environment variables from STDIN\n(WARNING: this deletes all current variables and replace them with the new list loaded from STDIN)',
   }, env('importEnv'));
-  const envImportVarsCommand = cliparse.command('import-vars', {
+  const envImportVarsFromLocalEnvCommand = cliparse.command('import-vars', {
     description: 'Add or update environment variables named <variable-names> (comma separated), taking their values from the current environment',
     args: [args.envVariableNames],
-  }, env('importEnvVars'));
+  }, env('importVarsFromLocalEnv'));
   const envCommands = cliparse.command('env', {
     description: 'Manage Clever Cloud application environment',
     options: [opts.alias, opts.sourceableEnvVarsList],
-    commands: [envSetCommand, envRemoveCommand, envImportCommand, envImportVarsCommand],
+    commands: [envSetCommand, envRemoveCommand, envImportCommand, envImportVarsFromLocalEnvCommand],
   }, env('list'));
 
   // LINK COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -131,6 +131,7 @@ function run () {
       aliases: ['f'],
       description: 'Display access logs continuously (ignores before/until, after/since)',
     }),
+    importAsJson: cliparse.flag('json', { description: 'Import variables as JSON (an array of { "name": "THE_NAME", "value": "the value" } objects)' }),
     addonId: cliparse.option('addon', { metavar: 'addon_id', description: 'Addon ID' }),
     after: cliparse.option('after', {
       metavar: 'after',
@@ -495,6 +496,7 @@ function run () {
   }, env('rm'));
   const envImportCommand = cliparse.command('import', {
     description: 'Load environment variables from STDIN\n(WARNING: this deletes all current variables and replace them with the new list loaded from STDIN)',
+    options: [opts.importAsJson],
   }, env('importEnv'));
   const envImportVarsFromLocalEnvCommand = cliparse.command('import-vars', {
     description: 'Add or update environment variables named <variable-names> (comma separated), taking their values from the current environment',
@@ -590,6 +592,7 @@ function run () {
   }, publishedConfig('rm'));
   const publishedConfigImportCommand = cliparse.command('import', {
     description: 'Load published configuration from STDIN\n(WARNING: this deletes all current variables and replace them with the new list loaded from STDIN)',
+    options: [opts.importAsJson],
   }, publishedConfig('importEnv'));
   const publishedConfigCommands = cliparse.command('published-config', {
     description: 'Manage the configuration made available to other applications by this application',

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -585,11 +585,11 @@ function run () {
     args: [args.envVariableName, args.envVariableValue],
   }, publishedConfig('set'));
   const publishedConfigRemoveCommand = cliparse.command('rm', {
-    description: 'Remove a published configuration item from a Clever Cloud application',
+    description: 'Remove a published configuration variable from a Clever Cloud application',
     args: [args.envVariableName],
   }, publishedConfig('rm'));
   const publishedConfigImportCommand = cliparse.command('import', {
-    description: 'Load published configuration from STDIN',
+    description: 'Load published configuration from STDIN\n(WARNING: this deletes all current variables and replace them with the new list loaded from STDIN)',
   }, publishedConfig('importEnv'));
   const publishedConfigCommands = cliparse.command('published-config', {
     description: 'Manage the configuration made available to other applications by this application',

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   "scripts": {
     "pretest": "npm run lint",
     "test": "grunt test",
-    "lint": "eslint src scripts",
-    "lint:fix": "eslint --fix src scripts"
+    "lint": "eslint bin src scripts",
+    "lint:fix": "eslint --fix bin src scripts"
   },
   "repository": {
     "type": "git",

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -67,7 +67,7 @@ async function importEnv (params) {
   Logger.println('Environment variables have been set');
 };
 
-async function importEnvVars (params) {
+async function importVarsFromLocalEnv (params) {
   const [envNames] = params.args;
   const { alias } = params.options;
 
@@ -88,4 +88,4 @@ async function importEnvVars (params) {
   Logger.println('Your environment variables have been successfully saved');
 };
 
-module.exports = { list, set, rm, importEnv, importEnvVars };
+module.exports = { list, set, rm, importEnv, importVarsFromLocalEnv };

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -58,11 +58,12 @@ async function rm (params) {
 };
 
 async function importEnv (params) {
-  const { alias } = params.options;
+  const { alias, json } = params.options;
+  const format = json ? 'json' : 'name-equals-value';
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
 
-  const vars = await variables.readVariablesFromStdin();
-  await application.updateAllEnvVars({ id: ownerId, appId }, vars).then(sendToApi);
+  const envVars = await variables.readVariablesFromStdin(format);
+  await application.updateAllEnvVars({ id: ownerId, appId }, envVars).then(sendToApi);
 
   Logger.println('Environment variables have been set');
 };

--- a/src/commands/published-config.js
+++ b/src/commands/published-config.js
@@ -50,10 +50,11 @@ async function rm (params) {
 };
 
 async function importEnv (params) {
-  const { alias } = params.options;
+  const { alias, json } = params.options;
+  const format = json ? 'json' : 'name-equals-value';
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
 
-  const publishedConfigs = await variables.readVariablesFromStdin();
+  const publishedConfigs = await variables.readVariablesFromStdin(format);
   await application.updateAllExposedEnvVars({ id: ownerId, appId }, publishedConfigs).then(sendToApi);
 
   Logger.println('Your published configs have been set');


### PR DESCRIPTION
This is a follow-up of the work started by @clementd-fretlink in https://github.com/CleverCloud/clever-tools/pull/326

NOTES: Some code will be move in the clever-client to be also used in the clever-components:

* https://github.com/CleverCloud/clever-client.js/issues/28
* https://github.com/CleverCloud/clever-components/issues/97