### PR TITLE
feat(domain): init diag command

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -155,6 +155,12 @@ function run () {
       description: 'Short name for the application',
       complete: Application.listAvailableAliases,
     }),
+    domain: cliparse.option('filter', {
+      aliases: ['f'],
+      default: '',
+      metavar: 'TEXT',
+      description: 'Check only domains containing the provided text',
+    }),
     naturalName: cliparse.flag('natural-name', {
       aliases: ['n'],
       description: 'Show the application names or aliases if possible',
@@ -593,10 +599,14 @@ function run () {
     description: 'Manage the favourite domain name for an application',
     commands: [domainSetFavouriteCommand, domainUnsetFavouriteCommand],
   }, domain.getFavourite);
+  const domainDiagApplicationCommand = cliparse.command('diag', {
+    description: 'Check if domains associated to a specific app are properly configured',
+    options: [opts.humanJsonOutputFormat, opts.domain],
+  }, domain.diagApplication);
   const domainCommands = cliparse.command('domain', {
     description: 'Manage domain names for an application',
     options: [opts.alias, opts.appIdOrName],
-    commands: [domainCreateCommand, domainFavouriteCommands, domainRemoveCommand],
+    commands: [domainCreateCommand, domainFavouriteCommands, domainRemoveCommand, domainDiagApplicationCommand],
   }, domain.list);
 
   // DRAIN COMMANDS

--- a/docs/applications-config.md
+++ b/docs/applications-config.md
@@ -88,6 +88,24 @@ clever domain favourite set FQDN
 clever domain favourite unset FQDN
 ```
 
+To check if the domains of an application are properly configured, use:
+
+```
+clever domain diag
+clever domain diag --format json
+clever domain diag --app APP_ID_OR_NAME
+```
+
+You can only diagnose some domains of the application using a text filter:
+
+```
+clever domain diag --filter .tld
+clever domain diag --filter mydomain.tld
+```
+
+> [!NOTE]
+> Domain diagnosis is not made for applications using a 3rd party CDN or a dedicated load balancer.
+
 ## scale and dedicated build
 
 You can easily change the number of instances and `flavor` for an application. It can have a different `flavor` used for build phase, to get it done faster. We also provide horizontal and vertical scaling: you can set a minimal/maximal `flavor` and number of instance, then we autoscale depending on incoming load. To change this, use `clever scale` with the following options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "string-length": "4.0.2",
         "superagent": "6.1.0",
         "text-table": "0.2.0",
+        "tldts": "6.1.30",
         "update-notifier": "5.1.0",
         "uuid": "8.3.2",
         "ws": "7.4.6",
@@ -8290,6 +8291,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.30.tgz",
+      "integrity": "sha512-NErlfxa+LPJynXZ07f86N6ylkXhYaOL4rB2k+qwF69cdvol1IJHmlouXE8c7Hrqr1BiYNWL4qbdTxaX+szfOpQ==",
+      "dependencies": {
+        "tldts-core": "^6.1.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.52",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.52.tgz",
+      "integrity": "sha512-j4OxQI5rc1Ve/4m/9o2WhWSC4jGc4uVbCINdOEJRAraCi0YqTqgMcxUx7DbmuP0G3PCixoof/RZB0Q5Kh9tagw=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -15119,6 +15136,19 @@
           }
         }
       }
+    },
+    "tldts": {
+      "version": "6.1.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.30.tgz",
+      "integrity": "sha512-NErlfxa+LPJynXZ07f86N6ylkXhYaOL4rB2k+qwF69cdvol1IJHmlouXE8c7Hrqr1BiYNWL4qbdTxaX+szfOpQ==",
+      "requires": {
+        "tldts-core": "^6.1.30"
+      }
+    },
+    "tldts-core": {
+      "version": "6.1.52",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.52.tgz",
+      "integrity": "sha512-j4OxQI5rc1Ve/4m/9o2WhWSC4jGc4uVbCINdOEJRAraCi0YqTqgMcxUx7DbmuP0G3PCixoof/RZB0Q5Kh9tagw=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.8.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "9.0.0",
+        "@clevercloud/client": "9.1.0",
         "cliparse": "0.5.0",
         "colors": "1.4.0",
         "common-env": "6.4.0",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@clevercloud/client": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-9.0.0.tgz",
-      "integrity": "sha512-eXq7Lom5gLgd74TCUG5ImcdFDFWM/5F3lMxilt26mBuYl906MGBeeTBXSkKqMepfm01VAlUyxgeEvWF6J7ST1w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-9.1.0.tgz",
+      "integrity": "sha512-Dw0NSIhzq7bCJBrF9ikmATltlgxsjV0c1DHsGMOI5nTYqRfCnvIroU8HaVvESCsFNNV5HmYt8z5a4O1Q48MnFQ==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"
@@ -9136,9 +9136,9 @@
       }
     },
     "@clevercloud/client": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-9.0.0.tgz",
-      "integrity": "sha512-eXq7Lom5gLgd74TCUG5ImcdFDFWM/5F3lMxilt26mBuYl906MGBeeTBXSkKqMepfm01VAlUyxgeEvWF6J7ST1w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-9.1.0.tgz",
+      "integrity": "sha512-Dw0NSIhzq7bCJBrF9ikmATltlgxsjV0c1DHsGMOI5nTYqRfCnvIroU8HaVvESCsFNNV5HmYt8z5a4O1Q48MnFQ==",
       "requires": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scripts/*.sh"
   ],
   "dependencies": {
-    "@clevercloud/client": "9.0.0",
+    "@clevercloud/client": "9.1.0",
     "cliparse": "0.5.0",
     "colors": "1.4.0",
     "common-env": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "string-length": "4.0.2",
     "superagent": "6.1.0",
     "text-table": "0.2.0",
+    "tldts": "6.1.30",
     "update-notifier": "5.1.0",
     "uuid": "8.3.2",
     "ws": "7.4.6",

--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -2,6 +2,16 @@ import * as Application from '../models/application.js';
 import { Logger } from '../logger.js';
 import { get as getApp, addDomain, getFavouriteDomain as getFavouriteDomainWithError, markFavouriteDomain, unmarkFavouriteDomain, removeDomain } from '@clevercloud/client/esm/api/v2/application.js';
 import { sendToApi } from '../models/send-to-api.js';
+import colors from 'colors/safe.js';
+import { parse as parseDomain } from 'tldts';
+import { diagDomainConfig } from '@clevercloud/client/esm/utils/diag-domain-config.js';
+import { DnsResolver } from '../models/node-dns-resolver.js';
+
+/**
+ * @typedef {import('@clevercloud/client/esm/utils/diag-domain-config.types.js').DomainInfo} DomainInfo
+ * @typedef {import('@clevercloud/client/esm/utils/diag-domain-config.types.js').ResolveDnsResult} ResolveDnsResult
+ * @typedef {import('@clevercloud/client/esm/utils/diag-domain-config.types.js').DomainDiag} DomainDiag
+ */
 
 function getFavouriteDomain ({ ownerId, appId }) {
   return getFavouriteDomainWithError({ id: ownerId, appId })
@@ -78,4 +88,217 @@ export async function rm (params) {
 
   await removeDomain({ id: ownerId, appId, domain: encodedFqdn }).then(sendToApi);
   Logger.println('Your domain has been successfully removed');
+}
+
+export async function diagApplication (params) {
+  const dnsResolver = new DnsResolver();
+  const allDomainDiagnostics = [];
+  const { alias, app: appIdOrName, format, filter } = params.options;
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
+  const hasDomainFilter = filter.length > 0;
+  let hasError = false;
+
+  const app = await getApp({ id: ownerId, appId }).then(sendToApi);
+  const expectedDnsForPublicLoadBalancer = await getDefaultLoadBalancersDnsInfo({ id: ownerId, appId }).then(sendToApi);
+
+  const loadBalancerDnsConfig = {
+    aRecords: expectedDnsForPublicLoadBalancer[0].dns.a,
+    cnameRecord: expectedDnsForPublicLoadBalancer[0].dns.cname,
+  };
+
+  const filteredDomains = app.vhosts.filter(({ fqdn }) => fqdn.includes(filter));
+  const domains = getParsedDomains(filteredDomains);
+  const sortedDomains = sortDomains(domains);
+
+  for (const { hostname, pathPrefix, isApex } of sortedDomains) {
+    const resolvedDnsConfig = {
+      aRecords: await dnsResolver.resolveA(hostname),
+      cnameRecords: await dnsResolver.resolveCname(hostname) ?? [],
+    };
+
+    const diagnosticResults = diagDomainConfig({ hostname, pathPrefix, isApex }, resolvedDnsConfig, loadBalancerDnsConfig);
+    allDomainDiagnostics.push({ ...diagnosticResults, resolvedDnsConfig });
+
+    if (diagnosticResults.diagSummary === 'invalid' || diagnosticResults.diagSummary === 'no-config') {
+      hasError = true;
+    }
+  }
+
+  switch (format) {
+    case 'json':
+      Logger.printJson(allDomainDiagnostics);
+      break;
+    default: {
+      allDomainDiagnostics.forEach((diag) => reportDomainDiagnostics(diag));
+
+      if (allDomainDiagnostics.length === 0 && !hasDomainFilter) {
+        Logger.println(`\nNo domain associated to the app "${app.name}" (${app.id})`);
+      }
+
+      if (allDomainDiagnostics.length === 0 && hasDomainFilter) {
+        Logger.println(`\nNo domain matches "${filter}" for the app "${app.name}" (${app.id})`);
+      }
+    }
+  }
+
+  if (hasError) {
+    throw new Error('At least one of the domains is misconfigured');
+  }
+}
+
+/** @param {DomainDiag & { resolvedDnsConfig: ResolveDnsResult }} domainDiag */
+function reportDomainDiagnostics ({ hostname, pathPrefix, resolvedDnsConfig, diagDetails, diagSummary }) {
+
+  const validDiags = diagDetails.filter((diag) => diag.code === 'valid-a');
+  const unknownDiags = diagDetails.filter((diag) => diag.code === 'unknown-a');
+  const missingDiags = diagDetails.filter((diag) => diag.code === 'missing-a');
+  const suggestedCname = diagDetails.find((diag) => diag.code === 'suggested-cname');
+  const missingCname = diagDetails.find((diag) => diag.code === 'missing-cname');
+  const unknownCname = diagDetails.find((diag) => diag.code === 'unknown-cname');
+
+  const hasARecords = resolvedDnsConfig.aRecords.length > 0;
+  const hasCnameRecord = resolvedDnsConfig.cnameRecords.length > 0;
+
+  Logger.println('\n' + colors.blue(hostname) + colors.yellow(pathPrefix) + '\n');
+
+  switch (diagSummary) {
+    case 'managed':
+      printlnWithIndent(colors.green('✔ Managed by Clever Cloud'), 2);
+      printlnWithIndent('ⓘ cleverapps.io domains should only be used for testing purposes', 2);
+      break;
+    case 'no-config':
+      printlnWithIndent(colors.red('✘ No DNS configuration found'), 2);
+      break;
+    case 'valid':
+      printlnWithIndent(colors.green('✔ Your configuration is valid'), 2);
+      break;
+    case 'invalid':
+      printlnWithIndent(colors.red('✘ Something is wrong with your configuration'), 2);
+      break;
+    case 'incomplete':
+      printlnWithIndent(colors.yellow('⚠ Your configuration is incomplete'), 2);
+      break;
+  }
+
+  // Valid records
+  if (validDiags.length > 0) {
+    Logger.println('');
+    validDiags.forEach((diag) => {
+      const source = hasCnameRecord ? `(from CNAME ${resolvedDnsConfig.cnameRecords[0]}.)` : '';
+      printlnWithIndent(`${diag.record.value} ${colors.green('✔ A Record OK')} ${source}`, 2);
+    });
+  }
+
+  // Replace A with CNAME
+  if (diagSummary === 'valid' && suggestedCname != null) {
+    Logger.println('');
+    printlnWithIndent('ⓘ You can replace your A records with this CNAME:', 2);
+    printlnWithIndent(suggestedCname.record.value, 6);
+  }
+
+  // Replace A Records with CNAME
+  if (missingCname != null && unknownCname == null && (diagSummary === 'invalid' || diagSummary === 'incomplete')) {
+    const cnameToUse = suggestedCname != null ? suggestedCname.record.value : missingCname.record.value;
+
+    Logger.println('');
+    printlnWithIndent('⇄ Replace your A records with this CNAME:', 2);
+    printlnWithIndent(cnameToUse, 6);
+    Logger.println('');
+    printlnWithIndent('or:', 2);
+  }
+
+  // Replace unknown CNAME with missing CNAME
+  if ((diagSummary === 'invalid') && missingCname != null && unknownCname != null) {
+    Logger.println('');
+    printlnWithIndent('➖Remove this CNAME record:', 2);
+    printlnWithIndent(unknownCname.record.value + '. ', 6);
+    Logger.println('');
+    printlnWithIndent('➕Add this CNAME record instead:', 2);
+    printlnWithIndent(missingCname.record.value, 6);
+
+    if (hasARecords) {
+      Logger.println('');
+      printlnWithIndent('or:', 2);
+    }
+  }
+
+  // Add CNAME
+  if (diagSummary === 'no-config' && missingCname != null) {
+    Logger.println('');
+    printlnWithIndent('➕Add this CNAME record:', 2);
+    printlnWithIndent(missingCname.record.value, 6);
+  }
+
+  // Remove Unknown records
+  if (unknownDiags.length > 0) {
+    Logger.println('');
+    printlnWithIndent('➖Remove these A records:', 2);
+
+    unknownDiags.forEach((diag) => {
+      const source = hasCnameRecord ? `(from CNAME ${resolvedDnsConfig.cnameRecords[0]}.)` : '';
+      printlnWithIndent(diag.record.value + source, 6);
+    });
+  }
+
+  // Add missing A records
+  if (missingDiags.length > 0) {
+    Logger.println('');
+    printlnWithIndent('➕Add these A records:', 2);
+
+    missingDiags.forEach((missingDiag) => printlnWithIndent(missingDiag.record.value, 6));
+  }
+}
+
+// TODO: put in clever client
+function getDefaultLoadBalancersDnsInfo (params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/load-balancers/organisations/${params.id}/applications/${params.appId}/load-balancers/default`,
+    headers: {
+      Accept: 'application/json',
+    },
+    // no query params
+    // no body
+  });
+}
+
+/**
+ * Parses domain information from vhosts array
+ *
+ * @param {Array<{ fqdn: string }>} vhosts
+ * @returns {Array<Partial<DomainInfo>>} Array of parsed domain objects
+ */
+function getParsedDomains (vhosts) {
+  return vhosts.map(({ fqdn }) => {
+    const { hostname, pathname } = new URL('https://' + fqdn);
+    const { subdomain } = parseDomain(fqdn);
+
+    return { hostname, pathPrefix: pathname, isApex: subdomain === '' };
+  });
+}
+
+/**
+ * Sorts an array of parsed domain by hostname (alphabetical order)
+ *
+ * @param {Array<Partial<DomainInfo>>} parsedDomains - Array of parsed domains to sort
+ * @returns {Array<Partial<DomainInfo>>} Sorted array of parsed domains
+ */
+function sortDomains (parsedDomains) {
+  return parsedDomains
+    .slice()
+    .sort((a, b) => {
+      const reverseA = a.hostname.split('.').reverse().join('.');
+      const reverseB = b.hostname.split('.').reverse().join('.');
+      return reverseA.localeCompare(reverseB);
+    });
+}
+
+/**
+ * Prints a line of text with specified indentation.
+ *
+ * @param {string} text - The text to be printed.
+ * @param {number} indentLevel - The number of spaces to indent the text.
+ */
+function printlnWithIndent (text, indentLevel) {
+  Logger.println(' '.repeat(indentLevel) + text);
 }

--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -71,7 +71,7 @@ export async function removeLinkedApplication ({ appId, alias }) {
 
 export function findApp (config, alias) {
   if (_.isEmpty(config.apps)) {
-    throw new Error('There are no applications linked. You can add one with `clever link`');
+    throw new Error('There is no linked or targeted application. Use `--app` option or `clever link` command');
   }
 
   if (alias != null) {
@@ -102,7 +102,7 @@ export function checkAlreadyLinked (apps, name, alias) {
 
 function findDefaultApp (config) {
   if (_.isEmpty(config.apps)) {
-    throw new Error('There are no applications linked. You can add one with `clever link`');
+    throw new Error('There is no linked or targeted application. Use `--app` option or `clever link` command');
   }
 
   if (config.default != null) {
@@ -125,7 +125,7 @@ async function getAppDetailsForId (appId) {
   const config = await loadApplicationConf();
 
   if (_.isEmpty(config.apps)) {
-    throw new Error('There are no applications linked. You can add one with `clever link`');
+    throw new Error('There is no linked or targeted application. Use `--app` option or `clever link` command');
   }
 
   const [appById, secondAppById] = _.filter(config.apps, { app_id: appId });

--- a/src/models/node-dns-resolver.js
+++ b/src/models/node-dns-resolver.js
@@ -1,0 +1,43 @@
+import { Resolver } from 'node:dns/promises';
+
+export class DnsResolver {
+  constructor () {
+    this._resolver = new Resolver();
+  }
+
+  /**
+   * Resolves A records for the given hostname.
+   *
+   * @async
+   * @param {string} hostname - The hostname to resolve A records for.
+   * @returns {Promise<string[]>} A promise that resolves to an array of IP addresses, or an empty array if not found or an error occurs.
+   */
+  resolveA (hostname) {
+    return this._resolver.resolve4(hostname).catch((error) => {
+      switch (error.code) {
+        case 'ENOTFOUND':
+        case 'ENODATA':
+          return [];
+      }
+      throw new Error(`Could not resolve DNS for ${hostname}. Caused by: ${error.message}`);
+    });
+  }
+
+  /**
+   * Resolves CNAME records for the given hostname.
+   *
+   * @async
+   * @param {string} hostname - The hostname to resolve CNAME records for.
+   * @returns {Promise<string|null>} A promise that resolves to the CNAME record if found, or null if not found or an error occurs.
+   */
+  resolveCname (hostname) {
+    return this._resolver.resolveCname(hostname).catch((error) => {
+      switch (error.code) {
+        case 'ENOTFOUND':
+        case 'ENODATA':
+          return null;
+      }
+      throw new Error(`Could not resolve DNS for ${hostname}. Caused by: ${error.message}`);
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Adds a `clever domain diag [--app {appId|appName}] [--domain {string}] [-F json]` command,
- This command allows users to get diagnostics about DNS configs for every domain associated to a given app,

Some important context:

- we throw errors and tell users their DNS config is wrong when:
  - no config was found (no CNAME / no A records),
  - the config contains at least one unknown record (a record that does not match the default Load Balancer config of the app).
- APEX domains can only be configured with A records so diagnostics for such domains will never mention CNAME records,
- we don't support configs relying on a CDN (like Cloudflare for instance) and we don't support private Load Balancers for now (no API).

## How to review?

- You should probably review the PR from the client first: https://github.com/CleverCloud/clever-client.js/pull/116
- Check the last commit, ignore the `chore` commit (this part should be reviewed within the client project),
- Play with the command :+1:
`clever domain diag [--app {appId|appName}] [--domain {string}] [-F json]` 

## TODO

- [x] rebase on big rework once it's merged on master
- [x] replace local client with new published version once it's released