### PR TITLE
add domain favourite commands

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -477,10 +477,30 @@ function run () {
     description: 'Remove a domain name from a Clever Cloud application',
     args: [args.fqdn],
   }, domain('rm'));
+  const domainGetFavouriteCommand = cliparse.command('get', {
+    description: 'Get the favourite domain for a Clever Cloud application',
+    options: [opts.alias],
+    args: [],
+  }, domain('getFavourite'));
+  const domainSetFavouriteCommand = cliparse.command('set', {
+    description: 'Set the favourite domain for a Clever Cloud application',
+    options: [opts.alias],
+    args: [args.fqdn],
+  }, domain('setFavourite'));
+  const domainUnsetFavouriteCommand = cliparse.command('unset', {
+    description: 'Unset the favourite domain for a Clever Cloud application',
+    options: [opts.alias],
+    args: [args.fqdn],
+  }, domain('unsetFavourite'));
+  const domainFavouriteCommands = cliparse.command('favourite', {
+    description: 'Manage Clever Cloud application favourite domain name',
+    options: [opts.alias],
+    commands: [domainGetFavouriteCommand, domainSetFavouriteCommand, domainUnsetFavouriteCommand],
+  }, domain('getFavourite'));
   const domainCommands = cliparse.command('domain', {
     description: 'Manage Clever Cloud application domain names',
     options: [opts.alias],
-    commands: [domainCreateCommand, domainRemoveCommand],
+    commands: [domainCreateCommand, domainFavouriteCommands, domainRemoveCommand],
   }, domain('list'));
 
   // DRAIN COMMANDS

--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
-const AppConfig = require("../models/app_configuration.js");
-const Logger = require("../logger.js");
+const AppConfig = require('../models/app_configuration.js');
+const Logger = require('../logger.js');
 const {
   get: getApp,
   addDomain,
@@ -9,10 +9,10 @@ const {
   markFavouriteDomain,
   unmarkFavouriteDomain,
   removeDomain,
-} = require("@clevercloud/client/cjs/api/application.js");
-const { sendToApi } = require("../models/send-to-api.js");
+} = require('@clevercloud/client/cjs/api/application.js');
+const { sendToApi } = require('../models/send-to-api.js');
 
-async function list(params) {
+async function list (params) {
   const { alias } = params.options;
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
 
@@ -20,17 +20,17 @@ async function list(params) {
   return app.vhosts.forEach(({ fqdn }) => Logger.println(fqdn));
 }
 
-async function add(params) {
+async function add (params) {
   const [fqdn] = params.args;
   const { alias } = params.options;
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
   const encodedFqdn = encodeURIComponent(fqdn);
 
   await addDomain({ id: ownerId, appId, domain: encodedFqdn }).then(sendToApi);
-  Logger.println("Your domain has been successfully saved");
+  Logger.println('Your domain has been successfully saved');
 }
 
-async function getFavourite(params) {
+async function getFavourite (params) {
   const { alias } = params.options;
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
 
@@ -40,51 +40,53 @@ async function getFavourite(params) {
       if (error.id === 4021) {
         // No favourite vhost
         return { fqdn: null };
-      } else {
+      }
+      else {
         throw error;
       }
     });
   if (fqdn != null) {
     return Logger.println(fqdn);
-  } else {
-    return Logger.println("No favourite domain set");
+  }
+  else {
+    return Logger.println('No favourite domain set');
   }
 }
 
-async function setFavourite(params) {
+async function setFavourite (params) {
   const [fqdn] = params.args;
   const { alias } = params.options;
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
   const encodedFqdn = encodeURIComponent(fqdn);
 
   await markFavouriteDomain({ id: ownerId, appId, domain: encodedFqdn }).then(
-    sendToApi
+    sendToApi,
   );
-  Logger.println("Your favourite domain has been successfully set");
+  Logger.println('Your favourite domain has been successfully set');
 }
 
-async function unsetFavourite(params) {
+async function unsetFavourite (params) {
   const [fqdn] = params.args;
   const { alias } = params.options;
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
   const encodedFqdn = encodeURIComponent(fqdn);
 
   await unmarkFavouriteDomain({ id: ownerId, appId, domain: encodedFqdn }).then(
-    sendToApi
+    sendToApi,
   );
-  Logger.println("Your favourite domain has been successfully unset");
+  Logger.println('Your favourite domain has been successfully unset');
 }
 
-async function rm(params) {
+async function rm (params) {
   const [fqdn] = params.args;
   const { alias } = params.options;
   const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
   const encodedFqdn = encodeURIComponent(fqdn);
 
   await removeDomain({ id: ownerId, appId, domain: encodedFqdn }).then(
-    sendToApi
+    sendToApi,
   );
-  Logger.println("Your domain has been successfully removed");
+  Logger.println('Your domain has been successfully removed');
 }
 
 module.exports = { list, add, getFavourite, setFavourite, unsetFavourite, rm };


### PR DESCRIPTION
I had the need to display the favourite domain for an application. I figured out that setting/unsetting might be useful as well.

As for the naming: 

```
clever domain favourite get 
```
vs
```
clever domain get-favourite
```

I chose to add a `favourite` subcommand as it keeps to the same pattern of short names, I don't know if it feels too much levels of subcommands.




