### PR TITLE
Add TLS to MateriaDB KV connect info

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -146,7 +146,7 @@ function displayAddon (format, addon, providerName, message) {
           colors.yellow(`/!\\ The MateriaDB ${providerName.toUpperCase()} provider is in Alpha testing phase, don't store sensitive or production grade data`),
           'You can easily use MateriaDB KV with \'redis-cli\', with such commands:',
           colors.blue(`source <(clever addon env ${addon.id} -F shell)`),
-          colors.blue('redis-cli -h $KV_HOST -p $KV_PORT'),
+          colors.blue('redis-cli -h $KV_HOST -p $KV_PORT --tls'),
         ].join('\n');
         Logger.println(materiaMessage);
       }


### PR DESCRIPTION
MateriaDB KV server now need a TLS connection, so we need to add `--tls` to the connect command we show after the creation of an add-on. 