### PR TITLE
fix(update-notifier): set `isGlobal` to `true`

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -43,7 +43,7 @@ if (!updateNotifierExplicitFalse && !isRunThroughPackagedBinary) {
   }).notify({
     isGlobal: true,
     getDetails () {
-      const docsUrl = 'https://www.clever-cloud.com/doc/clever-tools/getting_started';
+      const docsUrl = 'https://github.com/CleverCloud/clever-tools/tree/master/docs#how-to-use-clever-tools';
       return `\nPlease follow this link to update your clever-tools:\n${docsUrl}`;
     },
   });

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -41,6 +41,7 @@ if (!updateNotifierExplicitFalse && !isRunThroughPackagedBinary) {
     pkg,
     tagsUrl: 'https://api.github.com/repos/CleverCloud/clever-tools/tags',
   }).notify({
+    isGlobal: true,
     getDetails () {
       const docsUrl = 'https://www.clever-cloud.com/doc/clever-tools/getting_started';
       return `\nPlease follow this link to update your clever-tools:\n${docsUrl}`;


### PR DESCRIPTION
Fixes #812

## What does this PR do?

This PR enables the `isGlobal` flag of the `update-notifier` as discussed with @davlgd.

The update message now rightfully specifies to use `npm i -g` instead of `npm i`
![usual clever tools update message specifying to use npm i -g clever-tools](https://github.com/user-attachments/assets/0f814b5c-91fc-4f8b-a9b5-c5dba1349c37)
