### PR TITLE
Nix support: new repository

### DIFF
--- a/docs/setup-systems.md
+++ b/docs/setup-systems.md
@@ -155,4 +155,4 @@ COPY --from=clevercloud/clever-tools /bin/clever /usr/local/bin/clever
 
 If you are using Nix, you will find a Nix derivation on Fretlink's GitHub repository:
 
-* https://github.com/fretlink/clever-tools-nix
+* https://github.com/funky-thunks/clever-tools-nix


### PR DESCRIPTION
The original Nix bindings were supported by a company that no longer exists.

I've updated to 3.6.1 at this occasion.