### PR TITLE
ci: fix fpm installation by using ruby 3.3 instead of 2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: '[Build] [Prepare] Setup ruby'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: '[Build] [Prepare] Install fpm'
         run: gem install fpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: '[Prepare] Setup ruby'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: '[Prepare] Install fpm'
         run: gem install fpm


### PR DESCRIPTION
Fixes #682
