### PR TITLE
fix(dependencies): remove `text-table` from `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,8 +59,7 @@
         "mocha": "8.4.0",
         "pkg": "5.8.1",
         "rollup": "4.14.1",
-        "semver": "7.3.5",
-        "text-table": "0.2.0"
+        "semver": "7.3.5"
       },
       "engines": {
         "node": ">=18"
@@ -7788,8 +7787,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -14245,8 +14243,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "mocha": "8.4.0",
     "pkg": "5.8.1",
     "rollup": "4.14.1",
-    "semver": "7.3.5",
-    "text-table": "0.2.0"
+    "semver": "7.3.5"
   },
   "overrides": {
     "pkg-fetch": "3.5.2"


### PR DESCRIPTION
`text-table` is an essential dependency so it should not be part of `devDependencies`.

When installing `clever-tools` with `NODE_ENV="production"`, the `text-table` was not being installed which cause issues (for instance within the `nix` package).

This is a `fix` and not a `chore` commit because this actually makes the nix package broken for commands relying on the `text-table` dependency.

Fixes #819

