### PR TITLE
docs(setup-systems): add nix stable channel

### DIFF
--- a/docs/setup-systems.md
+++ b/docs/setup-systems.md
@@ -148,4 +148,4 @@ COPY --from=clevercloud/clever-tools /bin/clever /usr/local/bin/clever
 
 ## Nix package manager
 
-If you are using Nix on NixOS or any other compatible system, the package is available in `unstable` channel. Follow [these instructions](https://search.nixos.org/packages?channel=unstable&show=clever-tools&from=0&size=50&sort=relevance&type=packages&query=clever-tools).
+If you are using Nix on NixOS or any other compatible system, the package is available in both `stable` and `unstable` channels. Follow [these instructions](https://search.nixos.org/packages?channel=unstable&show=clever-tools&from=0&size=50&sort=relevance&type=packages&query=clever-tools).


### PR DESCRIPTION
Fixes #788

## What does this PR do?

- Updates setup instructions now that `clever-tools` is part of the stable branch (`24.11` release).