### PR TITLE
Add-on: list versions and options of a specific provider, create add-on with available options

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -297,6 +297,14 @@ function run () {
       description: 'Region to provision the addon in, depends on the provider',
       complete: Addon('completeRegion'),
     }),
+    addonVersion: cliparse.option('addon-version', {
+      metavar: 'addon-version',
+      description: 'The version to use for the add-on',
+    }),
+    addonOptions: cliparse.option('option', {
+      metavar: 'option',
+      description: 'Option to enable for the add-on. Multiple --option argument can be passed to enable multiple options',
+    }),
     region: cliparse.option('region', {
       aliases: ['r'],
       default: 'par',
@@ -379,7 +387,7 @@ function run () {
   const addonCreateCommand = cliparse.command('create', {
     description: 'Create an addon',
     args: [args.addonProvider, args.addonName],
-    options: [opts.linkAddon, opts.confirmAddonCreation, opts.addonPlan, opts.addonRegion],
+    options: [opts.linkAddon, opts.confirmAddonCreation, opts.addonPlan, opts.addonRegion, opts.addonVersion, opts.addonOptions],
   }, addon('create'));
   const addonDeleteCommand = cliparse.command('delete', {
     description: 'Delete an addon',

--- a/package-lock.json
+++ b/package-lock.json
@@ -490,9 +490,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "boom": {
       "version": "7.3.0",
@@ -917,13 +917,13 @@
       "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
     "cliparse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cliparse/-/cliparse-0.3.1.tgz",
-      "integrity": "sha512-Bxe5Tl6eq+Ek6v0juw8vxGhTF4ywuDFSu88ANB+iXvtBXxP6Xza4tt6Roq/OsourViQJzPeoQhHtASegqnnVCw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/cliparse/-/cliparse-0.3.3.tgz",
+      "integrity": "sha512-xe+P76J2s98dHCKVZqt7yNwH2MuZAKsrj5723d+ON6l0eSv54okeAMIZXW73it8grI0UHNzq2mAO01XlY+BsbA==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "lodash": "^4.17.11",
-        "minimist": "^1.2.0"
+        "bluebird": "^3.7.2",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5"
       }
     },
     "cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
       }
     },
     "@clevercloud/client": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-6.0.0.tgz",
-      "integrity": "sha512-dqLLujUUP0mDNxTu8rCC43xIVy9+/dyp9zcZNlr3szUtxYDr49UnWXrVKYTkOOhB7QMB/RKxtwrl0dG2c3K2Tw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-7.2.0.tgz",
+      "integrity": "sha512-IdtVjW0FuzlfVdptAVHhywMErvnVJuCaivwFK0jo0vXacw6Uqu45a04Hs42ShYEqKM0luVBIpbR5794dujPtnQ==",
       "requires": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"
@@ -3539,7 +3539,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scripts/*.sh"
   ],
   "dependencies": {
-    "@clevercloud/client": "^6.0.0",
+    "@clevercloud/client": "^7.2.0",
     "clf-date": "^0.2.0",
     "cliparse": "^0.3.1",
     "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@clevercloud/client": "^7.2.0",
     "clf-date": "^0.2.0",
-    "cliparse": "^0.3.1",
+    "cliparse": "^0.3.3",
     "colors": "^1.4.0",
     "common-env": "^6.4.0",
     "eventsource": "^1.0.7",

--- a/src/commands/accesslogs.js
+++ b/src/commands/accesslogs.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { getAccessLogsFromWarp10InBatches, getContinuousAccessLogsFromWarp10 } = require('@clevercloud/client/cjs/access-logs.js');
-const { getWarp10AccessLogsToken } = require('@clevercloud/client/cjs/api/warp-10.js');
+const { getWarp10AccessLogsToken } = require('@clevercloud/client/cjs/api/v2/warp-10.js');
 const { ONE_HOUR_MICROS, ONE_SECOND_MICROS, toMicroTimestamp } = require('@clevercloud/client/cjs/utils/date.js');
 
 const Addon = require('../models/addon.js');

--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -9,6 +9,7 @@ const formatTable = require('../format-table')();
 const Logger = require('../logger.js');
 const Organisation = require('../models/organisation.js');
 const User = require('../models/user.js');
+const { parseAddonOptions } = require('../models/addon.js');
 
 async function list (params) {
   const { org: orgaIdOrName } = params.options;
@@ -30,6 +31,8 @@ async function list (params) {
 async function create (params) {
   const [providerName, name] = params.args;
   const { link: linkedAppAlias, plan: planName, region, yes: skipConfirmation, org: orgaIdOrName } = params.options;
+  const version = params.options['addon-version'];
+  const addonOptions = parseAddonOptions(params.options.option);
 
   const ownerId = (orgaIdOrName != null)
     ? await Organisation.getId(orgaIdOrName)
@@ -47,12 +50,14 @@ async function create (params) {
       planName,
       region,
       skipConfirmation,
+      version,
+      addonOptions,
     });
     await Addon.link(linkedAppData.ownerId, linkedAppData.appId, { addon_id: newAddon.id });
     Logger.println(`Addon ${name} (id: ${newAddon.id}) successfully created and linked to the application`);
   }
   else {
-    const newAddon = await Addon.create({ ownerId, name, providerName, planName, region, skipConfirmation });
+    const newAddon = await Addon.create({ ownerId, name, providerName, planName, region, skipConfirmation, version, addonOptions });
     Logger.println(`Addon ${name} (id: ${newAddon.id}) successfully created`);
   }
 }

--- a/src/commands/cancel-deploy.js
+++ b/src/commands/cancel-deploy.js
@@ -2,7 +2,7 @@
 
 const AppConfig = require('../models/app_configuration.js');
 const Logger = require('../logger.js');
-const { getAllDeployments, cancelDeployment } = require('@clevercloud/client/cjs/api/application.js');
+const { getAllDeployments, cancelDeployment } = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 async function cancelDeploy (params) {

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
 const AppConfig = require('../models/app_configuration.js');
 const Application = require('../models/application.js');

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -7,7 +7,7 @@ const Application = require('../models/application.js');
 const git = require('../models/git.js');
 const Log = require('../models/log.js');
 const Logger = require('../logger.js');
-const { getAllDeployments } = require('@clevercloud/client/cjs/api/application.js');
+const { getAllDeployments } = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 // Once the API call to redeploy() has been triggered successfully,

--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -9,7 +9,7 @@ const {
   markFavouriteDomain,
   unmarkFavouriteDomain,
   removeDomain,
-} = require('@clevercloud/client/cjs/api/application.js');
+} = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 function getFavouriteDomain ({ ownerId, appId }) {

--- a/src/commands/drain.js
+++ b/src/commands/drain.js
@@ -4,7 +4,7 @@ const AppConfig = require('../models/app_configuration.js');
 const { createDrainBody } = require('../models/drain.js');
 const Logger = require('../logger.js');
 
-const { getDrains, createDrain, deleteDrain, updateDrainState } = require('@clevercloud/client/cjs/api/log.js');
+const { getDrains, createDrain, deleteDrain, updateDrainState } = require('@clevercloud/client/cjs/api/v2/log.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 // TODO: This could be useful in other commands

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -5,7 +5,7 @@ const Logger = require('../logger.js');
 const variables = require('../models/variables.js');
 const { sendToApi } = require('../models/send-to-api.js');
 const { toNameEqualsValueString, validateName } = require('@clevercloud/client/cjs/utils/env-vars.js');
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
 async function list (params) {
   const { alias, 'add-export': addExports } = params.options;

--- a/src/commands/notify-email.js
+++ b/src/commands/notify-email.js
@@ -5,7 +5,7 @@ const colors = require('colors/safe');
 const Logger = require('../logger.js');
 const { getOwnerAndApp, getOrgaIdOrUserId } = require('../models/notification.js');
 
-const { getEmailhooks, createEmailhook, deleteEmailhook } = require('@clevercloud/client/cjs/api/notification.js');
+const { getEmailhooks, createEmailhook, deleteEmailhook } = require('@clevercloud/client/cjs/api/v2/notification.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 function displayEmailhook (hook) {

--- a/src/commands/published-config.js
+++ b/src/commands/published-config.js
@@ -5,7 +5,7 @@ const Logger = require('../logger.js');
 const variables = require('../models/variables.js');
 const { sendToApi } = require('../models/send-to-api.js');
 const { toNameEqualsValueString, validateName } = require('@clevercloud/client/cjs/utils/env-vars.js');
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
 async function list (params) {
   const { alias } = params.options;

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -6,7 +6,7 @@ const colors = require('colors/safe');
 const AppConfig = require('../models/app_configuration.js');
 const Logger = require('../logger.js');
 
-const { get: getApplication, getAllInstances } = require('@clevercloud/client/cjs/api/application.js');
+const { get: getApplication, getAllInstances } = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 function displayGroupInfo (instances, commit) {

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const AppConfig = require('../models/app_configuration.js');
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const Logger = require('../logger.js');
 const { sendToApi } = require('../models/send-to-api.js');
 

--- a/src/commands/tcp-redirs.js
+++ b/src/commands/tcp-redirs.js
@@ -7,7 +7,7 @@ const Organisation = require('../models/organisation.js');
 const { sendToApi } = require('../models/send-to-api.js');
 const Interact = require('../models/interact.js');
 const Logger = require('../logger.js');
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
 async function listNamespaces (params) {
   const namespaces = await Organisation.getNamespaces(params);

--- a/src/commands/webhooks.js
+++ b/src/commands/webhooks.js
@@ -5,7 +5,7 @@ const colors = require('colors/safe');
 const Logger = require('../logger.js');
 const { getOwnerAndApp, getOrgaIdOrUserId } = require('../models/notification.js');
 
-const { getWebhooks, createWebhook, deleteWebhook } = require('@clevercloud/client/cjs/api/notification.js');
+const { getWebhooks, createWebhook, deleteWebhook } = require('@clevercloud/client/cjs/api/v2/notification.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 function displayWebhook (hook) {

--- a/src/models/activity.js
+++ b/src/models/activity.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
 const { sendToApi } = require('./send-to-api.js');
 

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const autocomplete = require('cliparse').autocomplete;
 const colors = require('colors/safe');
-const { get: getAddon, getAll: getAllAddons, remove: removeAddon, create: createAddon, preorder: preorderAddon, update: updateAddon } = require('@clevercloud/client/cjs/api/addon.js');
-const { getAllAddonProviders } = require('@clevercloud/client/cjs/api/product.js');
-const { getSummary } = require('@clevercloud/client/cjs/api/user.js');
+const { get: getAddon, getAll: getAllAddons, remove: removeAddon, create: createAddon, preorder: preorderAddon, update: updateAddon } = require('@clevercloud/client/cjs/api/v2/addon.js');
+const { getAllAddonProviders } = require('@clevercloud/client/cjs/api/v2/product.js');
+const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
 
 const Interact = require('./interact.js');
 const Logger = require('../logger.js');

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -6,6 +6,7 @@ const colors = require('colors/safe');
 const { get: getAddon, getAll: getAllAddons, remove: removeAddon, create: createAddon, preorder: preorderAddon, update: updateAddon } = require('@clevercloud/client/cjs/api/v2/addon.js');
 const { getAllAddonProviders } = require('@clevercloud/client/cjs/api/v2/product.js');
 const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
+const { getAddonProvider } = require('@clevercloud/client/cjs/api/v4/addon-providers.js');
 
 const Interact = require('./interact.js');
 const Logger = require('../logger.js');
@@ -22,6 +23,16 @@ async function getProvider (providerName) {
     throw new Error('invalid provider name');
   }
   return provider;
+}
+
+function getProviderInfos (providerName) {
+  return getAddonProvider({ providerId: providerName }).then(sendToApi)
+    .catch(() => {
+      // An error can occur because the add-on api doesn't implement this endpoint yet
+      // This is fine, just ignore it
+      Logger.debug(`${providerName} doesn't yet implement the provider info endpoint`);
+      return Promise.resolve(null);
+    });
 }
 
 async function list (ownerId, appId, showAll) {
@@ -160,6 +171,7 @@ module.exports = {
   delete: deleteAddon,
   findById,
   getProvider,
+  getProviderInfos,
   link,
   list,
   listProviders,

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
-const application = require('@clevercloud/client/cjs/api/application.js');
+const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const autocomplete = require('cliparse').autocomplete;
-const product = require('@clevercloud/client/cjs/api/product.js');
+const product = require('@clevercloud/client/cjs/api/v2/product.js');
 
 const AppConfiguration = require('./app_configuration.js');
 const Interact = require('./interact.js');

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -55,8 +55,8 @@ async function writeOAuthConf (oauthData) {
 }
 
 const conf = env.getOrElseAll({
-  API_HOST: 'https://api.clever-cloud.com/v2',
-  // API_HOST: 'https://ccapi-preprod.cleverapps.io/v2',
+  API_HOST: 'https://api.clever-cloud.com',
+  // API_HOST: 'https://ccapi-preprod.cleverapps.io',
   LOG_WS_URL: 'wss://api.clever-cloud.com/v2/logs/logs-socket/<%- appId %>?since=<%- timestamp %>',
   LOG_HTTP_URL: 'https://api.clever-cloud.com/v2/logs/<%- appId %>',
   EVENT_URL: 'wss://api.clever-cloud.com/v2/events/event-socket',

--- a/src/models/deployments.js
+++ b/src/models/deployments.js
@@ -4,7 +4,7 @@ const { promisify } = require('util');
 const delay = promisify(setTimeout);
 
 const Logger = require('../logger.js');
-const { getDeployment, getAllDeployments } = require('@clevercloud/client/cjs/api/application.js');
+const { getDeployment, getAllDeployments } = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('./send-to-api.js');
 
 const DEPLOYMENT_POLLING_DELAY = 5000;

--- a/src/models/domain.js
+++ b/src/models/domain.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 
 const Logger = require('../logger.js');
-const { getAllDomains, getFavouriteDomain } = require('@clevercloud/client/cjs/api/application.js');
+const { getAllDomains, getFavouriteDomain } = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 async function getBest (appId, orgaId) {

--- a/src/models/log.js
+++ b/src/models/log.js
@@ -5,7 +5,7 @@ const colors = require('colors/safe');
 
 const Logger = require('../logger.js');
 const { Deferred } = require('./utils.js');
-const { getOldLogs } = require('@clevercloud/client/cjs/api/log.js');
+const { getOldLogs } = require('@clevercloud/client/cjs/api/v2/log.js');
 const { LogsStream } = require('@clevercloud/client/cjs/streams/logs.node.js');
 const { sendToApi, getHostAndTokens } = require('./send-to-api.js');
 const { waitForDeploymentEnd, waitForDeploymentStart } = require('./deployments.js');

--- a/src/models/organisation.js
+++ b/src/models/organisation.js
@@ -5,8 +5,8 @@ const autocomplete = require('cliparse').autocomplete;
 
 const AppConfig = require('./app_configuration.js');
 
-const organisation = require('@clevercloud/client/cjs/api/organisation.js');
-const { getSummary } = require('@clevercloud/client/cjs/api/user.js');
+const organisation = require('@clevercloud/client/cjs/api/v2/organisation.js');
+const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 async function getId (orgaIdOrName) {

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { get } = require('@clevercloud/client/cjs/api/organisation.js');
+const { get } = require('@clevercloud/client/cjs/api/v2/organisation.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 function getCurrent () {


### PR DESCRIPTION
This PR does two things that are a bit linked, I could split it in two, you tell me your preferences. This also updates the clever-client to the 7.x branch.

This is linked to #449 .

First, the `clever addon providers show <provider>` will now display available versions and features for each plan, when available. An example with Elasticsearch that has multiple options available

```
Plan xs                  
  CPUs: 1                    
  DISK: 10 GB                
  MEMORY: 1 GB                      
  NODES: 1              
  Type: Dedicated            
  Available versions: 6, 7 (default)
  Options for version 6:     
    kibana: default=false
    apm: default=false              
    encryption: default=false
  Options for version 7:     
    kibana: default=false           
    apm: default=false       
    encryption: default=false
```

Second, the `clever addon create` can now take two new arguments:
- `--addon-version` which can set the version of the add-on you want to create. I could have named it `--version` but it prints clever-tools's version. I didn't really look into how to fix that.
- `--option feature=state` (`--option encryption=true`) to add options when creating your add-on.

For the `--option`, it takes a value of the form `feature=state` because we might want to have options enabled by default at some point. This gives us the possibility to use `--option encryption=false` to disabled it if we ever enable it by default. The API already supports options enabled by default. The `--option` can take multiple values:
- true
- false
- enabled
- disabled

For example, to create a PostgreSQL add-on on version 11 with the encryption at rest enabled on the smaller plan:
```
clever addon create postgresql-addon test-from-cli --plan XXS_SML --addon-version 11 --option encryption=enabled
```

Let me know what you think of this.