### PR TITLE
fix(rollup): prevent build failure on MacOS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,10 @@ export default defineConfig({
     format: 'cjs',
     sourcemap: 'inline',
   },
+  // This dependency is only pulled in when building on MacOS (see https://github.com/CleverCloud/clever-tools/issues/864)
+  // It's a binary file and it shouldn't be parsed by rollup, only copied.
+  // We exclude it from the bundle because it's a dependency that is pulled by `curlconverter` but we don't actually need it.
+  external: ['fsevents'],
   plugins: [
     {
       transform (code, id) {


### PR DESCRIPTION
Fixes #864

## What does this PR do?

- Fixes the `npm run build` command on MacOS.

The rollup build fails because:
- the whole `curlconverter` module is imported,
- the `curlconverter` codebase relies on `nunjucks` to handle `ansible`, `yaml`, etc. but not `JSON` (and I believe that's the only one we actually use),
- `nunjucks` relies on `chokidar`,
- when building on MacOS, `chokidar` relies on the `fsevents` package which is essentially a binary file (`fsevents.node`) built specifically for `darwin` :skull: ,
- our rollup build tries to parse the binary code from `fsevent.node`,
- it fails and crashes.

This is why this PR excludes `fsevents` from the bundle.
We could exclude nunjucks or chokidar but I went for the safest solution because I don't know much about nunjucks or chokidar (although chokidar is meant to watch files so I don't see why we would need that in the bundle).

As explained in the issue, we could also create a plugin to handle `fsevents` properly but since we don't actually need this dependency, I don't think it's a good idea to go there.

## How to test?

- If you're on MacOS, run `npm run build`, it should work (and it shouldn't work on master),
- If you're on MacOS, test the `node build/clever.cjs curl` command (I don't see any other potential impact).