### PR TITLE
feat (applications): add git+ssh URL in local config data

### DIFF
--- a/src/commands/applications.js
+++ b/src/commands/applications.js
@@ -28,13 +28,16 @@ function formatApps (apps, onlyAliases, json) {
     }
     else {
       return apps
-        .map((app) =>
-          [
+        .map((app) => {
+          const sshUrl = app.git_ssh_url ?? app.deploy_url.replace('https://', 'git+ssh://git@');
+          return [
             `Application ${app.name}`,
             `  alias: ${colors.bold(app.alias)}`,
-            `  id: ${app.app_id}`,
-            `  deployment url: ${app.deploy_url}`].join('\n'),
-        )
+            `  ID: ${app.app_id}`,
+            `  deployment URL: ${app.deploy_url}`,
+            `  git+ssh URL: ${sshUrl}`,
+          ].join('\n');
+        })
         .join('\n\n');
     }
   }

--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -38,6 +38,7 @@ async function addLinkedApplication (appData, alias, ignoreParentConfig) {
     app_id: appData.id,
     org_id: appData.ownerId,
     deploy_url: appData.deployment.httpUrl || appData.deployment.url,
+    git_ssh_url: appData.deployment.url,
     name: appData.name,
     alias: alias || slugify(appData.name),
   };


### PR DESCRIPTION
It's done when app is created or its informations queried. 
It will only work for newly linked/created apps

Fix #619 