### PR TITLE
Update zones and runtimes lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ Where `type` is one of:
 - `haskell`: for haskell applications
 - `jar`: for applications deployed as standalone jar files
 - `maven`: for applications launched with maven
-- `node`: for node.js applications
+- `meteor`: for Meteor applications launched with Node.js
+- `node`: for Node.js applications
 - `php`: for PHP applications
 - `play1`: for Play1 applications
 - `play2`: for Play2 applications

--- a/README.md
+++ b/README.md
@@ -261,11 +261,17 @@ Where `type` is one of:
 
 Where region is one of:
 
-- `par` (for Paris)
-- `mtl` (for Montreal)
+- `par` (Paris, [Clever Cloud](https://www.clever-cloud.com/infrastructure/))
+- `rbx` (Roubaix, OVHcloud)
+- `rbxhds` (Roubaix, HDS servers, OVHcloud)
+- `scw` (Paris, [Scaleway DC5](https://www.clever-cloud.com/blog/press/2023/01/17/clever-cloud-and-scaleway-join-forces-to-unveil-a-sovereign-european-paas-offering/))
+- `jed` (Jeddah, Oracle Cloud)
+- `mtl` (Montreal, OVHcloud)
+- `sgp` (Singapore, OVHcloud)
+- `syd` (Sydney, OVHcloud)
+- `wsw` (Warsaw, OVHcloud)
 
-`--org` allows you to chose the organisation in which your app is
-created.
+`--org` allows you to chose the organisation in which your app is created.
 
 `--alias` allows you to deploy the same application in multiple environments on Clever Cloud (eg: production, testing, …)
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -22,6 +22,7 @@ const Parsers = require('../src/parsers.js');
 const handleCommandPromise = require('../src/command-promise-handler.js');
 const Formatter = require('../src/models/format-string.js');
 const { getOutputFormatOption } = require('../src/get-output-format-option.js');
+const { AVAILABLE_ZONES } = require('../src/models/application.js');
 
 // Exit cleanly if the program we pipe to exits abruptly
 process.stdout.on('error', (error) => {
@@ -326,7 +327,7 @@ function run () {
       aliases: ['r'],
       default: 'par',
       metavar: 'zone',
-      description: 'Region, can be \'par\' for Paris or \'mtl\' for Montreal',
+      description: `Region, can be ${AVAILABLE_ZONES.map((name) => `'${name}'`).join(', ')}`,
       complete: Application('listAvailableZones'),
     }),
     search: cliparse.option('search', {

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -18,7 +18,7 @@ function listAvailableTypes () {
 };
 
 function listAvailableZones () {
-  return autocomplete.words(['par', 'mtl']);
+  return autocomplete.words(['par', 'rbx', 'rbxhds', 'scw', 'jed', 'mtl', 'sgp', 'syd', 'wsw']);
 };
 
 function listAvailableAliases () {

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -14,7 +14,7 @@ const User = require('./user.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 function listAvailableTypes () {
-  return autocomplete.words(['docker', 'elixir', 'go', 'gradle', 'haskell', 'jar', 'maven', 'node', 'php', 'play1', 'play2', 'python', 'ruby', 'rust', 'sbt', 'static-apache', 'war']);
+  return autocomplete.words(['docker', 'elixir', 'go', 'gradle', 'haskell', 'jar', 'maven', 'meteor', 'node', 'php', 'play1', 'play2', 'python', 'ruby', 'rust', 'sbt', 'static-apache', 'war']);
 };
 
 function listAvailableZones () {

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -17,8 +17,10 @@ function listAvailableTypes () {
   return autocomplete.words(['docker', 'elixir', 'go', 'gradle', 'haskell', 'jar', 'maven', 'meteor', 'node', 'php', 'play1', 'play2', 'python', 'ruby', 'rust', 'sbt', 'static-apache', 'war']);
 };
 
+const AVAILABLE_ZONES = ['par', 'rbx', 'rbxhds', 'scw', 'jed', 'mtl', 'sgp', 'syd', 'wsw'];
+
 function listAvailableZones () {
-  return autocomplete.words(['par', 'rbx', 'rbxhds', 'scw', 'jed', 'mtl', 'sgp', 'syd', 'wsw']);
+  return autocomplete.words(AVAILABLE_ZONES);
 };
 
 function listAvailableAliases () {
@@ -241,6 +243,7 @@ module.exports = {
   listAvailableAliases,
   listAvailableFlavors,
   listAvailableTypes,
+  AVAILABLE_ZONES,
   listAvailableZones,
   listDependencies,
   __mergeScalabilityParameters: mergeScalabilityParameters,


### PR DESCRIPTION
This is a combination of 3 PRs from @davlgd:

* https://github.com/CleverCloud/clever-tools/pull/622
* https://github.com/CleverCloud/clever-tools/pull/623
* https://github.com/CleverCloud/clever-tools/pull/624

Bonus:

* Adjusted the commit messages
* Created a `AVAILABLE_ZONES` constant to reuse the list in `clever.js`
* Added a commit to add meteor in the README