### PR TITLE
feat: add list env to the cli for addons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ spec/empty-repo
 spec/application.instance-types.js
 .clever.json
 releases/
+.idea/

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -398,10 +398,17 @@ function run () {
     description: 'List available addon providers',
     commands: [addonShowProviderCommand],
   }, addon('listProviders'));
+
+  const addonListEnvs = cliparse.command('list', {
+    description: 'List the env variables for addon',
+    options: [opts.orgaIdOrName],
+    args: [opts.addonId],
+  }, addon('listAddonsEnvCallback'));
+
   const addonCommands = cliparse.command('addon', {
     description: 'Manage addons',
     options: [opts.orgaIdOrName],
-    commands: [addonCreateCommand, addonDeleteCommand, addonRenameCommand, addonProvidersCommand],
+    commands: [addonCreateCommand, addonDeleteCommand, addonRenameCommand, addonProvidersCommand, addonListEnvs],
   }, addon('list'));
 
   // APPLICATIONS COMMAND
@@ -755,6 +762,7 @@ function run () {
       accesslogsCommand,
       activityCommand,
       addonCommands,
+      addonListEnvs,
       appCreateCommand,
       applicationsCommand,
       appLinkCommand,

--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -111,6 +111,14 @@ async function showProvider (params) {
   });
 }
 
+async function listAddonsEnvCallback (params) {
+  const { org } = params.options;
+  const organisationId = org.orga_id;
+  const [addon] = params.args;
+  const response = await Addon.listAddonEnv(organisationId, addon);
+  Logger.println(response);
+}
+
 module.exports = {
   list,
   create,
@@ -118,4 +126,5 @@ module.exports = {
   rename,
   listProviders,
   showProvider,
+  listAddonsEnvCallback,
 };

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -3,7 +3,15 @@
 const application = require('@clevercloud/client/cjs/api/application.js');
 const autocomplete = require('cliparse').autocomplete;
 const colors = require('colors/safe');
-const { get: getAddon, getAll: getAllAddons, remove: removeAddon, create: createAddon, preorder: preorderAddon, update: updateAddon } = require('@clevercloud/client/cjs/api/addon.js');
+const {
+  get: getAddon,
+  getAll: getAllAddons,
+  remove: removeAddon,
+  create: createAddon,
+  preorder: preorderAddon,
+  update: updateAddon,
+  getAllEnvVars,
+} = require('@clevercloud/client/cjs/api/addon.js');
 const { getAllAddonProviders } = require('@clevercloud/client/cjs/api/product.js');
 const { getSummary } = require('@clevercloud/client/cjs/api/user.js');
 
@@ -153,6 +161,13 @@ async function findById (addonId) {
   throw new Error(`Could not find add-on with ID: ${addonId}`);
 }
 
+async function listAddonEnv (organisationId, addonId) {
+  return getAllEnvVars({
+    id: organisationId,
+    addonId,
+  }).then(sendToApi);
+}
+
 module.exports = {
   completePlan,
   completeRegion,
@@ -165,4 +180,5 @@ module.exports = {
   listProviders,
   rename,
   unlink,
+  listAddonEnv,
 };


### PR DESCRIPTION
Hello, we added the possibility to list the env variables of an addon via the CLI,

usage: clever addon list --org <org> <addonId>