### PR TITLE
fix(addon): error with options parsing

### DIFF
--- a/src/parsers.js
+++ b/src/parsers.js
@@ -4,15 +4,16 @@ import * as Application from './models/application.js';
 import ISO8601 from 'iso8601-duration';
 import Duration from 'duration-js';
 
-const addonOptionsRegex = /^\w+=.+$/;
+const addonOptionsRegex = /^[\w-]+=.+$/;
 
 export function addonOptions (options) {
-  for (const option of options) {
+  const optionsArray = typeof options === 'string' ? [options] : options;
+  for (const option of optionsArray) {
     if (!option.match(addonOptionsRegex)) {
       return cliparse.parsers.error('Invalid option: ' + option);
     }
   }
-  return cliparse.parsers.success(options.join(','));
+  return cliparse.parsers.success(optionsArray.join(','));
 }
 
 export function flavor (flavor) {


### PR DESCRIPTION
This PR: 
- Manage options name with `-` in the option parser
- Single option case (then options is a string, checked as an array of char)

This should fix #855 @francoisfreitag can you confirm?