### PR TITLE
Update README to set arch in deb install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are using a GNU/Linux distribution that uses `.deb` packages like Debian 
 
 ```sh
 curl -fsSL https://clever-tools.clever-cloud.com/gpg/cc-nexus-deb.public.gpg.key | gpg --dearmor -o /usr/share/keyrings/cc-nexus-deb.gpg
-echo "deb [signed-by=/usr/share/keyrings/cc-nexus-deb.gpg] https://nexus.clever-cloud.com/repository/deb stable main" | tee -a /etc/apt/sources.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/cc-nexus-deb.gpg] https://nexus.clever-cloud.com/repository/deb stable main" | tee -a /etc/apt/sources.list
 apt-get update
 apt-get install clever-tools
 ```
@@ -51,7 +51,7 @@ NOTES:
 * If you want access to the beta channel, you can use this in your `sources.list`:
 
 ```sh
-echo "deb [signed-by=/usr/share/keyrings/cc-nexus-deb.gpg] https://nexus.clever-cloud.com/repository/deb-beta beta main" | tee -a /etc/apt/sources.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/cc-nexus-deb.gpg] https://nexus.clever-cloud.com/repository/deb-beta beta main" | tee -a /etc/apt/sources.list
 ```
 
 #### CentOS/Fedora (.rpm)


### PR DESCRIPTION
The deb instruction doesn't set arch resulting in warnings when using `apt update`. This PR fix this.