### PR TITLE
refactor: reorganize config variables and declare new ones for common URLs

### DIFF
--- a/src/commands/addon.js
+++ b/src/commands/addon.js
@@ -11,6 +11,7 @@ import { getAllEnvVars } from '@clevercloud/client/esm/api/v2/addon.js';
 import { sendToApi } from '../models/send-to-api.js';
 import { toNameEqualsValueString } from '@clevercloud/client/esm/utils/env-vars.js';
 import { resolveAddonId } from '../models/ids-resolver.js';
+import { conf } from '../models/configuration.js';
 
 const formatTable = initFormatTable();
 
@@ -124,7 +125,7 @@ function displayAddon (format, addon, providerName, message) {
     keycloak: {
       status: 'beta',
       postCreateInstructions: [
-        'Learn more about Keycloak on Clever Cloud: https://developers.clever-cloud.com/doc/addons/keycloak/',
+        `Learn more about Keycloak on Clever Cloud: ${conf.DOC_URL}/addons/keycloak/`,
       ].join('\n'),
     },
     kv: {
@@ -133,19 +134,19 @@ function displayAddon (format, addon, providerName, message) {
         colors.yellow('You can easily use Materia KV with \'redis-cli\', with such commands:'),
         colors.blue(`source <(clever addon env ${addon.id} -F shell)`),
         colors.blue('redis-cli -h $KV_HOST -p $KV_PORT --tls'),
-        'Learn more about Materia KV on Clever Cloud: https://developers.clever-cloud.com/doc/addons/materia-kv/',
+        `Learn more about Materia KV on Clever Cloud: ${conf.DOC_URL}/addons/materia-kv/`,
       ].join('\n'),
     },
     'addon-matomo': {
       status: 'beta',
       postCreateInstructions: [
-        'Learn more about Matomo on Clever Cloud: https://developers.clever-cloud.com/doc/addons/matomo/',
+        `Learn more about Matomo on Clever Cloud: ${conf.DOC_URL}/addons/matomo/`,
       ].join('\n'),
     },
     metabase: {
       status: 'beta',
       postCreateInstructions: [
-        'Learn more about Metabase on Clever Cloud: https://developers.clever-cloud.com/doc/addons/metabase/',
+        `Learn more about Metabase on Clever Cloud: ${conf.DOC_URL}/addons/metabase/`,
       ].join('\n'),
     },
     otoroshi: {
@@ -157,7 +158,7 @@ function displayAddon (format, addon, providerName, message) {
     'addon-pulsar': {
       status: 'beta',
       postCreateInstructions: [
-        'Learn more about Pulsar on Clever Cloud: https://developers.clever-cloud.com/doc/addons/pulsar/',
+        `Learn more about Pulsar on Clever Cloud: ${conf.DOC_URL}/addons/pulsar/`,
       ].join('\n'),
     },
   };
@@ -210,7 +211,7 @@ function displayAddon (format, addon, providerName, message) {
           Logger.println();
           Logger.println(`Your ${provider.name} is starting:`);
           Logger.println(` - Access it: ${urlToShow.startsWith('http') ? urlToShow : `https://${urlToShow}`}`);
-          Logger.println(` - Manage it: https://console.clever-cloud.com/goto/${addon.id}`);
+          Logger.println(` - Manage it: ${conf.GOTO_URL}/${addon.id}`);
         }
 
         if (providerName === 'keycloak') {

--- a/src/commands/console.js
+++ b/src/commands/console.js
@@ -2,23 +2,22 @@ import * as Application from '../models/application.js';
 import * as AppConfig from '../models/app_configuration.js';
 import { Logger } from '../logger.js';
 import openPage from 'open';
+import { conf } from '../models/configuration.js';
 
 export async function openConsole (params) {
   const { alias, app: appIdOrName } = params.options;
-
-  const baseUrl = 'https://console.clever-cloud.com';
 
   const { apps } = await AppConfig.loadApplicationConf();
   // If no app is linked or asked, open the Console without any context
   if (apps.length === 0 && !appIdOrName) {
     Logger.println('Opening the Console in your browser');
-    await openPage(baseUrl, { wait: false });
+    await openPage(conf.CONSOLE_URL, { wait: false });
     return;
   }
 
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const prefixPath = (ownerId.startsWith('user_')) ? 'users/me' : `organisations/${ownerId}`;
-  const url = `${baseUrl}/${prefixPath}/applications/${appId}`;
+  const url = `${conf.CONSOLE_URL}/${prefixPath}/applications/${appId}`;
 
   Logger.debug(`URL: ${url}`);
   Logger.println(`Opening the Console in your browser for application ${appId}`);

--- a/src/commands/curl.js
+++ b/src/commands/curl.js
@@ -16,11 +16,11 @@ async function loadTokens () {
 }
 
 function printCleverCurlHelp () {
-  const apiDocUrlv2 = 'https://developers.clever-cloud.com/api/v2/';
-  const apiDocUrlv4 = 'https://developers.clever-cloud.com/api/v4/';
+  const apiDocUrlv2 = `${conf.API_DOC_URL}/v2/`;
+  const apiDocUrlv4 = `${conf.API_DOC_URL}/v4/`;
 
   Logger.println(`Usage: clever curl
-Query Clever Cloud's API using Clever Tools credentials. For example: 
+Query Clever Cloud's API using Clever Tools credentials. For example:
 
   clever curl ${conf.API_HOST}/v2/self
   clever curl ${conf.API_HOST}/v2/summary
@@ -28,7 +28,7 @@ Query Clever Cloud's API using Clever Tools credentials. For example:
   clever curl ${conf.API_HOST}/v2/organisations/<ORGANISATION_ID>/applications | jq '.[].id'
   clever curl ${conf.API_HOST}/v4/billing/organisations/<ORGANISATION_ID>/<INVOICE_NUMBER>.pdf > invoice.pdf
 
-Our API documentation is available here : 
+Our API documentation is available here :
 
   ${apiDocUrlv2}
   ${apiDocUrlv4}`);

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -123,11 +123,6 @@ export async function setFeature (feature, value) {
 
 export const conf = env.getOrElseAll({
   API_HOST: 'https://api.clever-cloud.com',
-  // API_HOST: 'https://ccapi-preprod.cleverapps.io',
-  LOG_WS_URL: 'wss://api.clever-cloud.com/v2/logs/logs-socket/<%- appId %>?since=<%- timestamp %>',
-  LOG_HTTP_URL: 'https://api.clever-cloud.com/v2/logs/<%- appId %>',
-  EVENT_URL: 'wss://api.clever-cloud.com/v2/events/event-socket',
-  WARP_10_EXEC_URL: 'https://c1-warp10-clevercloud-customers.services.clever-cloud.com/api/v0/exec',
   // the disclosure of these tokens is not considered as a vulnerability. Do not report this to our security service.
   OAUTH_CONSUMER_KEY: 'T5nFjKeHH4AIlEveuGhB5S3xg8T19e',
   OAUTH_CONSUMER_SECRET: 'MgVMqTr6fWlf2M0tkC2MXOnhfqBWDT',
@@ -136,8 +131,6 @@ export const conf = env.getOrElseAll({
   CONFIGURATION_FILE: getConfigPath(CONFIG_FILES.MAIN),
   EXPERIMENTAL_FEATURES_FILE: getConfigPath(CONFIG_FILES.EXPERIMENTAL_FEATURES_FILE),
   CONSOLE_TOKEN_URL: 'https://console.clever-cloud.com/cli-oauth',
-  // CONSOLE_TOKEN_URL: 'https://next-console.cleverapps.io/cli-oauth',
 
-  CLEVER_CONFIGURATION_DIR: path.resolve('.', 'clevercloud'),
   APP_CONFIGURATION_FILE: path.resolve('.', '.clever.json'),
 });

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -133,5 +133,9 @@ export const conf = env.getOrElseAll({
   CONFIGURATION_FILE: getConfigPath(CONFIG_FILES.MAIN),
   EXPERIMENTAL_FEATURES_FILE: getConfigPath(CONFIG_FILES.EXPERIMENTAL_FEATURES_FILE),
 
+  API_DOC_URL: 'https://developers.clever-cloud.com/api',
+  DOC_URL: 'https://developers.clever-cloud.com/doc',
+  CONSOLE_URL: 'https://console.clever-cloud.com',
   CONSOLE_TOKEN_URL: 'https://console.clever-cloud.com/cli-oauth',
+  GOTO_URL: 'https://console.clever-cloud.com/goto',
 });

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -123,14 +123,15 @@ export async function setFeature (feature, value) {
 
 export const conf = env.getOrElseAll({
   API_HOST: 'https://api.clever-cloud.com',
+  SSH_GATEWAY: 'ssh@sshgateway-clevercloud-customers.services.clever-cloud.com',
+
   // the disclosure of these tokens is not considered as a vulnerability. Do not report this to our security service.
   OAUTH_CONSUMER_KEY: 'T5nFjKeHH4AIlEveuGhB5S3xg8T19e',
   OAUTH_CONSUMER_SECRET: 'MgVMqTr6fWlf2M0tkC2MXOnhfqBWDT',
-  SSH_GATEWAY: 'ssh@sshgateway-clevercloud-customers.services.clever-cloud.com',
-
-  CONFIGURATION_FILE: getConfigPath(CONFIG_FILES.MAIN),
-  EXPERIMENTAL_FEATURES_FILE: getConfigPath(CONFIG_FILES.EXPERIMENTAL_FEATURES_FILE),
-  CONSOLE_TOKEN_URL: 'https://console.clever-cloud.com/cli-oauth',
 
   APP_CONFIGURATION_FILE: path.resolve('.', '.clever.json'),
+  CONFIGURATION_FILE: getConfigPath(CONFIG_FILES.MAIN),
+  EXPERIMENTAL_FEATURES_FILE: getConfigPath(CONFIG_FILES.EXPERIMENTAL_FEATURES_FILE),
+
+  CONSOLE_TOKEN_URL: 'https://console.clever-cloud.com/cli-oauth',
 });

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -1,7 +1,6 @@
 import { Logger } from '../logger.js';
 import { addOauthHeader } from '@clevercloud/client/esm/oauth.js';
-import { conf, loadOAuthConf } from '../models/configuration.js';
-import { execWarpscript } from '@clevercloud/client/esm/request-warp10.superagent.js';
+import { conf, loadOAuthConf } from './configuration.js';
 import { prefixUrl } from '@clevercloud/client/esm/prefix-url.js';
 import { request } from '@clevercloud/client/esm/request.fetch.js';
 import { subtle as cryptoSuble } from 'node:crypto';
@@ -45,12 +44,6 @@ export function processError (error) {
     throw new Error('The connection to the Clever Cloud API was closed abruptly, please try again.', { cause: error });
   }
   throw error;
-}
-
-export function sendToWarp10 (requestParams) {
-  return Promise.resolve(requestParams)
-    .then(prefixUrl(conf.WARP_10_EXEC_URL))
-    .then((requestParams) => execWarpscript(requestParams, { retry: 1 }));
 }
 
 export async function getHostAndTokens () {


### PR DESCRIPTION
As discussed previously, this PR defines a `const` with URLs we need in multiple parts of the CLI to define them once, use them when needed and make update easier. 