### PR TITLE
feat(deploy): add the support of exit-on option

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -57,7 +57,7 @@ const Parsers = require('../src/parsers.js');
 const handleCommandPromise = require('../src/command-promise-handler.js');
 const Formatter = require('../src/models/format-string.js');
 const { AVAILABLE_ZONES } = require('../src/models/application.js');
-const { getOutputFormatOption, getSameCommitPolicyOption } = require('../src/command-options.js');
+const { getOutputFormatOption, getSameCommitPolicyOption, getExitOnOption } = require('../src/command-options.js');
 
 // Exit cleanly if the program we pipe to exits abruptly
 process.stdout.on('error', (error) => {
@@ -246,6 +246,7 @@ function run () {
       aliases: ['f'],
       description: 'Force deploy even if it\'s not fast-forwardable',
     }),
+    exitOnDeploy: getExitOnOption(),
     sameCommitPolicy: getSameCommitPolicyOption(),
     webhookFormat: cliparse.option('format', {
       metavar: 'format',
@@ -713,7 +714,7 @@ function run () {
   const deploy = lazyRequirePromiseModule('../src/commands/deploy.js');
   const deployCommand = cliparse.command('deploy', {
     description: 'Deploy an application',
-    options: [opts.alias, opts.branch, opts.gitTag, opts.quiet, opts.forceDeploy, opts.followDeployLogs, opts.sameCommitPolicy],
+    options: [opts.alias, opts.branch, opts.gitTag, opts.quiet, opts.forceDeploy, opts.followDeployLogs, opts.sameCommitPolicy, opts.exitOnDeploy],
   }, deploy('deploy'));
 
   // DIAG COMMAND
@@ -975,7 +976,7 @@ function run () {
   const restart = lazyRequirePromiseModule('../src/commands/restart.js');
   const restartCommand = cliparse.command('restart', {
     description: 'Start or restart an application',
-    options: [opts.alias, opts.appIdOrName, opts.commit, opts.withoutCache, opts.quiet, opts.followDeployLogs],
+    options: [opts.alias, opts.appIdOrName, opts.commit, opts.withoutCache, opts.quiet, opts.followDeployLogs, opts.exitOnDeploy],
   }, restart('restart'));
 
   // SCALE COMMAND

--- a/src/command-options.js
+++ b/src/command-options.js
@@ -36,7 +36,26 @@ function getSameCommitPolicyOption () {
   });
 }
 
+function getExitOnOption () {
+  const availableExitOn = ['deploy-start', 'deploy-end', 'never'];
+  return cliparse.option('exit-on', {
+    aliases: ['e'],
+    metavar: 'exiton',
+    parser: (exitOnStrategy) => {
+      return availableExitOn.includes(exitOnStrategy)
+        ? cliparse.parsers.success(exitOnStrategy)
+        : cliparse.parsers.error(`The exit-on strategy must be one of ${availableExitOn.join(', ')}`);
+    },
+    default: 'deploy-end',
+    description: `Step at which the logs streaming is ended, steps are: ${availableExitOn.join(', ')}`,
+    complete () {
+      return cliparse.autocomplete.words(availableExitOn);
+    },
+  });
+}
+
 module.exports = {
   getOutputFormatOption,
   getSameCommitPolicyOption,
+  getExitOnOption,
 };

--- a/src/commands/restart.js
+++ b/src/commands/restart.js
@@ -6,11 +6,14 @@ const Application = require('../models/application.js');
 const git = require('../models/git.js');
 const Log = require('../models/log-v4.js');
 const Logger = require('../logger.js');
+const ExitStrategy = require('../models/exit-strategy-option.js');
 
 // Once the API call to redeploy() has been triggerred successfully,
 // the rest (waiting for deployment state to evolve and displaying logs) is done with auto retry (resilient to network pb)
 async function restart (params) {
-  const { alias, app: appIdOrName, quiet, commit, 'without-cache': withoutCache, follow } = params.options;
+  const { alias, app: appIdOrName, quiet, commit, 'without-cache': withoutCache, follow, 'exit-on': exitOnDeploy } = params.options;
+
+  const exitStrategy = ExitStrategy.get(follow, exitOnDeploy);
 
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const fullCommitId = await git.resolveFullCommitId(commit);
@@ -38,8 +41,8 @@ async function restart (params) {
     appId,
     deploymentId: redeploy.deploymentId,
     quiet,
-    follow,
     redeployDate,
+    exitStrategy,
   });
 }
 

--- a/src/models/exit-strategy-option.js
+++ b/src/models/exit-strategy-option.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const colors = require('colors/safe');
+const Logger = require('../logger.js');
+
+function get (follow, exitOnDeploy) {
+  if (follow) {
+    if (exitOnDeploy === 'deploy-start') {
+      throw new Error('The `follow` and `exit-on` set to "deploy-start" options are not compatible');
+    }
+    Logger.println(colors.yellow('The `follow` option is deprecated and will be removed in an upcoming major, use --exit-on set to "never" instead'));
+    return 'never';
+  }
+  return exitOnDeploy;
+}
+
+// plotQuietWarning: If in quiet mode and exitStrategy set to never plot a warning to indicate that the command will end
+function plotQuietWarning (exitStrategy, quiet) {
+  if (exitStrategy === 'never' && quiet) {
+    Logger.println(colors.bold.yellow('The "never" exit-on strategy is not compatible with the "quiet" mode, it will exit once the deployment ends'));
+  }
+}
+
+module.exports = { get, plotQuietWarning };


### PR DESCRIPTION
As discussed in #319 implements the `exit-on` option for the `deploy` command. 

For the `timeout`, we should first consider how we support duration (as seen in #609). 

I opened an issue for the timeout option: #693 

closes #319 