### PR TITLE
feat(profile): open in the Console

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -765,7 +765,7 @@ async function run () {
 
   // OPEN COMMAND
   const openCommand = cliparse.command('open', {
-    description: 'Open an application in your browser',
+    description: 'Open an application in the Console',
     options: [opts.alias, opts.appIdOrName],
   }, open.open);
 
@@ -776,9 +776,13 @@ async function run () {
   }, consoleModule.openConsole);
 
   // PROFILE COMMAND
+  const profileOpenCommand = cliparse.command('open', {
+    description: 'Open your profile in the Console',
+  }, profile.openProfile);
   const profileCommand = cliparse.command('profile', {
     description: 'Display the profile of the current user',
     options: [opts.humanJsonOutputFormat],
+    commands: [profileOpenCommand],
   }, profile.profile);
 
   // PUBLISHED CONFIG COMMANDS

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -1,5 +1,5 @@
 import colors from 'colors/safe.js';
-
+import openPage from 'open';
 import { Logger } from '../logger.js';
 import * as User from '../models/user.js';
 
@@ -46,3 +46,9 @@ export async function profile (params) {
     }
   }
 };
+
+export async function openProfile () {
+  const URL = 'https://console.clever-cloud.com/users/me/information';
+  Logger.debug('Opening the profile page in your browser');
+  await openPage(URL, { wait: false });
+}


### PR DESCRIPTION
This PR allow an user to open his user profile in the console with the command `clever profile open`. I also make texts the same for such commands.