### PR TITLE
feat(backups): support JSON format when plotting a backup list

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1037,7 +1037,7 @@ function run () {
   const backupsCommand = cliparse.command('backups', {
     description: 'List available database backups',
     args: [args.databaseId],
-    options: [opts.orgaIdOrName],
+    options: [opts.orgaIdOrName, opts.humanJsonOutputFormat],
     commands: [
       downloadBackupCommand,
     ],


### PR DESCRIPTION
As mentioned in https://github.com/CleverCloud/clever-tools/issues/589 implement format option for the `clever database backups` command