### PR TITLE
feat(console): open the Console even if no app is linked

### DIFF
--- a/src/commands/console.js
+++ b/src/commands/console.js
@@ -1,18 +1,30 @@
 'use strict';
 
 const Application = require('../models/application.js');
+const AppConfig = require('../models/app_configuration.js');
 const Logger = require('../logger.js');
 const openPage = require('open');
 
 async function openConsole (params) {
   const { alias, app: appIdOrName } = params.options;
 
+  const baseUrl = 'https://console.clever-cloud.com';
+
+  const { apps } = await AppConfig.loadApplicationConf();
+  // If no app is linked or asked, open the Console without any context
+  if (apps.length === 0 && !appIdOrName) {
+    Logger.println('Opening the Console in your browser');
+    await openPage(baseUrl, { wait: false });
+    return;
+  }
+
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
-
-  Logger.println('Opening the console in your browser');
-
   const prefixPath = (ownerId.startsWith('user_')) ? 'users/me' : `organisations/${ownerId}`;
-  const url = `https://console.clever-cloud.com/${prefixPath}/applications/${appId}`;
+  const url = `${baseUrl}/${prefixPath}/applications/${appId}`;
+
+  Logger.debug(`URL: ${url}`);
+  Logger.println(`Opening the Console in your browser for application ${appId}`);
+
   await openPage(url, { wait: false });
 }
 


### PR DESCRIPTION
This PR has been rebased on `support-app-id` from Pierre