### PR TITLE
docs(setup-systems): reintroduce nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clever Tools
 
-Deploy on Clever Cloud and control you applications, add-ons, services from command line.
+Deploy on Clever Cloud and control your applications, add-ons, services from command line.
 
 - [Create a Clever Cloud account](https://console.clever-cloud.com)
 

--- a/docs/setup-systems.md
+++ b/docs/setup-systems.md
@@ -15,6 +15,7 @@ Clever Cloud CLI is based on Node.js. We thought it to be easily available on an
   - [Chocolatey](/docs/setup-systems.md#chocolatey)
   - [Binary (.zip)](/docs/setup-systems.md#binary-zip)
 - [Docker](/docs/setup-systems.md#docker)
+- [Nix package manager](/docs/setup-systems.md#nix-package-manager)
 
 ## GNU/Linux
 
@@ -144,3 +145,7 @@ In your `Dockerfile` copy `clever-tools` from the image itself with a simple one
 ```Dockerfile
 COPY --from=clevercloud/clever-tools /bin/clever /usr/local/bin/clever
 ```
+
+## Nix package manager
+
+If you are using Nix on NixOS or any other compatible system, the package is available in `unstable` channel. Follow [these instructions](https://search.nixos.org/packages?channel=unstable&show=clever-tools&from=0&size=50&sort=relevance&type=packages&query=clever-tools).


### PR DESCRIPTION
Fixes #748

The `clever-tools` package is now available directly on `nixpkgs - unstable`.

This PR simply updates the docs to reflect that.

## TODO:

- [x] wait for the nixpkgs website to reflect the `clever-tools` availability (right now searching for the package yields nothing even though it's available and it works when adding it to your config)
- [x] create an issue to update the docs once the package makes it to the latest release branch (next major version probably unless it's backported before that but it's unlikely).