### PR TITLE
format .clever.json for readability

### DIFF
--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -111,7 +111,7 @@ async function getAppDetails ({ alias }) {
 };
 
 function persistConfig (modifiedConfig) {
-  const jsonContents = JSON.stringify(modifiedConfig);
+  const jsonContents = JSON.stringify(modifiedConfig, null, 2);
   return fs.writeFile(conf.APP_CONFIGURATION_FILE, jsonContents);
 };
 


### PR DESCRIPTION
The generated file `.clever.json` could be formatted with indentations for readability convenience.