### PR TITLE
Fix bugs on clever logs and enable retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "^8.0.2",
+        "@clevercloud/client": "^8.1.0",
         "clf-date": "^0.2.0",
         "cliparse": "^0.3.3",
         "colors": "1.4.0",
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@clevercloud/client": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.0.2.tgz",
-      "integrity": "sha512-smSsmX2GAYed96k8n+qVRxEtc8hvfuvwPW0c5sW/R9x9Z8OsorS+Xpe2OFc0ADsEbJhGqbEHr84TKuIuSUu7dw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.1.0.tgz",
+      "integrity": "sha512-JhwqxON/w0R+0l+4Jig7JJTsuW8ZyNYVjd7DmDRB7B86YIfDcWwikD2aLj5BTm2AsedNjAx1RDePY3rl7fK2Jg==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"
@@ -8360,9 +8360,9 @@
       }
     },
     "@clevercloud/client": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.0.2.tgz",
-      "integrity": "sha512-smSsmX2GAYed96k8n+qVRxEtc8hvfuvwPW0c5sW/R9x9Z8OsorS+Xpe2OFc0ADsEbJhGqbEHr84TKuIuSUu7dw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-8.1.0.tgz",
+      "integrity": "sha512-JhwqxON/w0R+0l+4Jig7JJTsuW8ZyNYVjd7DmDRB7B86YIfDcWwikD2aLj5BTm2AsedNjAx1RDePY3rl7fK2Jg==",
       "requires": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scripts/*.sh"
   ],
   "dependencies": {
-    "@clevercloud/client": "^8.0.2",
+    "@clevercloud/client": "^8.1.0",
     "clf-date": "^0.2.0",
     "cliparse": "^0.3.3",
     "colors": "1.4.0",

--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -25,6 +25,7 @@ async function displayLogs (params) {
     tokens,
     ownerId,
     appId,
+    connectionTimeout: 10_000,
     retryConfiguration,
     since,
     until,

--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -33,10 +33,10 @@ async function displayLogs (params) {
 
   logStream
     .on('open', (event) => {
-      Logger.debug(`stream opened! ${JSON.stringify({ appId, filter, deploymentId })}`);
+      Logger.debug(colors.blue(`Logs stream (open) ${JSON.stringify({ appId, filter, deploymentId })}`));
     })
     .on('error', (event) => {
-      Logger.debug(`an error occured: ${event.detail}`);
+      Logger.debug(colors.red(`Logs stream (error) ${event.error.message}`));
     })
     .onLog((log) => {
       Logger.println(formatLogLine(log));

--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -1,4 +1,4 @@
-const { getHostAndTokens } = require('./send-to-api.js');
+const { getHostAndTokens, processError } = require('./send-to-api.js');
 const colors = require('colors/safe');
 const { Deferred } = require('./utils.js');
 const Logger = require('../logger.js');
@@ -45,6 +45,7 @@ async function displayLogs (params) {
   // start() is blocking until end of stream
   logStream.start()
     .then((reason) => deferred.resolve())
+    .catch(processError)
     .catch((error) => deferred.reject(error));
 
   return logStream;

--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -36,7 +36,7 @@ async function displayLogs (params) {
       Logger.debug(`stream opened! ${JSON.stringify({ appId, filter, deploymentId })}`);
     })
     .on('error', (event) => {
-      Logger.error(`an error occured: ${event.detail}`);
+      Logger.debug(`an error occured: ${event.detail}`);
     })
     .onLog((log) => {
       Logger.println(formatLogLine(log));

--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -9,6 +9,11 @@ const { ApplicationLogStream } = require('@clevercloud/client/cjs/streams/applic
 const THROTTLE_ELEMENTS = 2000;
 const THROTTLE_PER_IN_MILLISECONDS = 100;
 
+const retryConfiguration = {
+  enabled: true,
+  maxRetryCount: 6,
+};
+
 async function displayLogs (params) {
 
   const deferred = params.deferred || new Deferred();
@@ -20,6 +25,7 @@ async function displayLogs (params) {
     tokens,
     ownerId,
     appId,
+    retryConfiguration,
     since,
     until,
     deploymentId,

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -28,7 +28,7 @@ async function sendToApi (requestParams) {
       }
       return requestParams;
     })
-    .then((requestParams) => request(requestParams, { retry: 1 }))
+    .then(request)
     .catch(processError);
 }
 

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -23,9 +23,7 @@ async function sendToApi (requestParams) {
     .then(prefixUrl(conf.API_HOST))
     .then(addOauthHeader(tokens))
     .then((requestParams) => {
-      if (process.env.CLEVER_VERBOSE) {
-        Logger.debug(`${requestParams.method.toUpperCase()} ${requestParams.url} ? ${JSON.stringify(requestParams.queryParams)}`);
-      }
+      Logger.debug(`${requestParams.method.toUpperCase()} ${requestParams.url} ? ${JSON.stringify(requestParams.queryParams)}`);
       return requestParams;
     })
     .then(request)

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -28,7 +28,19 @@ async function sendToApi (requestParams) {
       }
       return requestParams;
     })
-    .then((requestParams) => request(requestParams, { retry: 1 }));
+    .then((requestParams) => request(requestParams, { retry: 1 }))
+    .catch(processError);
+}
+
+function processError (error) {
+  const code = error.code ?? error?.cause?.code;
+  if (code === 'EAI_AGAIN') {
+    throw new Error('Cannot reach the Clever Cloud API, please check your internet connection.', { cause: error });
+  }
+  if (code === 'ECONNRESET') {
+    throw new Error('The connection to the Clever Cloud API was closed abruptly, please try again.', { cause: error });
+  }
+  throw error;
 }
 
 function sendToWarp10 (requestParams) {
@@ -45,4 +57,4 @@ async function getHostAndTokens () {
   };
 }
 
-module.exports = { sendToApi, sendToWarp10, getHostAndTokens };
+module.exports = { sendToApi, sendToWarp10, getHostAndTokens, processError };


### PR DESCRIPTION
## What is in this PR?

* Update @clevercloud/client to 8.0.3 to get all the small bug fixes around retry and network failures
* Enable auto retry on network failures (we forgot to enable it when we switched to the new logs API)
* Improve open and error debug message (wording and colors)
* Only print SSE errors as debug when verbose mode is enabled
* Improve error message with `EAI_AGAIN` and `ECONNRESET`

I also took the opportunity to fix/refactor a few details in the code (see commits).

## What to QA?

Download the preview binary and test `clever logs`:

* Without time window
* With just `--since`
* With just `--until`
* With both `--since` and `--until`
* Try to cut your internet connection for more than 20 secs
* Try to cut your internet connection for a few seconds (or switch between 2 network interfaces)
  * The logs stream should auto retry and resume from the last received log
* Try with an without `-v`

You can also test `clever restart` or `clever deploy` with network failures.

This app is really helpful to test logs https://github.com/CleverCloud/clever-test-logs