### PR TITLE
Add command to get add-on env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ spec/empty-repo
 spec/application.instance-types.js
 .clever.json
 releases/
+.idea/
 .s3cfg*
 *.gpg.key
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * skip preorder step on addon creation
 * add `clever addon env` command
+* improve implicit ID params (owner and add-on ID / real ID) for `clever database`
 
 ## 2.10.1 (2023-02-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # clever-tools changelog
 
 ## Unrelease (????-??-??)
+
 * skip preorder step on addon creation
+* add `clever addon env` command
 
 ## 2.10.1 (2023-02-20)
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -91,7 +91,7 @@ function run () {
     }),
     appNameCreation: cliparse.argument('app-name', { description: 'Application name' }),
     backupId: cliparse.argument('backup-id', { description: 'A Database backup ID (format: UUID)' }),
-    databaseId: cliparse.argument('database-id', { description: 'A database ID (format: postgresql_UUID, mysql_UUID, ...)' }),
+    databaseId: cliparse.argument('database-id', { description: 'Any database ID (format: addon_UUID, postgresql_UUID, mysql_UUID, ...)' }),
     drainId: cliparse.argument('drain-id', { description: 'Drain ID' }),
     drainType: cliparse.argument('drain-type', {
       description: 'Drain type',

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -130,6 +130,7 @@ function run () {
   const opts = {
     sourceableEnvVarsList: cliparse.flag('add-export', { description: 'Display sourceable env variables setting' }),
     accesslogsFormat: getOutputFormatOption(['simple', 'extended', 'clf']),
+    addonEnvFormat: getOutputFormatOption(['shell']),
     accesslogsFollow: cliparse.flag('follow', {
       aliases: ['f'],
       description: 'Display access logs continuously (ignores before/until, after/since)',
@@ -574,10 +575,16 @@ function run () {
     description: 'List available addon providers',
     commands: [addonShowProviderCommand],
   }, addon('listProviders'));
+  const addonEnvCommand = cliparse.command('env', {
+    description: 'List the environment variables for an add-on',
+    options: [opts.addonEnvFormat],
+    args: [opts.addonId],
+  }, addon('env'));
+
   const addonCommands = cliparse.command('addon', {
     description: 'Manage addons',
     options: [opts.orgaIdOrName],
-    commands: [addonCreateCommand, addonDeleteCommand, addonRenameCommand, addonProvidersCommand],
+    commands: [addonCreateCommand, addonDeleteCommand, addonRenameCommand, addonProvidersCommand, addonEnvCommand],
   }, addon('list'));
 
   // APPLICATIONS COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1011,7 +1011,7 @@ function run () {
   const downloadBackupCommand = cliparse.command('download', {
     description: 'Download a database backup',
     args: [args.databaseId, args.backupId],
-    options: [opts.orgaIdOrName, opts.output],
+    options: [opts.output],
   }, database('downloadBackups'));
   const backupsCommand = cliparse.command('backups', {
     description: 'List available database backups',

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -21,6 +21,7 @@ const git = require('../src/models/git.js');
 const Parsers = require('../src/parsers.js');
 const handleCommandPromise = require('../src/command-promise-handler.js');
 const Formatter = require('../src/models/format-string.js');
+const { getOutputFormatOption } = require('../src/get-output-format-option.js');
 
 // Exit cleanly if the program we pipe to exits abruptly
 process.stdout.on('error', (error) => {
@@ -65,7 +66,6 @@ function lazyRequire (modulePath) {
   };
 }
 
-const AccessLogs = lazyRequire('../src/models/accesslogs.js');
 const Addon = lazyRequire('../src/models/addon.js');
 const Application = lazyRequire('../src/models/application.js');
 const ApplicationConfiguration = lazyRequire('../src/models/application_configuration.js');
@@ -129,16 +129,7 @@ function run () {
   // OPTIONS
   const opts = {
     sourceableEnvVarsList: cliparse.flag('add-export', { description: 'Display sourceable env variables setting' }),
-    accesslogsFormat: cliparse.option('format', {
-      aliases: ['F'],
-      metavar: 'format',
-      parser: Parsers.accessLogsFormat,
-      default: 'simple',
-      description: 'Output format (one of simple, extended, clf or json)',
-      complete () {
-        return cliparse.autocomplete.words(AccessLogs('listAvailableFormats')());
-      },
-    }),
+    accesslogsFormat: getOutputFormatOption(['simple', 'extended', 'clf']),
     accesslogsFollow: cliparse.flag('follow', {
       aliases: ['f'],
       description: 'Display access logs continuously (ignores before/until, after/since)',

--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -5,20 +5,19 @@ const { getBackups } = require('@clevercloud/client/cjs/api/v2/backups.js');
 const { println } = require('../logger.js');
 const formatTable = require('../format-table')();
 const superagent = require('superagent');
-const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
 const fs = require('fs');
+const { findOwnerId } = require('../models/addon.js');
+const { resolveRealId } = require('../models/ids-resolver.js');
 
 async function listBackups (params) {
 
-  const [databaseId] = params.args;
   const { org } = params.options;
+  const [addonIdOrRealId] = params.args;
 
-  const ownerId = await resolveOwnerId(org, databaseId);
-  if (ownerId == null) {
-    throw new Error('organisation ID is mandatory');
-  }
+  const addonId = await resolveRealId(addonIdOrRealId);
+  const ownerId = await findOwnerId(org, addonId);
 
-  const backups = await getBackups({ ownerId, ref: databaseId }).then(sendToApi);
+  const backups = await getBackups({ ownerId, ref: addonId }).then(sendToApi);
 
   if (backups.length === 0) {
     println('There are no backups yet');
@@ -47,15 +46,13 @@ async function listBackups (params) {
 
 async function downloadBackups (params) {
 
-  const [databaseId, backupId] = params.args;
   const { org, output } = params.options;
+  const [addonIdOrRealId, backupId] = params.args;
 
-  const ownerId = await resolveOwnerId(org, databaseId);
-  if (ownerId == null) {
-    throw new Error('organisation ID is mandatory');
-  }
+  const addonId = await resolveRealId(addonIdOrRealId);
+  const ownerId = await findOwnerId(org, addonId);
 
-  const backups = await getBackups({ ownerId, ref: databaseId }).then(sendToApi);
+  const backups = await getBackups({ ownerId, ref: addonId }).then(sendToApi);
   const backup = backups.find((backup) => backup.backup_id === backupId);
 
   if (backup == null) {
@@ -72,35 +69,6 @@ async function downloadBackups (params) {
   }
 
   process.stdout.write(res.body);
-}
-
-/**
- * Try to get an ownerId from the API
- * @param {*} org cliparse param's option for orga
- * @param {String} databaseId the resource which belong to the owner we are looking for
- * @returns the owner ID (or null if cannot be found)
- */
-async function resolveOwnerId (org, databaseId) {
-
-  if (org != null && org.orga_name != null) {
-    return org.orga_name;
-  }
-
-  const summary = await getSummary().then(sendToApi);
-
-  const userHasAddon = summary.user.addons.some((addon) => addon.realId === databaseId);
-  if (userHasAddon) {
-    return summary.user.id;
-  }
-
-  for (const orga of summary.organisations) {
-    const orgaHasAddon = orga.addons.some((addon) => addon.realId === databaseId);
-    if (orgaHasAddon) {
-      return orga.id;
-    }
-  }
-
-  return null;
 }
 
 module.exports = { listBackups, downloadBackups };

--- a/src/get-output-format-option.js
+++ b/src/get-output-format-option.js
@@ -1,0 +1,23 @@
+const cliparse = require('cliparse');
+
+function getOutputFormatOption (formats = []) {
+  const availableFormats = ['human', 'json', ...formats];
+  return cliparse.option('format', {
+    aliases: ['F'],
+    metavar: 'format',
+    parser: (format) => {
+      return availableFormats.includes(format)
+        ? cliparse.parsers.success(format)
+        : cliparse.parsers.error('The output format must be one of ' + availableFormats.join(', '));
+    },
+    default: 'human',
+    description: `Output format (${availableFormats.join(', ')})`,
+    complete () {
+      return cliparse.autocomplete.words(availableFormats);
+    },
+  });
+}
+
+module.exports = {
+  getOutputFormatOption,
+};

--- a/src/models/accesslogs.js
+++ b/src/models/accesslogs.js
@@ -2,12 +2,10 @@
 
 const clfDate = require('clf-date');
 
-function listAvailableFormats () {
-  return ['simple', 'extended', 'clf', 'json'];
-}
-
 function getFormatter (format, isAddon) {
   switch (format.toLowerCase()) {
+    // "simple" is the legacy default, "human" is the new one
+    case 'human':
     case 'simple':
       return isAddon ? formatSimpleAddon : formatSimple;
     case 'extended':
@@ -53,4 +51,4 @@ function formatCLFAddon (l) {
   return `${l.ipS} - - [${clfDate(new Date(l.t))}] "- - -" - ${l.bOut}`;
 }
 
-module.exports = { listAvailableFormats, getFormatter };
+module.exports = { getFormatter };

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -2,8 +2,13 @@
 
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const autocomplete = require('cliparse').autocomplete;
-const colors = require('colors/safe');
-const { get: getAddon, getAll: getAllAddons, remove: removeAddon, create: createAddon, preorder: preorderAddon, update: updateAddon } = require('@clevercloud/client/cjs/api/v2/addon.js');
+const {
+  get: getAddon,
+  getAll: getAllAddons,
+  remove: removeAddon,
+  create: createAddon,
+  update: updateAddon,
+} = require('@clevercloud/client/cjs/api/v2/addon.js');
 const { getAllAddonProviders } = require('@clevercloud/client/cjs/api/v2/product.js');
 const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
 const { getAddonProvider } = require('@clevercloud/client/cjs/api/v4/addon-providers.js');
@@ -11,6 +16,7 @@ const { getAddonProvider } = require('@clevercloud/client/cjs/api/v4/addon-provi
 const Interact = require('./interact.js');
 const Logger = require('../logger.js');
 const { sendToApi } = require('../models/send-to-api.js');
+const { resolveOwnerId } = require('./ids-resolver.js');
 
 function listProviders () {
   return getAllAddonProviders({}).then(sendToApi);
@@ -242,6 +248,20 @@ async function findById (addonId) {
   throw new Error(`Could not find add-on with ID: ${addonId}`);
 }
 
+async function findOwnerId (org, addonId) {
+
+  if (org != null && org.orga_id != null) {
+    return org.orga_id;
+  }
+
+  const ownerId = await resolveOwnerId(addonId);
+  if (ownerId != null) {
+    return ownerId;
+  }
+
+  throw new Error(`Add-on ${addonId} does not exist`);
+}
+
 function parseAddonOptions (options) {
   if (options == null) {
     return {};
@@ -275,6 +295,7 @@ module.exports = {
   create,
   delete: deleteAddon,
   findById,
+  findOwnerId,
   getProvider,
   getProviderInfos,
   link,

--- a/src/models/ids-resolver.js
+++ b/src/models/ids-resolver.js
@@ -1,0 +1,110 @@
+const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
+const { sendToApi } = require('./send-to-api.js');
+const { loadIdsCache, writeIdsCache } = require('./configuration.js');
+
+/*
+This system uses a simplified representation of the summary to expose IDs links:
+
+* app ID => owner ID
+* add-on ID => owner ID
+* real add-on ID => owner ID
+* add-on ID => real add-on ID
+* real add-on ID => add-on ID
+
+{
+  owners: {
+    [appid]: [ownerId],
+    [addonId]: [ownerId],
+    [realId]: [ownerId],
+  },
+  addons: {
+    [addonId]: { realId: [realId], addonId: [addonId] },
+    [realId]: { realId: [realId], addonId: [addonId] },
+  },
+}
+ */
+
+async function resolveOwnerId (id) {
+  return getIdFromCacheOrSummary((ids) => ids.owners[id]);
+}
+
+async function resolveAddonId (id) {
+
+  const addonId = await getIdFromCacheOrSummary((ids) => {
+    return (ids.addons[id] != null) ? ids.addons[id].addonId : null;
+  });
+
+  if (addonId != null) {
+    return addonId;
+  }
+
+  throw new Error(`Add-on ${id} does not exist`);
+}
+
+async function resolveRealId (id) {
+
+  const realId = await getIdFromCacheOrSummary((ids) => {
+    return (ids.addons[id] != null) ? ids.addons[id].realId : null;
+  });
+
+  if (realId != null) {
+    return realId;
+  }
+
+  throw new Error(`Add-on ${id} does not exist foo`);
+}
+
+async function getIdFromCacheOrSummary (callback) {
+
+  const idsFromCache = await loadIdsCache();
+  const idFromCache = callback(idsFromCache);
+  if (idFromCache != null) {
+    return idFromCache;
+  }
+
+  const idsFromSummary = await getIdsFromSummary();
+  await writeIdsCache(idsFromSummary);
+
+  const idFromSummary = callback(idsFromSummary);
+  if (idFromSummary != null) {
+    return idFromSummary;
+  }
+
+  return null;
+}
+
+async function getIdsFromSummary () {
+
+  const ids = {
+    owners: {},
+    addons: {},
+  };
+
+  const summary = await getSummary().then(sendToApi);
+
+  const owners = [
+    summary.user,
+    ...summary.organisations,
+  ];
+
+  for (const owner of owners) {
+    for (const app of owner.applications) {
+      ids.owners[app.id] = owner.id;
+    }
+    for (const addon of owner.addons) {
+      ids.owners[addon.id] = owner.id;
+      ids.owners[addon.realId] = owner.id;
+      const addonIds = { addonId: addon.id, realId: addon.realId };
+      ids.addons[addon.id] = addonIds;
+      ids.addons[addon.realId] = addonIds;
+    }
+  }
+
+  return ids;
+}
+
+module.exports = {
+  resolveOwnerId,
+  resolveAddonId,
+  resolveRealId,
+};

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -79,14 +79,6 @@ function commaSeparated (string) {
   return cliparse.parsers.success(string.split(','));
 }
 
-function accessLogsFormat (format) {
-  const availableFormats = AccessLogs.listAvailableFormats();
-  if (availableFormats.includes(format)) {
-    return cliparse.parsers.success(format);
-  }
-  return cliparse.parsers.error('The format must be one of ' + availableFormats.join(', '));
-}
-
 function integer (string) {
   const integer = parseInt(string);
   if (isNaN(integer)) {
@@ -162,7 +154,6 @@ module.exports = {
   addonIdOrName,
   ngIdOrLabel,
   commaSeparated,
-  accessLogsFormat,
   integer,
   tag,
   tags,


### PR DESCRIPTION
Closes #584

This PR is based on the collective work of @Nowadays, @leyour-m and @lenglet-k in https://github.com/CleverCloud/clever-tools/pull/447.
We adjusted a few details (see issue #584) but the main goal is the same.

## ids-resolver

This PR also contains the introduction of the `ids-resolver` which can:

* resolve an owner ID from:
  * an app ID
  * an add-on ID
  * a real ID
* resolve an add-on ID from a real ID
* resolve a real ID from an add-on ID

This resolver is used in the new `clever addon env`, it is also introduced in `clever database backups` commands.

We'll use it in the other commands in the future.

## getOutputFormatOption

This PR also contains a helper function to declare command line options with limited possible values for output format (`human` by default and `json`).
