### PR TITLE
feat(addon): support JSON format when plotting an add-on list

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -602,7 +602,7 @@ function run () {
 
   const addonCommands = cliparse.command('addon', {
     description: 'Manage addons',
-    options: [opts.orgaIdOrName],
+    options: [opts.orgaIdOrName, opts.humanJsonOutputFormat],
     commands: [addonCreateCommand, addonDeleteCommand, addonRenameCommand, addonProvidersCommand, addonEnvCommand],
   }, addon('list'));
 

--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -16,20 +16,42 @@ const { toNameEqualsValueString } = require('@clevercloud/client/cjs/utils/env-v
 const { resolveAddonId } = require('../models/ids-resolver.js');
 
 async function list (params) {
-  const { org: orgaIdOrName } = params.options;
+  const { org: orgaIdOrName, format } = params.options;
 
   const ownerId = await Organisation.getId(orgaIdOrName);
   const addons = await Addon.list(ownerId);
 
-  const formattedAddons = addons.map((addon) => {
-    return [
-      addon.plan.name + ' ' + addon.provider.name,
-      addon.region,
-      colors.bold.green(addon.name),
-      addon.id,
-    ];
-  });
-  Logger.println(formatTable(formattedAddons));
+  switch (format) {
+    case 'json': {
+      const formattedAddons = addons.map((addon) => {
+        return {
+          addonId: addon.id,
+          creationDate: addon.creationDate,
+          name: addon.name,
+          planName: addon.plan.name,
+          planSlug: addon.plan.slug,
+          providerId: addon.provider.id,
+          realId: addon.realId,
+          region: addon.region,
+          type: addon.provider.name,
+        };
+      });
+      Logger.printJson(formattedAddons);
+      break;
+    }
+    case 'human':
+    default: {
+      const formattedAddons = addons.map((addon) => {
+        return [
+          addon.plan.name + ' ' + addon.provider.name,
+          addon.region,
+          colors.bold.green(addon.name),
+          addon.id,
+        ];
+      });
+      Logger.println(formatTable(formattedAddons));
+    }
+  }
 }
 
 async function create (params) {


### PR DESCRIPTION
As mentioned in https://github.com/CleverCloud/clever-tools/issues/589 implement format option for the `clever addon` command