### PR TITLE
Fix colors version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@clevercloud/client": "^7.4.0",
     "clf-date": "^0.2.0",
     "cliparse": "^0.3.3",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "common-env": "^6.4.0",
     "eventsource": "^1.1.0",
     "isomorphic-git": "^1.8.2",


### PR DESCRIPTION
https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/