### PR TITLE
feat: support --app option

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -666,7 +666,7 @@ function run () {
   const cancelDeploy = lazyRequirePromiseModule('../src/commands/cancel-deploy.js');
   const cancelDeployCommand = cliparse.command('cancel-deploy', {
     description: 'Cancel an ongoing deployment',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
   }, cancelDeploy('cancelDeploy'));
 
   // CONFIG COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1014,7 +1014,7 @@ function run () {
   const ssh = lazyRequirePromiseModule('../src/commands/ssh.js');
   const sshCommand = cliparse.command('ssh', {
     description: 'Connect to running instances through SSH',
-    options: [opts.alias, opts.sshIdentityFile],
+    options: [opts.alias, opts.appIdOrName, opts.sshIdentityFile],
   }, ssh('ssh'));
 
   // STATUS COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1028,7 +1028,7 @@ function run () {
   const stop = lazyRequirePromiseModule('../src/commands/stop.js');
   const stopCommand = cliparse.command('stop', {
     description: 'Stop a running application',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
   }, stop('stop'));
 
   // TCP-REDIRS COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -976,7 +976,7 @@ function run () {
   const restart = lazyRequirePromiseModule('../src/commands/restart.js');
   const restartCommand = cliparse.command('restart', {
     description: 'Start or restart an application',
-    options: [opts.alias, opts.commit, opts.withoutCache, opts.quiet, opts.followDeployLogs],
+    options: [opts.alias, opts.appIdOrName, opts.commit, opts.withoutCache, opts.quiet, opts.followDeployLogs],
   }, restart('restart'));
 
   // SCALE COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -772,7 +772,7 @@ function run () {
   }, drain('disable'));
   const drainCommands = cliparse.command('drain', {
     description: 'Manage drains',
-    options: [opts.alias, opts.addonId],
+    options: [opts.alias, opts.appIdOrName, opts.addonId],
     commands: [drainCreateCommand, drainRemoveCommand, drainEnableCommand, drainDisableCommand],
   }, drain('list'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -605,7 +605,7 @@ function run () {
   const accesslogsModule = lazyRequirePromiseModule('../src/commands/accesslogs.js');
   const accesslogsCommand = cliparse.command('accesslogs', {
     description: 'Fetch access logs',
-    options: [opts.alias, opts.accesslogsFormat, opts.before, opts.after, opts.accesslogsFollow, opts.addonId],
+    options: [opts.alias, opts.appIdOrName, opts.accesslogsFormat, opts.before, opts.after, opts.accesslogsFollow, opts.addonId],
   }, accesslogsModule('accessLogs'));
 
   // ACTIVITY COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -796,7 +796,7 @@ function run () {
   }, env('importVarsFromLocalEnv'));
   const envCommands = cliparse.command('env', {
     description: 'Manage environment variables of an application',
-    options: [opts.alias, opts.sourceableEnvVarsList],
+    options: [opts.alias, opts.appIdOrName, opts.sourceableEnvVarsList],
     commands: [envSetCommand, envRemoveCommand, envImportCommand, envImportVarsFromLocalEnvCommand],
   }, env('list'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -707,7 +707,7 @@ function run () {
   const deleteCommandModule = lazyRequirePromiseModule('../src/commands/delete.js');
   const deleteCommand = cliparse.command('delete', {
     description: 'Delete an application',
-    options: [opts.alias, opts.confirmApplicationDeletion],
+    options: [opts.alias, opts.appIdOrName, opts.confirmApplicationDeletion],
   }, deleteCommandModule('deleteApp'));
 
   // DEPLOY COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -936,7 +936,7 @@ function run () {
   const open = lazyRequirePromiseModule('../src/commands/open.js');
   const openCommand = cliparse.command('open', {
     description: 'Open an application in your browser',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
   }, open('open'));
 
   // CONSOLE COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -968,7 +968,7 @@ function run () {
   }, publishedConfig('importEnv'));
   const publishedConfigCommands = cliparse.command('published-config', {
     description: 'Manage the configuration made available to other applications by this application',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
     commands: [publishedConfigSetCommand, publishedConfigRemoveCommand, publishedConfigImportCommand],
   }, publishedConfig('list'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1021,7 +1021,7 @@ function run () {
   const status = lazyRequirePromiseModule('../src/commands/status.js');
   const statusCommand = cliparse.command('status', {
     description: 'See the status of an application',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
   }, status('status'));
 
   // STOP COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -685,7 +685,7 @@ function run () {
   }, config('update'));
   const configCommands = cliparse.command('config', {
     description: 'Display or edit the configuration of your application',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
     commands: [configGetCommand, configSetCommand, configUpdateCommand],
   }, config('get'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -612,7 +612,7 @@ function run () {
   const activity = lazyRequirePromiseModule('../src/commands/activity.js');
   const activityCommand = cliparse.command('activity', {
     description: 'Show last deployments of an application',
-    options: [opts.alias, opts.follow, opts.showAllActivity],
+    options: [opts.alias, opts.appIdOrName, opts.follow, opts.showAllActivity],
   }, activity('activity'));
 
   // ADDON COMMANDS

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -318,9 +318,15 @@ function run () {
     onlyAddons: cliparse.flag('only-addons', { description: 'Only show add-on dependencies' }),
     onlyAliases: cliparse.flag('only-aliases', { description: 'List only application aliases' }),
     onlyApps: cliparse.flag('only-apps', { description: 'Only show app dependencies' }),
+    appIdOrName: cliparse.option('app', {
+      metavar: 'ID_OR_NAME',
+      description: 'Application to manage by its ID (or name, if unambiguous)',
+      parser: Parsers.appIdOrName,
+    }),
     orgaIdOrName: cliparse.option('org', {
+      metavar: 'ID_OR_NAME',
       aliases: ['o', 'owner'],
-      description: 'Organisation ID (or name, if unambiguous)',
+      description: 'Organisation to target by its ID (or name, if unambiguous)',
       parser: Parsers.orgaIdOrName,
     }),
     output: cliparse.option('output', {

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -93,8 +93,8 @@ const Application = lazyRequire('../src/models/application.js');
 const ApplicationConfiguration = lazyRequire('../src/models/application_configuration.js');
 const Drain = lazyRequire('../src/models/drain.js');
 const Notification = lazyRequire('../src/models/notification.js');
-const Organisation = lazyRequire('../src/models/organisation.js');
 const NetworkGroup = lazyRequire('../src/models/networkgroup.js');
+const Namespaces = lazyRequire('../src/models/namespaces.js');
 
 function run () {
 
@@ -223,7 +223,7 @@ function run () {
       metavar: 'namespace',
       description: 'Namespace in which the TCP redirection should be',
       required: true,
-      complete: Organisation('completeNamespaces'),
+      complete: Namespaces('completeNamespaces'),
     }),
     notificationEventType: cliparse.option('event', {
       metavar: 'type',
@@ -1047,7 +1047,7 @@ function run () {
   }, tcpRedirs('remove'));
   const tcpRedirsCommands = cliparse.command('tcp-redirs', {
     description: 'Control the TCP redirections from reverse proxies to your application',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
     commands: [tcpRedirsListNamespacesCommand, tcpRedirsAddCommand, tcpRedirsRemoveCommand],
   }, tcpRedirs('list'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -983,7 +983,7 @@ function run () {
   const scale = lazyRequirePromiseModule('../src/commands/scale.js');
   const scaleCommand = cliparse.command('scale', {
     description: 'Change scalability of an application',
-    options: [opts.alias, opts.flavor, opts.minFlavor, opts.maxFlavor, opts.instances, opts.minInstances, opts.maxInstances, opts.buildFlavor],
+    options: [opts.alias, opts.appIdOrName, opts.flavor, opts.minFlavor, opts.maxFlavor, opts.instances, opts.minInstances, opts.maxInstances, opts.buildFlavor],
   }, scale('scale'));
 
   // SERVICE COMMANDS

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -747,7 +747,7 @@ function run () {
   }, domain('getFavourite'));
   const domainCommands = cliparse.command('domain', {
     description: 'Manage domain names for an application',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
     commands: [domainCreateCommand, domainFavouriteCommands, domainRemoveCommand],
   }, domain('list'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1006,7 +1006,7 @@ function run () {
   }, service('unlinkAddon'));
   const serviceCommands = cliparse.command('service', {
     description: 'Manage service dependencies',
-    options: [opts.alias, opts.onlyApps, opts.onlyAddons, opts.showAll],
+    options: [opts.alias, opts.appIdOrName, opts.onlyApps, opts.onlyAddons, opts.showAll],
     commands: [serviceLinkAppCommand, serviceUnlinkAppCommand, serviceLinkAddonCommand, serviceUnlinkAddonCommand],
   }, service('list'));
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -943,7 +943,7 @@ function run () {
   const consoleModule = lazyRequirePromiseModule('../src/commands/console.js');
   const consoleCommand = cliparse.command('console', {
     description: 'Open an application in the Console',
-    options: [opts.alias],
+    options: [opts.alias, opts.appIdOrName],
   }, consoleModule('openConsole'));
 
   // PROFILE COMMAND

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -825,7 +825,7 @@ function run () {
   const logs = lazyRequirePromiseModule('../src/commands/logs.js');
   const logsCommand = cliparse.command('logs', {
     description: 'Fetch application logs, continuously',
-    options: [opts.alias, opts.before, opts.after, opts.search, opts.deploymentId, opts.addonId, opts.logsFormat],
+    options: [opts.alias, opts.appIdOrName, opts.before, opts.after, opts.search, opts.deploymentId, opts.addonId, opts.logsFormat],
   }, logs('appLogs'));
 
   // MAKE DEFAULT COMMAND

--- a/src/commands/activity.js
+++ b/src/commands/activity.js
@@ -4,12 +4,12 @@ const colors = require('colors/safe');
 const moment = require('moment');
 
 const Activity = require('../models/activity.js');
-const AppConfig = require('../models/app_configuration.js');
 const formatTable = require('../format-table');
 const Logger = require('../logger.js');
 const { Deferred } = require('../models/utils.js');
 const { EventsStream } = require('@clevercloud/client/cjs/streams/events.node.js');
 const { getHostAndTokens } = require('../models/send-to-api.js');
+const Application = require('../models/application.js');
 
 function getColoredState (state, isLast) {
   if (state === 'OK') {
@@ -87,8 +87,8 @@ function onEvent (previousEvent, newEvent) {
 }
 
 async function activity (params) {
-  const { alias, 'show-all': showAll, follow } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName, 'show-all': showAll, follow } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const events = await Activity.list(ownerId, appId, showAll);
   const reversedArrayWithIndex = events
     .reverse()

--- a/src/commands/cancel-deploy.js
+++ b/src/commands/cancel-deploy.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 const { getAllDeployments, cancelDeployment } = require('@clevercloud/client/cjs/api/v2/application.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 async function cancelDeploy (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const deployments = await getAllDeployments({ id: ownerId, appId, limit: 1 }).then(sendToApi);
 

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -2,7 +2,6 @@
 
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
-const AppConfig = require('../models/app_configuration.js');
 const Application = require('../models/application.js');
 const ApplicationConfiguration = require('../models/application_configuration.js');
 
@@ -10,8 +9,8 @@ const { sendToApi } = require('../models/send-to-api.js');
 
 async function get (params) {
   const [configurationName] = params.args;
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const app = await Application.get(ownerId, appId);
 
   if (configurationName == null) {
@@ -24,8 +23,8 @@ async function get (params) {
 
 async function set (params) {
   const [configurationName, configurationValue] = params.args;
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const config = ApplicationConfiguration.getById(configurationName);
 
   if (config != null) {
@@ -36,8 +35,8 @@ async function set (params) {
 }
 
 async function update (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const options = ApplicationConfiguration.parseOptions(params.options);
 
   if (Object.keys(options).length === 0) {

--- a/src/commands/console.js
+++ b/src/commands/console.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 const openPage = require('open');
 
 async function openConsole (params) {
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
 
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   Logger.println('Opening the console in your browser');
 

--- a/src/commands/delete.js
+++ b/src/commands/delete.js
@@ -5,13 +5,23 @@ const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 
 async function deleteApp (params) {
-  const { alias, yes: skipConfirmation } = params.options;
-  const appDetails = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName, yes: skipConfirmation } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
-  await Application.deleteApp(appDetails, skipConfirmation);
-  await Application.unlinkRepo(appDetails.alias);
-
-  Logger.println('The application has been deleted');
+  const app = await Application.get(ownerId, appId);
+  if (app == null) {
+    Logger.println('The application doesn\'t exist');
+  }
+  else {
+    // delete app
+    await Application.deleteApp(app, skipConfirmation);
+    Logger.println('The application has been deleted');
+    // unlink app
+    const wasUnlinked = await AppConfig.removeLinkedApplication({ appId, alias });
+    if (wasUnlinked) {
+      Logger.println('The application has been unlinked');
+    }
+  }
 };
 
 module.exports = { deleteApp };

--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 const {
   get: getApp,
@@ -26,8 +26,8 @@ function getFavouriteDomain ({ ownerId, appId }) {
 }
 
 async function list (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const app = await getApp({ id: ownerId, appId }).then(sendToApi);
   const favouriteDomain = await getFavouriteDomain({ ownerId, appId });
@@ -41,8 +41,8 @@ async function list (params) {
 
 async function add (params) {
   const [fqdn] = params.args;
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const encodedFqdn = encodeURIComponent(fqdn);
 
   await addDomain({ id: ownerId, appId, domain: encodedFqdn }).then(sendToApi);
@@ -50,8 +50,8 @@ async function add (params) {
 }
 
 async function getFavourite (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const favouriteDomain = await getFavouriteDomain({ ownerId, appId });
 
@@ -64,16 +64,16 @@ async function getFavourite (params) {
 
 async function setFavourite (params) {
   const [fqdn] = params.args;
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await markFavouriteDomain({ id: ownerId, appId }, { fqdn }).then(sendToApi);
   Logger.println('Your favourite domain has been successfully set');
 }
 
 async function unsetFavourite (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await unmarkFavouriteDomain({ id: ownerId, appId }).then(sendToApi);
   Logger.println('Favourite domain has been successfully unset');
@@ -81,8 +81,8 @@ async function unsetFavourite (params) {
 
 async function rm (params) {
   const [fqdn] = params.args;
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const encodedFqdn = encodeURIComponent(fqdn);
 
   await removeDomain({ id: ownerId, appId, domain: encodedFqdn }).then(sendToApi);

--- a/src/commands/drain.js
+++ b/src/commands/drain.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const { createDrainBody } = require('../models/drain.js');
 const Logger = require('../logger.js');
 
@@ -8,16 +8,16 @@ const { getDrains, createDrain, deleteDrain, updateDrainState } = require('@clev
 const { sendToApi } = require('../models/send-to-api.js');
 
 // TODO: This could be useful in other commands
-async function getAppOrAddonId ({ alias, addonId }) {
+async function getAppOrAddonId ({ alias, appIdOrName, addonId }) {
   return (addonId != null)
     ? addonId
-    : AppConfig.getAppDetails({ alias }).then(({ appId }) => appId);
+    : await Application.resolveId(appIdOrName, alias).then(({ appId }) => appId);
 }
 
 async function list (params) {
-  const { alias, addon: addonId } = params.options;
+  const { alias, app: appIdOrName, addon: addonId } = params.options;
 
-  const appIdOrAddonId = await getAppOrAddonId({ alias, addonId });
+  const appIdOrAddonId = await getAppOrAddonId({ alias, appIdOrName, addonId });
   const drains = await getDrains({ appId: appIdOrAddonId }).then(sendToApi);
 
   if (drains.length === 0) {
@@ -41,11 +41,11 @@ async function list (params) {
 
 async function create (params) {
   const [drainTargetType, drainTargetURL] = params.args;
-  const { alias, addon: addonId, username, password, 'api-key': apiKey, 'index-prefix': indexPrefix, 'sd-params': structuredDataParameters } = params.options;
+  const { alias, app: appIdOrName, addon: addonId, username, password, 'api-key': apiKey, 'index-prefix': indexPrefix, 'sd-params': structuredDataParameters } = params.options;
   const drainTargetCredentials = { username, password };
   const drainTargetConfig = { apiKey, indexPrefix, structuredDataParameters };
 
-  const appIdOrAddonId = await getAppOrAddonId({ alias, addonId });
+  const appIdOrAddonId = await getAppOrAddonId({ alias, appIdOrName, addonId });
   const body = createDrainBody(appIdOrAddonId, drainTargetURL, drainTargetType, drainTargetCredentials, drainTargetConfig);
   await createDrain({ appId: appIdOrAddonId }, body).then(sendToApi);
 
@@ -54,9 +54,9 @@ async function create (params) {
 
 async function rm (params) {
   const [drainId] = params.args;
-  const { alias, addon: addonId } = params.options;
+  const { alias, app: appIdOrName, addon: addonId } = params.options;
 
-  const appIdOrAddonId = await getAppOrAddonId({ alias, addonId });
+  const appIdOrAddonId = await getAppOrAddonId({ alias, appIdOrName, addonId });
   await deleteDrain({ appId: appIdOrAddonId, drainId }).then(sendToApi);
 
   Logger.println('Your drain has been successfully removed');
@@ -64,9 +64,9 @@ async function rm (params) {
 
 async function enable (params) {
   const [drainId] = params.args;
-  const { alias, addon: addonId } = params.options;
+  const { alias, app: appIdOrName, addon: addonId } = params.options;
 
-  const appIdOrAddonId = await getAppOrAddonId({ alias, addonId });
+  const appIdOrAddonId = await getAppOrAddonId({ alias, appIdOrName, addonId });
   await updateDrainState({ appId: appIdOrAddonId, drainId }, { state: 'ENABLED' }).then(sendToApi);
 
   Logger.println('Your drain has been enabled');
@@ -74,9 +74,9 @@ async function enable (params) {
 
 async function disable (params) {
   const [drainId] = params.args;
-  const { alias, addon: addonId } = params.options;
+  const { alias, app: appIdOrName, addon: addonId } = params.options;
 
-  const appIdOrAddonId = await getAppOrAddonId({ alias, addonId });
+  const appIdOrAddonId = await getAppOrAddonId({ alias, appIdOrName, addonId });
   await updateDrainState({ appId: appIdOrAddonId, drainId }, { state: 'DISABLED' }).then(sendToApi);
 
   Logger.println('Your drain has been disabled');

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const LogV2 = require('../models/log.js');
 const Log = require('../models/log-v4.js');
 const Logger = require('../logger.js');
@@ -9,7 +9,7 @@ const colors = require('colors/safe');
 const { resolveAddonId } = require('../models/ids-resolver.js');
 
 async function appLogs (params) {
-  const { alias, addon: addonIdOrRealId, after: since, before: until, search, 'deployment-id': deploymentId, format } = params.options;
+  const { alias, app: appIdOrName, addon: addonIdOrRealId, after: since, before: until, search, 'deployment-id': deploymentId, format } = params.options;
 
   // ignore --search ""
   const filter = (search !== '') ? search : null;
@@ -27,7 +27,7 @@ async function appLogs (params) {
     return LogV2.displayLogs({ appAddonId: addonId, since, until, filter, deploymentId });
   }
 
-  const { appId, ownerId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   if (isForHuman) {
     Logger.println(colors.blue('Waiting for application logs…'));

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -2,13 +2,13 @@
 
 const openPage = require('open');
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const Domain = require('../models/domain.js');
 const Logger = require('../logger.js');
 
 async function open (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const vhost = await Domain.getBest(appId, ownerId);
   const url = 'https://' + vhost.fqdn;

--- a/src/commands/published-config.js
+++ b/src/commands/published-config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 const variables = require('../models/variables.js');
 const { sendToApi } = require('../models/send-to-api.js');
@@ -8,8 +8,8 @@ const { toNameEqualsValueString, validateName } = require('@clevercloud/client/c
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
 
 async function list (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const publishedConfigs = await application.getAllExposedEnvVars({ id: ownerId, appId }).then(sendToApi);
   const pairs = Object.entries(publishedConfigs)
@@ -21,14 +21,14 @@ async function list (params) {
 
 async function set (params) {
   const [varName, varValue] = params.args;
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
 
   const nameIsValid = validateName(varName);
   if (!nameIsValid) {
     throw new Error(`Published config name ${varName} is invalid`);
   }
 
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const publishedConfigs = await application.getAllExposedEnvVars({ id: ownerId, appId }).then(sendToApi);
   publishedConfigs[varName] = varValue;
@@ -39,8 +39,8 @@ async function set (params) {
 
 async function rm (params) {
   const [varName] = params.args;
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const publishedConfigs = await application.getAllExposedEnvVars({ id: ownerId, appId }).then(sendToApi);
   delete publishedConfigs[varName];
@@ -50,9 +50,9 @@ async function rm (params) {
 };
 
 async function importEnv (params) {
-  const { alias, json } = params.options;
+  const { alias, app: appIdOrName, json } = params.options;
   const format = json ? 'json' : 'name-equals-value';
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const publishedConfigs = await variables.readVariablesFromStdin(format);
   await application.updateAllExposedEnvVars({ id: ownerId, appId }, publishedConfigs).then(sendToApi);

--- a/src/commands/scale.js
+++ b/src/commands/scale.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
 const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 
@@ -45,9 +44,9 @@ function validateOptions (options) {
 }
 
 async function scale (params) {
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
   const { minFlavor, maxFlavor, minInstances, maxInstances, buildFlavor } = validateOptions(params.options);
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await Application.setScalability(appId, ownerId, {
     minFlavor,

--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -1,17 +1,16 @@
 'use strict';
 
 const Addon = require('../models/addon.js');
-const AppConfig = require('../models/app_configuration.js');
 const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 
 async function list (params) {
-  const { alias, 'show-all': showAll, 'only-apps': onlyApps, 'only-addons': onlyAddons } = params.options;
+  const { alias, app: appIdOrName, 'show-all': showAll, 'only-apps': onlyApps, 'only-addons': onlyAddons } = params.options;
   if (onlyApps && onlyAddons) {
     throw new Error('--only-apps and --only-addons are mutually exclusive');
   }
 
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   if (!onlyAddons) {
     const apps = await Application.listDependencies(ownerId, appId, showAll);
@@ -27,36 +26,36 @@ async function list (params) {
 }
 
 async function linkApp (params) {
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
   const [dependency] = params.args;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await Application.link(ownerId, appId, dependency);
   Logger.println(`App ${dependency.app_id || dependency.app_name} successfully linked`);
 }
 
 async function unlinkApp (params) {
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
   const [dependency] = params.args;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await Application.unlink(ownerId, appId, dependency);
   Logger.println(`App ${dependency.app_id || dependency.app_name} successfully unlinked`);
 }
 
 async function linkAddon (params) {
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
   const [addon] = params.args;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await Addon.link(ownerId, appId, addon);
   Logger.println(`Addon ${addon.addon_id || addon.addon_name} successfully linked`);
 }
 
 async function unlinkAddon (params) {
-  const { alias } = params.options;
+  const { alias, app: appIdOrName } = params.options;
   const [addon] = params.args;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await Addon.unlink(ownerId, appId, addon);
   Logger.println(`Addon ${addon.addon_id || addon.addon_name} successfully unlinked`);

--- a/src/commands/ssh.js
+++ b/src/commands/ssh.js
@@ -2,13 +2,13 @@
 
 const { spawn } = require('child_process');
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const { conf } = require('../models/configuration.js');
 
 async function ssh (params) {
-  const { alias, 'identity-file': identityFile } = params.options;
+  const { alias, app: appIdOrName, 'identity-file': identityFile } = params.options;
 
-  const { appId } = await AppConfig.getAppDetails({ alias });
+  const { appId } = await Application.resolveId(appIdOrName, alias);
   const sshParams = ['-t', conf.SSH_GATEWAY, appId];
   if (identityFile != null) {
     sshParams.push('-i', identityFile);

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const colors = require('colors/safe');
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const Logger = require('../logger.js');
 
 const { get: getApplication, getAllInstances } = require('@clevercloud/client/cjs/api/v2/application.js');
@@ -66,8 +66,8 @@ function displayScalability (app) {
 }
 
 async function status (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const instances = await getAllInstances({ id: ownerId, appId }).then(sendToApi);
   const app = await getApplication({ id: ownerId, appId }).then(sendToApi);

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const AppConfig = require('../models/app_configuration.js');
+const Application = require('../models/application.js');
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const Logger = require('../logger.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
 async function stop (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await application.undeploy({ id: ownerId, appId }).then(sendToApi);
   Logger.println('App successfully stopped!');

--- a/src/commands/tcp-redirs.js
+++ b/src/commands/tcp-redirs.js
@@ -2,22 +2,25 @@
 
 const colors = require('colors/safe');
 
-const AppConfig = require('../models/app_configuration.js');
-const Organisation = require('../models/organisation.js');
+const Namespaces = require('../models/namespaces.js');
 const { sendToApi } = require('../models/send-to-api.js');
 const Interact = require('../models/interact.js');
 const Logger = require('../logger.js');
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
+const Application = require('../models/application.js');
 
 async function listNamespaces (params) {
-  const namespaces = await Organisation.getNamespaces(params);
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId } = await Application.resolveId(appIdOrName, alias);
+
+  const namespaces = await Namespaces.getNamespaces(ownerId);
 
   Logger.println('Available namespaces: ' + namespaces.map(({ namespace }) => namespace).join(', '));
 };
 
 async function list (params) {
-  const { alias } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const redirs = await application.getTcpRedirs({ id: ownerId, appId }).then(sendToApi);
 
@@ -46,8 +49,8 @@ async function acceptPayment (result, skipConfirmation) {
 }
 
 async function add (params) {
-  const { alias, namespace, yes: skipConfirmation } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName, namespace, yes: skipConfirmation } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const { port } = await application.addTcpRedir({ id: ownerId, appId }, { namespace }).then(sendToApi).catch((error) => {
     if (error.status === 402) {
@@ -65,8 +68,8 @@ async function add (params) {
 
 async function remove (params) {
   const [port] = params.args;
-  const { alias, namespace } = params.options;
-  const { ownerId, appId } = await AppConfig.getAppDetails({ alias });
+  const { alias, app: appIdOrName, namespace } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await application.removeTcpRedir({ id: ownerId, appId, sourcePort: port, namespace }).then(sendToApi);
 

--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -54,13 +54,21 @@ async function addLinkedApplication (appData, alias, ignoreParentConfig) {
   return persistConfig(currentConfig);
 };
 
-async function removeLinkedApplication (alias) {
+async function removeLinkedApplication ({ appId, alias }) {
   const currentConfig = await loadApplicationConf();
   const newConfig = {
     ...currentConfig,
-    apps: currentConfig.apps.filter((appEntry) => appEntry.alias !== alias),
+    apps: currentConfig.apps.filter((appEntry) => {
+      return appEntry.app_id !== appId && appEntry.alias !== alias;
+    }),
   };
-  return persistConfig(newConfig);
+
+  if (currentConfig.apps.length !== newConfig.apps.length) {
+    await persistConfig(newConfig);
+    return true;
+  }
+
+  return false;
 };
 
 function findApp (config, alias) {

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -89,18 +89,18 @@ async function create (name, typeName, region, orgaIdOrName, github, isTask, env
   return application.create({ id: ownerId }, newApp).then(sendToApi);
 };
 
-async function deleteApp (addDetails, skipConfirmation) {
-  Logger.debug('Deleting app: ' + addDetails.name + ' (' + addDetails.appId + ')');
+async function deleteApp (app, skipConfirmation) {
+  Logger.debug('Deleting app: ' + app.name + ' (' + app.id + ')');
 
   if (!skipConfirmation) {
     await Interact.confirm(
-      `Deleting the application ${addDetails.name} can't be undone, please type '${addDetails.name}' to confirm: `,
+      `Deleting the application ${app.name} can't be undone, please type '${app.name}' to confirm: `,
       'No confirmation, aborting application deletion',
-      [addDetails.name],
+      [app.name],
     );
   }
 
-  return application.remove({ id: addDetails.ownerId, appId: addDetails.appId }).then(sendToApi);
+  return application.remove({ id: app.ownerId, appId: app.id }).then(sendToApi);
 };
 
 function getApplicationByName (apps, name) {
@@ -204,7 +204,7 @@ async function linkRepo (app, orgaIdOrName, alias, ignoreParentConfig) {
 
 function unlinkRepo (alias) {
   Logger.debug(`Unlinking current repository from the app: ${alias}`);
-  return AppConfiguration.removeLinkedApplication(alias);
+  return AppConfiguration.removeLinkedApplication({ alias });
 };
 
 function redeploy (ownerId, appId, commit, withoutCache) {

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const autocomplete = require('cliparse').autocomplete;
 const product = require('@clevercloud/client/cjs/api/v2/product.js');
+const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
 
 const AppConfiguration = require('./app_configuration.js');
 const Interact = require('./interact.js');
@@ -12,6 +13,8 @@ const Organisation = require('./organisation.js');
 const User = require('./user.js');
 
 const { sendToApi } = require('../models/send-to-api.js');
+const AppConfig = require('./app_configuration.js');
+const { resolveOwnerId } = require('./ids-resolver.js');
 
 function listAvailableTypes () {
   return autocomplete.words(['docker', 'elixir', 'go', 'gradle', 'haskell', 'jar', 'maven', 'meteor', 'node', 'php', 'play1', 'play2', 'python', 'ruby', 'rust', 'sbt', 'static-apache', 'war']);
@@ -129,6 +132,62 @@ function getFromSelf (appId) {
   return application.get({ appId }).then(sendToApi);
 };
 
+/**
+ * @param {{app_id: string}|{app_name: string}} appIdOrName
+ * @param {string} alias
+ * @return {Promise<{appId: string, ownerId: string}>}
+ */
+async function resolveId (appIdOrName, alias) {
+  if (appIdOrName != null && alias != null) {
+    throw new Error('Only one of the `--app` or `--alias` options can be set at a time');
+  }
+
+  // -- resolve by linked app
+
+  if (appIdOrName == null) {
+    const appDetails = await AppConfig.getAppDetails({ alias });
+    return { appId: appDetails.appId, ownerId: appDetails.ownerId };
+  }
+
+  // -- resolve by app id
+
+  if (appIdOrName.app_id != null) {
+    const ownerId = await resolveOwnerId(appIdOrName.app_id);
+    if (ownerId != null) {
+      return {
+        appId: appIdOrName.app_id,
+        ownerId,
+      };
+    }
+
+    throw new Error('Application not found');
+  }
+
+  // -- resolve by app name
+
+  const summary = await getSummary({}).then(sendToApi);
+
+  const candidates = [summary.user, ...summary.organisations]
+    .flatMap((owner) => owner.applications.map((app) => ({ app, owner })))
+    .filter((candidate) => candidate.app.name === appIdOrName.app_name);
+
+  if (candidates.length === 0) {
+    throw new Error('Application not found');
+  }
+  if (candidates.length === 1) {
+    return {
+      appId: candidates[0].app.id,
+      ownerId: candidates[0].owner.id,
+    };
+  }
+
+  Logger.printErrorLine(`The name '${appIdOrName.app_name}' refers to multiple applications:`);
+  candidates.forEach((candidate) => {
+    Logger.printErrorLine(`- ${candidate.owner.name}: ${candidate.app.id} (${candidate.app.variantSlug})`);
+  });
+  throw new Error('Ambiguous application name, use the `--app` option with one of the IDs above');
+}
+
 async function linkRepo (app, orgaIdOrName, alias, ignoreParentConfig) {
   Logger.debug(`Linking current repository to the app: ${app.app_id || app.app_name}`);
 
@@ -237,6 +296,7 @@ async function unlink (ownerId, appId, dependency) {
 };
 
 module.exports = {
+  resolveId,
   create,
   deleteApp,
   get,

--- a/src/models/namespaces.js
+++ b/src/models/namespaces.js
@@ -1,0 +1,20 @@
+const Application = require('./application.js');
+const organisation = require('@clevercloud/client/cjs/api/v2/organisation.js');
+const { sendToApi } = require('./send-to-api.js');
+const { autocomplete } = require('cliparse');
+
+async function getNamespaces (ownerId) {
+  return organisation.getNamespaces({ id: ownerId }).then(sendToApi);
+}
+
+async function completeNamespaces () {
+  // Sadly we do not have access to current params in complete as of now
+  const { ownerId } = await Application.resolveId(null, null);
+
+  return getNamespaces(ownerId).then(autocomplete.words);
+}
+
+module.exports = {
+  getNamespaces,
+  completeNamespaces,
+};

--- a/src/models/organisation.js
+++ b/src/models/organisation.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const autocomplete = require('cliparse').autocomplete;
 
-const AppConfig = require('./app_configuration.js');
-
-const organisation = require('@clevercloud/client/cjs/api/v2/organisation.js');
 const { getSummary } = require('@clevercloud/client/cjs/api/v2/user.js');
 const { sendToApi } = require('../models/send-to-api.js');
 
@@ -37,22 +33,6 @@ async function getByName (name) {
   return filteredOrgs[0];
 }
 
-async function getNamespaces (params) {
-  const { alias } = params.options;
-  const { ownerId } = await AppConfig.getAppDetails({ alias });
-
-  return organisation.getNamespaces({ id: ownerId }).then(sendToApi);
-}
-
-function completeNamespaces () {
-  // Sadly we do not have access to current params in complete as of now
-  const params = { options: {} };
-
-  return getNamespaces(params).then(autocomplete.words);
-};
-
 module.exports = {
   getId,
-  getNamespaces,
-  completeNamespaces,
 };


### PR DESCRIPTION
Fixes #587

This PR adds the support of `--app` and `--org` options in all commands where an app is involved.

- `--app` can be an app_id or an app_name.

The first commit adds a smart app resolver which aim is to provide an app ID and owner ID from an `--app` or an `--alias`.

The following commits add the options to the commands and use the smart resolver.
