### PR TITLE
fix: addon delete without org parameter

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -176,7 +176,17 @@ async function deleteAddon (params) {
   const { yes: skipConfirmation, org: orgaIdOrName } = params.options;
   const [addon] = params.args;
 
-  const ownerId = await Organisation.getId(orgaIdOrName);
+  let ownerId = await Organisation.getId(orgaIdOrName);
+
+  if (ownerId == null && addon.addon_id != null) {
+    ownerId = await Addon.findOwnerId(ownerId, addon.addon_id);
+  }
+
+  if (ownerId == null && addon.addon_name != null) {
+    const foundAddon = await Addon.findByName(addon.addon_name);
+    ownerId = foundAddon.orgaId;
+  }
+
   await Addon.delete(ownerId, addon, skipConfirmation);
 
   Logger.println(`Addon ${addon.addon_id || addon.addon_name} successfully deleted`);

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -243,6 +243,22 @@ async function findById (addonId) {
   throw new Error(`Could not find add-on with ID: ${addonId}`);
 }
 
+async function findByName (addonName) {
+  const { user, organisations } = await getSummary({}).then(sendToApi);
+  for (const orga of [user, ...organisations]) {
+    for (const simpleAddon of orga.addons) {
+      if (simpleAddon.name === addonName) {
+        const addon = await getAddon({ id: orga.id, addonId: simpleAddon.id }).then(sendToApi);
+        return {
+          ...addon,
+          orgaId: orga.id,
+        };
+      }
+    }
+  }
+  throw new Error(`Could not find add-on with name ${addonName}`);
+}
+
 async function findOwnerId (org, addonId) {
 
   if (org != null && org.orga_id != null) {
@@ -305,6 +321,7 @@ module.exports = {
   delete: deleteAddon,
   findById,
   findOwnerId,
+  findByName,
   getProvider,
   getProviderInfos,
   link,


### PR DESCRIPTION
This PR: 

- add a `findByName` function in add-ons model, to find an add-on only by its name
- look for orgId by add-on ID or name if none is specified

Fixes #811 