### PR TITLE
feat(stop): allow to also cancel any ongoing deployment

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -249,6 +249,9 @@ function run () {
     }),
     exitOnDeploy: getExitOnOption(),
     sameCommitPolicy: getSameCommitPolicyOption(),
+    stopAll: cliparse.flag('all', {
+      description: 'Stop application and any ongoing deployment',
+    }),
     webhookFormat: cliparse.option('format', {
       metavar: 'format',
       default: 'raw',
@@ -1038,7 +1041,7 @@ function run () {
   const stop = lazyRequirePromiseModule('../src/commands/stop.js');
   const stopCommand = cliparse.command('stop', {
     description: 'Stop a running application',
-    options: [opts.alias, opts.appIdOrName],
+    options: [opts.alias, opts.appIdOrName, opts.stopAll],
   }, stop('stop'));
 
   // TCP-REDIRS COMMAND

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -4,13 +4,24 @@ const Application = require('../models/application.js');
 const application = require('@clevercloud/client/cjs/api/v2/application.js');
 const Logger = require('../logger.js');
 const { sendToApi } = require('../models/send-to-api.js');
+const { getAllDeployments, cancelDeployment } = require('@clevercloud/client/cjs/api/v2/application.js');
 
 async function stop (params) {
-  const { alias, app: appIdOrName } = params.options;
+  const { alias, app: appIdOrName, all } = params.options;
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   await application.undeploy({ id: ownerId, appId }).then(sendToApi);
   Logger.println('App successfully stopped!');
+
+  if (all) {
+    const deployments = await getAllDeployments({ id: ownerId, appId, limit: 1 }).then(sendToApi);
+    if (deployments.length !== 0 && deployments[0].state === 'WIP') {
+      const deploymentId = deployments[0].id;
+      await cancelDeployment({ id: ownerId, appId, deploymentId }).then(sendToApi);
+      Logger.println(`Deployment ${deploymentId} cancelled!`);
+    }
+
+  }
 }
 
 module.exports = { stop };


### PR DESCRIPTION
This PR adds `--cancel` and `-c` to the `stop` command. It allows to ask to stop the app and to cancel any ongoing deployment with only one command.

The branch has been rebased on `support-app-id` from Pierre