### PR TITLE
fix(domain): add missing spacing within diag report

### DIFF
--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -337,7 +337,7 @@ function reportDomainDiagnostics ({ hostname, pathPrefix, resolvedDnsConfig, dia
 
     unknownDiags.forEach((diag) => {
       const source = hasCnameRecord ? `(from CNAME ${resolvedDnsConfig.cnameRecords[0]}.)` : '';
-      printlnWithIndent(diag.record.value + source, 6);
+      printlnWithIndent(`${diag.record.value} ${source}`, 6);
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

- Adds a missing space between the record and the text "from (...)" when there are invalid A records coming from a CNAME

In prod:
![image](https://github.com/user-attachments/assets/4186caa1-bd1f-4cfa-8df3-c27d6e8ff907)

With the fix:
![image](https://github.com/user-attachments/assets/1791a3e5-ce73-4463-b449-bafa98cec367)
