### PR TITLE
restart/deploy: Fix Node.js < 18.16 abort bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased (????-??-??)
 
-...
+* chore: update @clevercloud/client to 8.0.2 (fix Node.js < 18.16 abort bug)
 
 ## 3.0.1 (2023-10-19)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "^8.0.1",
+        "@clevercloud/client": "^8.0.2",
         "clf-date": "^0.2.0",
         "cliparse": "^0.3.3",
         "colors": "1.4.0",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@clevercloud/client": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.0.1.tgz",
-      "integrity": "sha512-YpRlP3e/3K7B/k7C/iSdUW16sHNoELmoeN3JFq8UjsmwnB/ea/aP6zqCe2Fa7wmDXijHXt+oSLUA6M3+KyTarQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.0.2.tgz",
+      "integrity": "sha512-smSsmX2GAYed96k8n+qVRxEtc8hvfuvwPW0c5sW/R9x9Z8OsorS+Xpe2OFc0ADsEbJhGqbEHr84TKuIuSUu7dw==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"
@@ -7201,9 +7201,9 @@
       }
     },
     "@clevercloud/client": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.0.1.tgz",
-      "integrity": "sha512-YpRlP3e/3K7B/k7C/iSdUW16sHNoELmoeN3JFq8UjsmwnB/ea/aP6zqCe2Fa7wmDXijHXt+oSLUA6M3+KyTarQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.0.2.tgz",
+      "integrity": "sha512-smSsmX2GAYed96k8n+qVRxEtc8hvfuvwPW0c5sW/R9x9Z8OsorS+Xpe2OFc0ADsEbJhGqbEHr84TKuIuSUu7dw==",
       "requires": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scripts/*.sh"
   ],
   "dependencies": {
-    "@clevercloud/client": "^8.0.1",
+    "@clevercloud/client": "^8.0.2",
     "clf-date": "^0.2.0",
     "cliparse": "^0.3.3",
     "colors": "1.4.0",


### PR DESCRIPTION
## QA on clever restart

* [x] `clever restart` Node 18.18
* [x] `clever restart` Node 18.15
* [x] `clever restart` packaged (Node 18.15)