### PR TITLE
feat(addon): add URL to use/manage add-on at creation

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -101,6 +101,21 @@ export async function create (params) {
 
 function displayAddon (format, addon, providerName, message) {
 
+  const PROVIDERS_WITH_URL = {
+    keycloak: {
+      name: 'Keycloak',
+      urlEnv: 'CC_KEYCLOAK_URL',
+    },
+    'addon-matomo': {
+      name: 'Matomo',
+      urlEnv: 'MATOMO_URL',
+    },
+    metabase: {
+      name: 'Metabase',
+      urlEnv: 'METABASE_URL',
+    },
+  };
+
   const WIP_PROVIDERS = {
     keycloak: {
       status: 'beta',
@@ -158,6 +173,7 @@ function displayAddon (format, addon, providerName, message) {
         id: addon.id,
         realId: addon.realId,
         name: addon.name,
+        env: addon.env,
       };
 
       Logger.printJson((WIP_PROVIDERS[providerName] != null)
@@ -174,6 +190,19 @@ function displayAddon (format, addon, providerName, message) {
         `Real ID: ${addon.realId}`,
         `Name: ${addon.name}`,
       ].join('\n'));
+
+      if (providerName in PROVIDERS_WITH_URL) {
+        const provider = PROVIDERS_WITH_URL[providerName];
+        const urlEnv = addon.env.find((entry) => entry.name === provider.urlEnv);
+        const urlToShow = urlEnv.value;
+
+        if (urlEnv) {
+          Logger.println();
+          Logger.println(`Your ${provider.name} is starting:`);
+          Logger.println(` - Access it: ${urlToShow.startsWith('http') ? urlToShow : `https://${urlToShow}`}`);
+          Logger.println(` - Manage it: https://console.clever-cloud.com/${addon.id}`);
+        }
+      }
 
       if (providerName in WIP_PROVIDERS) {
 

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -1,7 +1,7 @@
 import * as application from '@clevercloud/client/esm/api/v2/application.js';
 import cliparse from 'cliparse';
 
-import { get as getAddon, getAll as getAllAddons, remove as removeAddon, create as createAddon, update as updateAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+import { get as getAddon, getAll as getAllAddons, getAllEnvVars, remove as removeAddon, create as createAddon, update as updateAddon } from '@clevercloud/client/esm/api/v2/addon.js';
 import { getAllAddonProviders } from '@clevercloud/client/esm/api/v2/product.js';
 import { getSummary } from '@clevercloud/client/esm/api/v2/user.js';
 import { getAddonProvider } from '@clevercloud/client/esm/api/v4/addon-providers.js';
@@ -161,7 +161,10 @@ export async function create ({ ownerId, name, providerName, planName, region, s
     options: createOptions,
   };
 
-  return createAddon({ id: ownerId }, addonToCreate).then(sendToApi);
+  const createdAddon = await createAddon({ id: ownerId }, addonToCreate).then(sendToApi);
+  createdAddon.env = await getAllEnvVars({ id: ownerId, addonId: createdAddon.id }).then(sendToApi);
+
+  return createdAddon;
 }
 
 async function getByName (ownerId, addonNameOrRealId) {


### PR DESCRIPTION
For add-ons with a public management URL, we tell the user what the URL is at creation, to ease onboarding. For that I added add-on env to returned object after creation (we'll move this to API side in a future iteration). 

I've only done this for KC, Matomo, Metabase for now, but we'll can go further for other add-ons too. This commit was based on refactor branch