### PR TITLE
fix: add-on env export in shell format

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -134,7 +134,7 @@ function run () {
   const opts = {
     sourceableEnvVarsList: cliparse.flag('add-export', { description: 'Display sourceable env variables setting' }),
     accesslogsFormat: getOutputFormatOption(['simple', 'extended', 'clf']),
-    addonEnvFormat: getOutputFormatOption(['shell']),
+    addonEnvFormat: cliparse.flag('add-export', { description: 'Display sourceable env variables setting' }),
     logsFormat: getOutputFormatOption(['json-stream']),
     accesslogsFollow: cliparse.flag('follow', {
       aliases: ['f'],

--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -145,7 +145,7 @@ function displayAddon (format, addon, providerName, message) {
           '',
           colors.yellow(`/!\\ The MateriaDB ${providerName.toUpperCase()} provider is in Alpha testing phase, don't store sensitive or production grade data`),
           'You can easily use MateriaDB KV with \'redis-cli\', with such commands:',
-          colors.blue(`source <(clever addon env ${addon.id} -F shell)`),
+          colors.blue(`source <(clever addon env ${addon.id} --add-export)`),
           colors.blue('redis-cli -h $KV_HOST -p $KV_PORT'),
         ].join('\n');
         Logger.println(materiaMessage);
@@ -235,7 +235,9 @@ async function showProvider (params) {
 
 async function env (params) {
 
-  const { org, format } = params.options;
+  const { org } = params.options;
+  const format = params.options['add-export'] ? 'shell' : params.options.format;
+
   const [addonIdOrRealId] = params.args;
 
   const addonId = await resolveAddonId(addonIdOrRealId);


### PR DESCRIPTION
Fix #719

My solution is using the `--add-export` we already use in `clever env` for applications. Thus, it's consistent with current CLI behavior. 