### PR TITLE
feat: add ssh-keys command

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -55,6 +55,7 @@ import * as restart from '../src/commands/restart.js';
 import * as scale from '../src/commands/scale.js';
 import * as service from '../src/commands/service.js';
 import * as ssh from '../src/commands/ssh.js';
+import * as sshKeys from '../src/commands/ssh-keys.js';
 import * as status from '../src/commands/status.js';
 import * as stop from '../src/commands/stop.js';
 import * as tcpRedirs from '../src/commands/tcp-redirs.js';
@@ -134,6 +135,8 @@ async function run () {
       description: 'Email address',
       parser: Parsers.email,
     }),
+    sshKeyName: cliparse.argument('ssh-key-name', { description: 'SSH key name' }),
+    sshKeyPath: cliparse.argument('ssh-key-path', { description: 'SSH public key path (.pub)' }),
     addonIdOrName: cliparse.argument('addon-id', {
       description: 'Add-on ID (or name, if unambiguous)',
       parser: Parsers.addonIdOrName,
@@ -512,6 +515,10 @@ async function run () {
     confirmApplicationDeletion: cliparse.flag('yes', {
       aliases: ['y'],
       description: 'Skip confirmation and delete the application directly',
+    }),
+    confirmSshKeyClean: cliparse.flag('yes', {
+      aliases: ['y'],
+      description: 'Skip confirmation and remove all SSH keys directly',
     }),
     confirmTcpRedirCreation: cliparse.flag('yes', {
       aliases: ['y'],
@@ -996,6 +1003,27 @@ async function run () {
     options: [opts.alias, opts.appIdOrName, opts.sshIdentityFile],
   }, ssh.ssh);
 
+  // SSH KEYS COMMANDS
+  const sshKeysAddCommand = cliparse.command('add', {
+    description: 'Add a new SSH key to the current user',
+    args: [args.sshKeyName, args.sshKeyPath],
+  }, sshKeys.add);
+  const sshKeysRemoveCommand = cliparse.command('remove', {
+    description: 'Remove a SSH key from the current user',
+    args: [args.sshKeyName],
+  }, sshKeys.remove);
+  const sshKeysRemoveAllCommand = cliparse.command('remove-all', {
+    description: 'Remove all SSH keys from the current user',
+    options: [opts.confirmSshKeyClean],
+  }, sshKeys.removeAll);
+  const sshKeysOpenConsoleCommand = cliparse.command('open', {
+    description: 'Open the SSH keys management page in the Console',
+  }, sshKeys.openConsole);
+  const sshKeysCommands = cliparse.command('ssh-keys', {
+    description: 'Manage SSH keys of the current user',
+    commands: [sshKeysAddCommand, sshKeysRemoveCommand, sshKeysRemoveAllCommand, sshKeysOpenConsoleCommand],
+  }, sshKeys.list);
+
   // STATUS COMMAND
   const statusCommand = cliparse.command('status', {
     description: 'See the status of an application',
@@ -1134,6 +1162,7 @@ async function run () {
     scaleCommand,
     serviceCommands,
     sshCommand,
+    sshKeysCommands,
     statusCommand,
     stopCommand,
     tcpRedirsCommands,

--- a/src/commands/ssh-keys.js
+++ b/src/commands/ssh-keys.js
@@ -1,0 +1,159 @@
+import { confirm } from '../models/interact.js';
+import colors from 'colors/safe.js';
+import { Logger } from '../logger.js';
+import fs from 'node:fs';
+import { sendToApi } from '../models/send-to-api.js';
+import { openBrowser } from '../models/utils.js';
+import dedent from 'dedent';
+import {
+  todo_addSshKey as addSshKey,
+  todo_getSshKeys as getSshKeys,
+  todo_removeSshKey as removeSshKey,
+} from '@clevercloud/client/esm/api/v2/user.js';
+
+/**
+ * List SSH keys of the current user
+ * @param {object} params The command parameters
+ * @param {string} params.options.format The output format
+ */
+export async function list (params) {
+  const { format } = params.options;
+
+  const keys = await getUserSshKeys();
+
+  switch (format) {
+    case 'json': {
+      Logger.printJson(keys);
+      break;
+    }
+    case 'human':
+    default: {
+      if (keys.length === 0) {
+        Logger.println(dedent`
+          ${colors.blue('🔐 No SSH keys')}
+          
+          To list the SSH keys on your local system, use the following command:
+          ${colors.grey('ssh-add -l -E sha256')}
+          
+          To create a new key pair, use the following command:
+          ${colors.grey('ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_clever -C "An optional comment"')}
+          
+          Then add the public key to your Clever Cloud account:
+          ${colors.grey('clever ssh-keys add myNewKey ~/.ssh/id_ed25519_clever.pub')}
+        `);
+        return;
+      }
+
+      Logger.println(`🔐 ${keys.length} SSH key(s):`);
+      keys.forEach((key) => {
+        Logger.println(` • ${colors.blue(key.name)}`, colors.grey(`(${key.fingerprint})`));
+      });
+    }
+  }
+}
+
+/**
+ * Add a SSH key to the current user
+ * @param {object} params The command parameters
+ * @param {Array<string>} params.args
+ */
+export async function add (params) {
+  const [keyName, filePath] = params.args;
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File ${filePath} does not exist`);
+  }
+
+  const pubKeyContent = fs.readFileSync(filePath, 'utf8').trim();
+  Logger.debug(`SSH key file content: ${pubKeyContent}`);
+
+  try {
+    await addSshKey({ key: encodeURIComponent(keyName) }, JSON.stringify(pubKeyContent)).then(sendToApi);
+  }
+  catch (e) {
+    console.log(e?.responseBody?.id);
+    if (e?.responseBody?.id === 505) {
+      throw new Error('This SSH key is not valid, please make sure you\'re pointing to the public key file');
+    }
+  }
+
+  Logger.printSuccess(`SSH key ${keyName} added successfully`);
+}
+
+/**
+ * Remove a SSH key from the current user
+ * @param {object} params The command parameters
+ * @param {Array<string>} params.args
+ */
+export async function remove (params) {
+  const [keyName] = params.args;
+
+  const keys = await getUserSshKeys();
+
+  if (keys.find((key) => key.name === keyName) == null) {
+    throw new Error(`SSH key ${colors.red(keyName)} not found`);
+  }
+
+  const keyNameEncoded = encodeURIComponent(keyName);
+  await removeSshKey({ key: keyNameEncoded }).then(sendToApi);
+
+  Logger.printSuccess(`SSH key ${keyName} removed successfully`);
+}
+
+/**
+ * Remove all SSH keys from the current user
+ * @param {object} params The command parameters
+ * @param {object} params.options The command options
+ * @param {boolean} params.options.yes The user confirmation
+ */
+export async function removeAll (params) {
+  if (!params.options.yes) {
+    await confirm(
+      'Are you sure you want to remove all your SSH keys? (y/n) ',
+      'No SSH keys removed',
+    );
+  }
+
+  const keys = await getUserSshKeys();
+
+  if (keys.length === 0) {
+    Logger.println('No SSH keys to remove');
+    return;
+  }
+
+  const results = await Promise.all(
+    keys.map((key) => {
+      const keyNameEncoded = encodeURIComponent(key.name);
+      return removeSshKey({ key: keyNameEncoded }).then(sendToApi)
+        .then(() => [true, key.name])
+        .catch(() => [false, key.name]);
+    }),
+  );
+
+  if (results.every(([isRemoved]) => isRemoved)) {
+    Logger.printSuccess('All SSH keys were removed successfully');
+  }
+  else {
+    const keyNamesWithErrors = results
+      .filter(([isRemoved]) => !isRemoved)
+      .map(([_, keyName]) => keyName)
+      .join(', ');
+    throw new Error(`Some errors occured while removing these SSH keys: ${keyNamesWithErrors}`);
+  }
+}
+
+/**
+ * Open the SSH keys management page of the Console in your browser
+ * @returns {Promise<void>} A promise that resolves when the page is opened
+ */
+export function openConsole () {
+  return openBrowser('/users/me/ssh-keys', 'Opening the SSH keys management page of the Console in your browser');
+}
+
+/**
+ * @return {Promise<Array<{ name: string, key: string, fingerprint: string }>>}
+ */
+async function getUserSshKeys () {
+  const rawKeys = await getSshKeys().then(sendToApi);
+  return rawKeys.sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
This PR adds a `ssh-keys` command, to add, remove(-all), list SSH keys from a user account and to open the SSH Keys panel from the Console. 

If no SSH keys are found, instructions to create one are printed.

## TODO

* [x] This PR is based on #874 (don't forget to merge it before this one)