### PR TITLE
docs(setup-systems): remove `Chocolatey` from Windows setup options

### DIFF
--- a/docs/setup-systems.md
+++ b/docs/setup-systems.md
@@ -112,8 +112,11 @@ If you use Windows and you have [Chocolatey](https://chocolatey.org) installed, 
 
 ```
 choco sources add -n=clevercloud -s='https://nexus.clever-cloud.com/repository/nupkg/'
+choco feature disable --name='usePackageRepositoryOptimizations'
 choco install clever-tools
 ```
+
+We need to disable `usePackageRepositoryOptimizations` feature because of [an incompatibility](https://github.com/chocolatey/choco/issues/3506) between Chocolatey and Nexus.
 
 ### Binary (.zip)
 


### PR DESCRIPTION
Fixes #869

## What does this PR do?

- Removes `Chocolatey` from Windows setup options

The [`chocolatey` package](https://community.chocolatey.org/packages/clever-tools) is outdated (`0.10.1` from 2018). 
We need to discuss if we want to maintain it there but in the meantime it would be better to simply remove this option from the setup docs.