### PR TITLE
Addon providers: don't fail listing if add-on's description is null

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -85,7 +85,7 @@ async function listProviders () {
     return [
       colors.bold(provider.id),
       provider.name,
-      provider.shortDesc,
+      provider.shortDesc || '',
     ];
   });
   Logger.println(formatTable(formattedProviders));


### PR DESCRIPTION
I have a custom add-on provider that doesn't have a description. Even though this is my fault and every providers should have a description, it could happen that one day, a provider doesn't have one. :)