### PR TITLE
feat(activity): add deployment id

### DIFF
--- a/src/commands/activity.js
+++ b/src/commands/activity.js
@@ -31,6 +31,7 @@ function getColoredState (state, isLast) {
 // We use examples of maximum width text to have a clean display
 const formatActivityTable = formatTable([
   moment().format(),
+  47,
   'IN PROGRESS',
   'downscale',
   // a git commit id is 40 chars long
@@ -42,6 +43,7 @@ function formatActivityLine (event) {
   return formatActivityTable([
     [
       moment(event.date).format(),
+      event.uuid,
       getColoredState(event.state, event.isLast),
       event.action,
       event.commit || 'not specified',

--- a/src/commands/activity.js
+++ b/src/commands/activity.js
@@ -34,8 +34,8 @@ const formatActivityTable = formatTable([
   47,
   'IN PROGRESS',
   'downscale',
-  // a git commit id is 40 chars long
-  40,
+  // a git commit id is 8 chars long
+  8,
   0,
 ]);
 
@@ -46,7 +46,7 @@ function formatActivityLine (event) {
       event.uuid,
       getColoredState(event.state, event.isLast),
       event.action,
-      event.commit || 'not specified',
+      event?.commit?.substring(0, 8) ?? 'N/A',
       event.cause,
     ],
   ]);


### PR DESCRIPTION
Fixes #430
Fixes #193

This PR displays the deployment id in the output table.

Before:

```
2024-04-16T13:02:20+02:00  OK           DEPLOY     af81a57abe99c43a47527ddfdda9a12833189d88  Git
2024-04-16T13:22:44+02:00  OK           DEPLOY     fa491d14d320a9acf70fb7fb7482959ea527e5fa  Git
2024-04-16T13:33:02+02:00  OK           DEPLOY     7fe5c8b4cbdccf4e763f2eb4b798bc5c442e659b  Git
```

After:

```
2024-04-16T13:02:20+02:00  deployment_6c931b46-0275-4935-8f1d-04b4d26f878a  OK           DEPLOY     af81a57abe99c43a47527ddfdda9a12833189d88  Git
2024-04-16T13:22:44+02:00  deployment_bf87aed5-f95e-4936-bcd7-f13bacf23491  OK           DEPLOY     fa491d14d320a9acf70fb7fb7482959ea527e5fa  Git
2024-04-16T13:33:02+02:00  deployment_b1f77ac7-2fec-4b5a-b1b2-5981a84575e0  OK           DEPLOY     7fe5c8b4cbdccf4e763f2eb4b798bc5c442e659b  Git
```
