### PR TITLE
Access logs: handle possibly undefined source object

### DIFF
--- a/src/models/accesslogs.js
+++ b/src/models/accesslogs.js
@@ -19,12 +19,21 @@ function getFormatter (format, isAddon) {
   }
 }
 
+function formatSource (l) {
+  if (l.s != null) {
+    const location = l.s.ct ? `${l.s.ct}, ${l.s.co}` : l.s.co;
+    return `${l.ipS} - ${location}`;
+  } else {
+    return l.ipS;
+  }
+}
+
 function formatSimple (l) {
   return `${new Date(l.t).toISOString()} ${l.ipS} ${l.vb} ${l.path}`;
 }
 
 function formatExtended (l) {
-  return `${new Date(l.t).toISOString()} [ ${l.ipS} - ${l.s.ct ? `${l.s.ct}, ${l.s.co}` : `${l.s.co}`} ] ${l.vb} ${l.h} ${l.path} ${l.sC}`;
+  return `${new Date(l.t).toISOString()} [ ${formatSource(l)} ] ${l.vb} ${l.h} ${l.path} ${l.sC}`;
 }
 
 function formatCLF (l) {
@@ -36,7 +45,7 @@ function formatSimpleAddon (l) {
 }
 
 function formatExtendedAddon (l) {
-  return `${new Date(l.t).toISOString()} [ ${l.ipS} - ${l.s.ct ? `${l.s.ct}, ${l.s.co}` : `${l.s.co}`} ] duration(ms): ${l.sDuration}`;
+  return `${new Date(l.t).toISOString()} [ ${formatSource(l)} ] duration(ms): ${l.sDuration}`;
 }
 
 function formatCLFAddon (l) {


### PR DESCRIPTION
Fix #399

After this fix, if the source object isn't defined, the log will appear as:
```
2020-11-02T16:31:36.512Z [ 10.2.204.148 ] GET console.clever-cloud.com /ping 304
```

I removed the localization part entirely because the `-` symbol is used as a delimiter in the extended format, not as a missing data symbol like it is in the CLF format.

I don't know if the extended log is meant to be parsed. If it is, how can we replace the source field? Using a `unknown` placeholder text? Or `missing`?