### PR TITLE
Fix isCleverMessage check in isBuildSucessMessage

### DIFF
--- a/src/models/log.js
+++ b/src/models/log.js
@@ -25,7 +25,8 @@ function isDeploymentFailedMessage (line) {
 };
 
 function isBuildSucessMessage (line) {
-  return _.startsWith(line._source['@message'].toLowerCase(), 'build succeeded in');
+  return isCleverMessage(line)
+    && _.startsWith(line._source['@message'].toLowerCase(), 'build succeeded in');
 };
 
 function formatLogLine (line) {


### PR DESCRIPTION
isCleverMessage was checked in isDeploymentSuccessMessage and isDeploymentFailedMessage, but not isBuildSucessMessage.