### PR TITLE
Change deb, rpm, nupkg publication from bintray to nexus

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('test') {
       agent {
         docker {
-          image 'centos:7'
+          image 'archlinux'
           // Run the container on the node specified at the top-level of the Pipeline, in the same workspace, rather than on a new node entirely:
           reuseNode true
         }
@@ -23,6 +23,7 @@ pipeline {
           sh 'echo "hello foobar"'
           sh 'ls /'
           sh 'uname -a'
+          sh 'cat /etc/os-release'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         docker {
           image 'centos:7'
           // Run the container on the node specified at the top-level of the Pipeline, in the same workspace, rather than on a new node entirely:
-          // reuseNode true
+          reuseNode true
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,76 +11,16 @@ pipeline {
     buildDiscarder(logRotator(daysToKeepStr: '5', numToKeepStr: '10', artifactDaysToKeepStr: '5', artifactNumToKeepStr: '10'))
   }
   stages {
-    stage('build') {
+    stage('test') {
+      agent {
+        docker {
+          image 'centos:7'
+          // Run the container on the node specified at the top-level of the Pipeline, in the same workspace, rather than on a new node entirely:
+          reuseNode true
+        }
+      }
       steps {
-        sh 'npm ci'
-        sh 'node scripts/job-build.js'
-      }
-    }
-    stage('package') {
-      steps {
-        sh 'node scripts/job-package.js'
-      }
-    }
-    stage('publish') {
-      when {
-        not {
-          environment name: 'GIT_TAG_NAME', value: ''
-        }
-        beforeAgent true
-      }
-      parallel {
-        stage('cellar') {
-          steps {
-            sh 'node scripts/job-publish-cellar.js'
-          }
-        }
-        stage('nexus') {
-          steps {
-            sh 'node scripts/job-publish-nexus.sh'
-          }
-        }
-        stage('arch') {
-          steps {
-            script {
-              sshagent (credentials: ['CI_CLEVER_CLOUD_SSH_KEY']) {
-                sh 'node ./scripts/job-publish-arch.js'
-              }
-            }
-          }
-        }
-        stage('brew') {
-          steps {
-            script {
-              sshagent (credentials: ['CI_CLEVER_CLOUD_SSH_KEY']) {
-                sh 'node ./scripts/job-publish-brew.js'
-              }
-            }
-          }
-        }
-        stage('exherbo') {
-          steps {
-            script {
-              sshagent (credentials: ['CI_CLEVER_CLOUD_SSH_KEY']) {
-                sh 'node ./scripts/job-publish-exherbo.js'
-              }
-            }
-          }
-        }
-        stage('npm') {
-          steps {
-            sh 'node ./scripts/job-publish-npm.js'
-          }
-        }
-        stage('dockerhub') {
-          steps {
-            script {
-              sshagent (credentials: ['CI_CLEVER_CLOUD_SSH_KEY']) {
-                sh 'node ./scripts/job-publish-dockerhub.js'
-              }
-            }
-          }
-        }
+          sh 'cat /etc/*release'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'cc-ci-agent' }
+  agent { label 'test-zepag-hyoob-todelete' }
   environment {
     GIT_TAG_NAME = gitTagName()
     S3_KEY_ID = credentials('CELLAR_CC_TOOLS_ACCESS_KEY_ID')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,9 +35,9 @@ pipeline {
             sh 'node scripts/job-publish-cellar.js'
           }
         }
-        stage('bintray') {
+        stage('nexus') {
           steps {
-            sh 'node scripts/job-publish-bintray.js'
+            sh 'node scripts/job-publish-nexus.sh'
           }
         }
         stage('arch') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         docker {
           image 'centos:7'
           // Run the container on the node specified at the top-level of the Pipeline, in the same workspace, rather than on a new node entirely:
-          reuseNode true
+          // reuseNode true
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,9 @@ pipeline {
         }
       }
       steps {
-          sh 'cat /etc/*release'
+          sh 'echo "hello foobar"'
+          sh 'ls /'
+          sh 'uname -a'
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -30,26 +30,26 @@ npm install -g clever-tools@beta
 
 ##### Warning
 
-Bintray is ending on May 1st 2021, we will migrate hosting as soon as possible. Please refer to the dedicated [issue](https://github.com/CleverCloud/clever-tools/issues/454) to track the migration.
+We recently moved from Bintray to a self hosted Nexus repository available at [https://nexus.clever-cloud.com](https://nexus.clever-cloud.com). You have to update the URL of your repository with the new one. If you experience any issue please let us know on the following [issue https://github.com/CleverCloud/clever-tools/issues/454](https://github.com/CleverCloud/clever-tools/issues/454).
 
 ---
 
 If you are using a GNU/Linux distribution that uses `.deb` packages like Debian or Ubuntu, you can run:
 
 ```sh
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "379CE192D401AB61"
-echo "deb https://dl.bintray.com/clevercloud/deb stable main" | tee -a /etc/apt/sources.list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "a7b8f38c536f1df2"
+echo "deb https://nexus.clever-cloud.com/repository/deb stable main" | tee -a /etc/apt/sources.list
 apt-get update
 apt-get install clever-tools
 ```
 
 NOTES:
 
-* The `.deb` packages are hosted on Bintray (their GPG key is required to trust their signed packages).
+* The `.deb` packages are hosted on Clever Cloud's public Nexus instance available at [https://nexus.clever-cloud.com](https://nexus.clever-cloud.com).(their GPG key is required to trust their signed packages).
 * If you want access to the beta channel, you can use this in your `sources.list`:
 
 ```sh
-echo "deb https://dl.bintray.com/clevercloud/deb unstable beta" | tee -a /etc/apt/sources.list
+echo "deb https://nexus.clever-cloud.com/repository/deb bionic unstable beta" | tee -a /etc/apt/sources.list
 ```
 
 #### CentOS/Fedora (.rpm)
@@ -58,21 +58,21 @@ echo "deb https://dl.bintray.com/clevercloud/deb unstable beta" | tee -a /etc/ap
 
 ##### Warning
 
-Bintray is ending on May 1st 2021, we will migrate hosting as soon as possible. Please refer to the dedicated [issue](https://github.com/CleverCloud/clever-tools/issues/454) to track the migration.
+We recently moved from Bintray to a self hosted Nexus repository available at [https://nexus.clever-cloud.com](https://nexus.clever-cloud.com). You have to update the URL of your repository with the new one. If you experience any issue please let us know on the following [issue https://github.com/CleverCloud/clever-tools/issues/454](https://github.com/CleverCloud/clever-tools/issues/454).
 
 ---
 
 If you are using a GNU/Linux distribution that uses `.rpm` packages like CentOS or Fedora, you can run:
 
 ```sh
-curl https://bintray.com/clevercloud/rpm/rpm > /etc/yum.repos.d/bintray-clevercloud-rpm.repo
-echo "exclude=*beta*" >> /etc/yum.repos.d/bintray-clevercloud-rpm.repo
+curl https://nexus.clever-cloud.com/repository/rpm/ > /etc/yum.repos.d/nexus-clevercloud-rpm.repo
+echo "exclude=*beta*" >> /etc/yum.repos.d/nexus-clevercloud-rpm.repo
 yum install clever-tools
 ```
 
 NOTES:
 
-* The `.rpm` packages are hosted on Bintray.
+* The `.rpm` packages are hosted on Clever Cloud's public Nexus instance available at  [https://nexus.clever-cloud.com](https://nexus.clever-cloud.com).
 * If you want access to the beta channel, you can omit the second line which contains an exclude option.
 
 #### Arch Linux
@@ -151,14 +151,14 @@ NOTES:
 
 ##### Warning
 
-Bintray is ending on May 1st 2021, we will migrate hosting as soon as possible. Please refer to the dedicated [issue](https://github.com/CleverCloud/clever-tools/issues/454) to track the migration.
+We recently moved from Bintray to a self hosted Nexus repository available at [https://nexus.clever-cloud.com](https://nexus.clever-cloud.com). You have to update the URL of your chocolatey repository with the new one. If you experience any issue please let us know on the following [issue https://github.com/CleverCloud/clever-tools/issues/454](https://github.com/CleverCloud/clever-tools/issues/454).
 
 ---
 
 If you are using Windows and you have [chocolatey](https://chocolatey.org) installed, you can run:
 
 ```bash
-choco sources add -n=clevercloud -s='https://api.bintray.com/nuget/clevercloud/nupkg'
+choco sources add -n=clevercloud -s='https://nexus.clever-cloud.com/repository/nupkg'
 choco install clever-tools
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,14 +46,15 @@ That's why we need `S3_KEY_ID` and `S3_SECRET_KEY` from the credentials.
 * If it's a stable version we publish the files under `X.Y.Z` but also under `latest`.
 * If it's a beta version we only publish the files under `X.Y.Z-beta.W`.
 
-#### Bintray
+#### Nexus
 
-`.deb` and `.rpm` are published on Bintray.
-That's why we need `BINTRAY_API_KEY` from the credentials.
+`.deb`, `.nupkg` and `.rpm` are published on Clever Cloud's public Nexus instance.
+That's why we need the `NEXUS_PASSWORD` and `NUGET_API_KEY` environment variables.
 
-* `.deb` are published on [Bintray](https://bintray.com/clevercloud/deb).
+* `.deb` are published on [Nexus](https://nexus.clever-cloud.com/repository/deb).
   * We use the `distribution` metadata to identify beta versions.
-* `.rpm` are published on [Bintray](https://bintray.com/clevercloud/rpm).
+* `.rpm` are published on [Nexus](https://nexus.clever-cloud.com/repository/rpm).
+* `.nupkg` are published on [Nexus](https://nexus.clever-cloud.com/repository/nupkg).
 
 #### Archlinux
 

--- a/docker-runner/Dockerfile
+++ b/docker-runner/Dockerfile
@@ -1,5 +1,7 @@
 FROM jenkins/jnlp-slave
 
+# We need this for all the installations
+# We also need this for the docker sibling mode on Clever (not jenkins user)
 USER root
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/docker-runner/Dockerfile
+++ b/docker-runner/Dockerfile
@@ -26,7 +26,3 @@ RUN echo \
 RUN apt-get update -y
 
 RUN apt-get install -y docker-ce docker-ce-cli containerd.io
-
-RUN usermod -a -G docker jenkins
-
-USER jenkins

--- a/docker-runner/Dockerfile
+++ b/docker-runner/Dockerfile
@@ -27,4 +27,6 @@ RUN apt-get update -y
 
 RUN apt-get install -y docker-ce docker-ce-cli containerd.io
 
+RUN usermod -a -G docker jenkins
+
 USER jenkins

--- a/docker-runner/Dockerfile
+++ b/docker-runner/Dockerfile
@@ -10,4 +10,21 @@ RUN apt-get install -y rpm
 RUN apt-get install -y ruby ruby-dev rubygems build-essential
 RUN gem install --no-ri --no-rdoc fpm
 
+RUN apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+RUN echo \
+    "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update -y
+
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io
+
 USER jenkins

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -10,10 +10,6 @@ const cellar = {
   host: 'cellar-c2.services.clever-cloud.com',
   bucket: 'clever-tools.clever-cloud.com',
 };
-const bintray = {
-  subject: 'clevercloud',
-  user: 'ci-clevercloud',
-};
 const git = {
   email: 'ci@clever-cloud.com',
   name: 'Clever Cloud CI',
@@ -79,12 +75,17 @@ function getBundleFilepath (type, version) {
   return `${releasesDir}/${version}/${appInfos.name}-${version}.${type}`;
 }
 
-function getBintrayApiKey () {
-  const apiKey = process.env.BINTRAY_API_KEY;
-  if (!apiKey) {
-    throw new Error('Could not read bintray API key!');
+function getNexusAuth () {
+  const user = process.env.NEXUS_USER || 'ci';
+  const password = process.env.NEXUS_PASSWORD;
+  const nugetApiKey = process.env.NEXUS_NUGET_API_KEY;
+  if (password == null) {
+    throw new Error('Could not read Nexus password!');
   }
-  return apiKey;
+  if (nugetApiKey == null) {
+    throw new Error('Could not read Nexus Nuget API key!');
+  }
+  return { user, password, nugetApiKey };
 }
 
 function getNpmToken () {
@@ -100,7 +101,6 @@ module.exports = {
   nodeVersion,
   releasesDir,
   cellar,
-  bintray,
   git,
   appInfos,
   getVersion,
@@ -109,6 +109,6 @@ module.exports = {
   getBinaryFilepath,
   getArchiveFilepath,
   getBundleFilepath,
-  getBintrayApiKey,
+  getNexusAuth,
   getNpmToken,
 };

--- a/scripts/job-publish-nexus.js
+++ b/scripts/job-publish-nexus.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const cfg = require('./config');
+const { promises: fs } = require('fs');
+const path = require('path');
+const superagent = require('superagent');
+
+const NEXUS_HOST = 'https://nexus.clever-cloud.com';
+const NEXUS_RPM = NEXUS_HOST + '/repository/yum-test-private/';
+const NEXUS_DEB = NEXUS_HOST + '/repository/apt-test-private/';
+const NEXUS_NUPKG = NEXUS_HOST + '/repository/nuget-test-private/';
+
+async function run () {
+
+  const version = cfg.getVersion(true);
+  const nexusAuth = cfg.getNexusAuth();
+
+  await publishRpmToNexus({ nexusAuth, filepath: cfg.getBundleFilepath('rpm', version) });
+  await publishDebToNexus({ nexusAuth, filepath: cfg.getBundleFilepath('deb', version) });
+  await publishNupkgToNexus({ nexusAuth, filepath: cfg.getBundleFilepath('nupkg', version) });
+}
+
+// https://help.sonatype.com/repomanager3/formats/yum-repositories
+async function publishRpmToNexus ({ nexusAuth, filepath }) {
+
+  const { base: filename } = path.parse(filepath);
+  const targetUrl = new URL(filename, NEXUS_RPM).toString();
+  const filebuffer = await fs.readFile(filepath);
+
+  console.log(`Uploading rpm on Nexus...`);
+  console.log(`  file ${filepath}`);
+  console.log(`  to ${NEXUS_RPM}`);
+
+  return superagent
+    .put(targetUrl)
+    .auth(nexusAuth.user, nexusAuth.password)
+    .on('progress', displayProgress())
+    .send(filebuffer)
+    .then(() => {
+      console.log(`  DONE!`);
+    });
+}
+
+// https://help.sonatype.com/repomanager3/formats/apt-repositories
+async function publishDebToNexus ({ nexusAuth, filepath }) {
+
+  const filebuffer = await fs.readFile(filepath);
+
+  console.log(`Uploading deb on Nexus...`);
+  console.log(`  file ${filepath}`);
+  console.log(`  to ${NEXUS_DEB}`);
+
+  return superagent
+    .post(NEXUS_DEB)
+    .auth(nexusAuth.user, nexusAuth.password)
+    .type('multipart/form-data')
+    .on('progress', displayProgress())
+    .send(filebuffer)
+    .then(() => console.log('  DONE!'));;
+}
+
+// https://help.sonatype.com/repomanager3/formats/nuget-repositories/deploying-packages-to-nuget-hosted-repositories#DeployingPackagestoNuGetHostedRepositories-AccessingyourNuGetAPIKey
+async function publishNupkgToNexus ({ nexusAuth, filepath }) {
+
+  const { base: filename } = path.parse(filepath);
+  const targetUrl = new URL(filename, NEXUS_NUPKG).toString();
+  const filebuffer = await fs.readFile(filepath);
+
+  console.log(`Uploading nupkg on Nexus...`);
+  console.log(`  file ${filepath}`);
+  console.log(`  to ${NEXUS_NUPKG}`);
+
+  return superagent
+    .put(targetUrl)
+    .set('X-NuGet-ApiKey', nexusAuth.nugetApiKey)
+    .attach('data', filebuffer)
+    .on('progress', displayProgress())
+    .then(() => console.log('  DONE!'));
+}
+
+function displayProgress () {
+  let lastPercent = 0;
+  return (event) => {
+    const percent = Math.floor((event.loaded / event.total) * 100);
+    if (percent > lastPercent + 15 || percent === 100) {
+      lastPercent = percent;
+      console.log(`  ${percent}%`);
+    }
+  };
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/job-publish-nexus.sh
+++ b/scripts/job-publish-nexus.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GIT_TAG="$(echo -e "${GIT_TAG_NAME}" | tr -d '[:space:]')"
+
+curl -u "ci:$NEXUS_PASSWORD" --upload-file ./releases/$GIT_TAG/clever-tools-$GIT_TAG.rpm https://nexus.clever-cloud.com/repository/rpm/
+curl -u "ci:$NEXUS_PASSWORD"  -H "Content-Type: multipart/form-data" --data-binary "@./releases/$GIT_TAG/clever-tools-$GIT_TAG.deb" "https://nexus.clever-cloud.com/repository/deb/"
+curl -u "ci:$NEXUS_PASSWORD"  -X PUT -H "X-NuGet-ApiKey: $NUGET_API_KEY" -F "data=@./releases/$GIT_TAG/clever-tools.$GIT_TAG.nupkg" https://nexus.clever-cloud.com/repository/nuget/


### PR DESCRIPTION
Bintray will close soon and as such we need a new home for our Deb, RPM and nupkg packages. 

This merge request enables packages deployment to nexus.clever-cloud.com instead of bintray.