### PR TITLE
Feat/json logs

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -135,6 +135,7 @@ function run () {
     sourceableEnvVarsList: cliparse.flag('add-export', { description: 'Display sourceable env variables setting' }),
     accesslogsFormat: getOutputFormatOption(['simple', 'extended', 'clf']),
     addonEnvFormat: getOutputFormatOption(['shell']),
+    logsFormat: getOutputFormatOption(['json-stream']),
     accesslogsFollow: cliparse.flag('follow', {
       aliases: ['f'],
       description: 'Display access logs continuously (ignores before/until, after/since)',
@@ -763,7 +764,7 @@ function run () {
   const logs = lazyRequirePromiseModule('../src/commands/logs.js');
   const logsCommand = cliparse.command('logs', {
     description: 'Fetch application logs, continuously',
-    options: [opts.alias, opts.before, opts.after, opts.search, opts.deploymentId, opts.addonId],
+    options: [opts.alias, opts.before, opts.after, opts.search, opts.deploymentId, opts.addonId, opts.logsFormat],
   }, logs('appLogs'));
 
   // MAKE DEFAULT COMMAND

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -8,23 +8,32 @@ const { Deferred } = require('../models/utils.js');
 const colors = require('colors/safe');
 
 async function appLogs (params) {
-  const { alias, addon: addonId, after: since, before: until, search, 'deployment-id': deploymentId } = params.options;
+  const { alias, addon: addonId, after: since, before: until, search, 'deployment-id': deploymentId, format } = params.options;
 
   // ignore --search ""
   const filter = (search !== '') ? search : null;
 
   const { appId, ownerId } = await AppConfig.getAppDetails({ alias });
 
+  const isForHuman = (format === 'human');
+
   // TODO: drop when addons are migrated to the v4 API
   if (addonId) {
-    Logger.println(colors.blue('Waiting for addon logs…'));
+    if (isForHuman) {
+      Logger.println(colors.blue('Waiting for addon logs…'));
+    }
+    else {
+      throw new Error(`"${format}" format is not yet available for add-on logs`);
+    }
     return LogV2.displayLogs({ appAddonId: addonId, since, until, filter, deploymentId });
   }
 
-  Logger.println(colors.blue('Waiting for application logs…'));
+  if (isForHuman) {
+    Logger.println(colors.blue('Waiting for application logs…'));
+  }
 
   const deferred = new Deferred();
-  await Log.displayLogs({ ownerId, appId, since, until, filter, deploymentId, deferred });
+  await Log.displayLogs({ ownerId, appId, since, until, filter, deploymentId, format, deferred });
   return deferred.promise;
 }
 


### PR DESCRIPTION
Support `--format` arg in logs command

To test it 
```
node ./clever.js logs -a xxx --since "2023-11-27T00:00:00" --until "2023-11-28T00:00:00" -F json
node ./clever.js logs -a xxx --since "2023-11-27T00:00:00" --until "2023-11-28T00:00:00" -F json-stream
node ./clever.js logs -a xxx --since "2023-11-27T00:00:00" --until "2023-11-28T00:00:00" -F human
node ./clever.js logs -a xxx --since "2023-11-27T00:00:00"  -F json <= Throw an Error 
```

both JSON format are compatible with `jq` command. Just append `| jq` at the end

`json-stream` follow the ndjson format