### PR TITLE
feat(addon): elastic plugins option support

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -342,6 +342,7 @@ function run () {
     }),
     addonOptions: cliparse.option('option', {
       metavar: 'option',
+      parser: Parsers.addonOptions,
       description: 'Option to enable for the add-on. Multiple --option argument can be passed to enable multiple options',
     }),
     region: cliparse.option('region', {

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -274,10 +274,14 @@ export function parseAddonOptions (options) {
     return {};
   }
 
-  return options.split(',').reduce((options, option) => {
-    const [key, value] = option.split('=');
+  const pairs = options.split(/,(?=\w+=)/) || [];
+
+  return pairs.reduce((options, pair) => {
+    const [key, ...valueParts] = pair.split('=');
+    const value = valueParts.join('=');
+
     if (value == null) {
-      throw new Error("Options are malformed. Usage is '--option name=enabled|disabled|true|false'");
+      throw new Error("Options are malformed. Usage is '--option name=enabled|disabled|true|false|plugin1,plugin2'");
     }
 
     let formattedValue = value;

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -4,6 +4,17 @@ import * as Application from './models/application.js';
 import ISO8601 from 'iso8601-duration';
 import Duration from 'duration-js';
 
+const addonOptionsRegex = /^\w+=.+$/;
+
+export function addonOptions (options) {
+  for (const option of options) {
+    if (!option.match(addonOptionsRegex)) {
+      return cliparse.parsers.error('Invalid option: ' + option);
+    }
+  }
+  return cliparse.parsers.success(options.join(','));
+}
+
 export function flavor (flavor) {
   const flavors = Application.listAvailableFlavors();
   if (flavors.includes(flavor)) {


### PR DESCRIPTION
This PR allows the support of elastic plug-ins at creation in Clever Tools. As this option is a comma-separated list, I separate options from pairs, looking for a `,` followed by a word and a `=` and matching it. 

It also adds a parser to add-ons options. It will help us to clean all this in a future release. Here I stay minimal on change to lower impact. 

I've tested it with multiple options, single options, comma-separated options, no options, and it seems working fine.