### PR TITLE
feat: add emails command

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -36,6 +36,7 @@ import * as deploy from '../src/commands/deploy.js';
 import * as diag from '../src/commands/diag.js';
 import * as domain from '../src/commands/domain.js';
 import * as drain from '../src/commands/drain.js';
+import * as emails from '../src/commands/emails.js';
 import * as env from '../src/commands/env.js';
 import * as features from '../src/commands/features.js';
 import * as kv from '../src/commands/kv.js';
@@ -128,6 +129,10 @@ async function run () {
     wgPublicKey: cliparse.argument('public-key', {
       metavar: 'public_key',
       description: 'Wireguard public key of the external peer to link to a Network Group',
+    }),
+    email: cliparse.argument('email', {
+      description: 'Email address',
+      parser: Parsers.email,
     }),
     addonIdOrName: cliparse.argument('addon-id', {
       description: 'Add-on ID (or name, if unambiguous)',
@@ -512,6 +517,10 @@ async function run () {
       aliases: ['y'],
       description: 'Skip confirmation even if the TCP redirection is not free',
     }),
+    yes: cliparse.flag('yes', {
+      aliases: ['y'],
+      description: 'Skip confirmation',
+    }),
     jsonFormat: cliparse.flag('json', { aliases: ['j'], description: 'Show result in JSON format' }),
     humanJsonOutputFormat: getOutputFormatOption(),
     tag: cliparse.option('tag', {
@@ -727,6 +736,31 @@ async function run () {
     privateOptions: [opts.humanJsonOutputFormat],
     commands: [drainCreateCommand, drainRemoveCommand, drainEnableCommand, drainDisableCommand],
   }, drain.list);
+
+  // EMAILS COMMANDS
+  const emailsAddCommand = cliparse.command('add', {
+    description: 'Add a new secondary email address to the current user',
+    args: [args.email],
+  }, emails.addSecondary);
+  const emailsPrimaryCommand = cliparse.command('primary', {
+    description: 'Set the primary email address of the current user',
+    args: [args.email],
+  }, emails.setPrimary);
+  const emailsRemoveCommand = cliparse.command('remove', {
+    description: 'Remove a secondary email address from the current user',
+    args: [args.email],
+  }, emails.removeSecondary);
+  const emailsClearCommand = cliparse.command('remove-all', {
+    description: 'Remove all secondary email addresses from the current user',
+    options: [opts.yes],
+  }, emails.removeAllSecondary);
+  const emailsOpenConsoleCommand = cliparse.command('open', {
+    description: 'Open the email addresses management page in the Console',
+  }, emails.openConsole);
+  const emailsCommands = cliparse.command('emails', {
+    description: 'Manage email addresses of the current user',
+    commands: [emailsAddCommand, emailsPrimaryCommand, emailsRemoveCommand, emailsClearCommand, emailsOpenConsoleCommand],
+  }, emails.list);
 
   // ENV COMMANDS
   const envSetCommand = cliparse.command('set', {
@@ -1084,6 +1118,7 @@ async function run () {
     domainCommands,
     drainCommands,
     emailNotificationsCommand,
+    emailsCommands,
     envCommands,
     featuresCommands,
     cliparseCommands.helpCommand,

--- a/src/commands/console.js
+++ b/src/commands/console.js
@@ -1,8 +1,6 @@
 import * as Application from '../models/application.js';
 import * as AppConfig from '../models/app_configuration.js';
-import { Logger } from '../logger.js';
-import openPage from 'open';
-import { conf } from '../models/configuration.js';
+import { openBrowser } from '../models/utils.js';
 
 export async function openConsole (params) {
   const { alias, app: appIdOrName } = params.options;
@@ -10,17 +8,13 @@ export async function openConsole (params) {
   const { apps } = await AppConfig.loadApplicationConf();
   // If no app is linked or asked, open the Console without any context
   if (apps.length === 0 && !appIdOrName) {
-    Logger.println('Opening the Console in your browser');
-    await openPage(conf.CONSOLE_URL, { wait: false });
+    await openBrowser('/', 'Opening the Console in your browser');
     return;
   }
 
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   const prefixPath = (ownerId.startsWith('user_')) ? 'users/me' : `organisations/${ownerId}`;
-  const url = `${conf.CONSOLE_URL}/${prefixPath}/applications/${appId}`;
+  const consolePath = `/${prefixPath}/applications/${appId}`;
 
-  Logger.debug(`URL: ${url}`);
-  Logger.println(`Opening the Console in your browser for application ${appId}`);
-
-  await openPage(url, { wait: false });
+  await openBrowser(consolePath, `Opening the Console in your browser for application ${appId}`);
 }

--- a/src/commands/emails.js
+++ b/src/commands/emails.js
@@ -1,0 +1,174 @@
+import colors from 'colors/safe.js';
+import * as User from '../models/user.js';
+import { Logger } from '../logger.js';
+import { openBrowser } from '../models/utils.js';
+import { sendToApi } from '../models/send-to-api.js';
+import { confirm } from '../models/interact.js';
+import {
+  todo_addEmailAddress as addEmailAddress,
+  todo_getEmailAddresses as getEmailAddresses,
+  todo_removeEmailAddress as removeEmailAddress,
+} from '@clevercloud/client/esm/api/v2/user.js';
+
+/**
+ * Show primary and secondary email addresses of the current user
+ * @param {object} params The command parameters
+ * @param {string} params.options.format The output format
+ */
+export async function list (params) {
+  const { format } = params.options;
+  const addresses = await getUserEmailAddresses();
+
+  switch (format) {
+    case 'json': {
+      Logger.printJson(addresses);
+      break;
+    }
+    case 'human':
+    default: {
+      Logger.println('✉️  Primary email address:');
+      Logger.println(` • ${colors.green(addresses.primary)}`);
+      if (addresses.secondary.length > 0) {
+        Logger.println();
+        Logger.println(`✉️  ${addresses.secondary.length} secondary email address(es):`);
+        addresses.secondary.forEach((address) =>
+          Logger.println(` • ${colors.blue(address)}`),
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Add a secondary email address to the current user
+ * @param {object} params The command parameters
+ * @param {Array<string>} params.args
+ */
+export async function addSecondary (params) {
+  const [secondaryAddress] = params.args;
+
+  const secondaryAddressEncoded = encodeURIComponent(secondaryAddress);
+  try {
+    await addEmailAddress({ email: secondaryAddressEncoded }).then(sendToApi);
+    Logger.printSuccess(`The server sent a confirmation email to ${secondaryAddress} to validate your secondary address`);
+  }
+  catch (e) {
+    switch (e?.responseBody?.id) {
+      case 101:
+        throw new Error('This address already belongs to your account');
+      case 550:
+        throw new Error('The format of this address is invalid');
+      case 1004:
+        throw new Error('This address belongs to another account');
+      default:
+        throw e;
+    }
+  }
+}
+
+/**
+ * Set the primary email address of the current user
+ * @param {object} params The command parameters
+ * @param {Array<string>} params.args
+ */
+export async function setPrimary (params) {
+  const [newPrimaryAddress] = params.args;
+
+  const addresses = await getUserEmailAddresses();
+
+  if (addresses.primary === newPrimaryAddress) {
+    throw new Error('This address is already the primary one');
+  }
+
+  if (!addresses.secondary.includes(newPrimaryAddress)) {
+    throw new Error('This address must be added as a secondary address before marking it as primary');
+  }
+
+  const newPrimaryEmailEncoded = encodeURIComponent(newPrimaryAddress);
+  await addEmailAddress({ email: newPrimaryEmailEncoded }, { make_primary: true }).then(sendToApi);
+
+  Logger.printSuccess(`Primary address updated to ${newPrimaryAddress} successfully`);
+}
+
+/**
+ * Remove a secondary email address from the current user
+ * @param {object} params The command parameters
+ * @param {Array<string>} params.args
+ */
+export async function removeSecondary (params) {
+  const [addressToRemove] = params.args;
+
+  const addresses = await getUserEmailAddresses();
+
+  if (!addresses.secondary.includes(addressToRemove)) {
+    throw new Error('This address is not part of the secondary addresses of the current user, it can\'t be removed');
+  }
+
+  const addressToRemoveEncoded = encodeURIComponent(addressToRemove);
+  await removeEmailAddress({ email: addressToRemoveEncoded }).then(sendToApi);
+
+  Logger.printSuccess(`Secondary address ${addressToRemove} removed successfully`);
+}
+
+/**
+ * Remove all secondary email addresses from the current user
+ * @param {object} params The command parameters
+ * @param {object} params.options The command options
+ * @param {boolean} params.options.yes The user confirmation
+ */
+export async function removeAllSecondary (params) {
+  if (!params.options.yes) {
+    await confirm(
+      'Are you sure you want to remove all your secondary addresses? (y/n) ',
+      'No secondary addresses removed',
+    );
+  }
+
+  const addresses = await getUserEmailAddresses();
+
+  if (addresses.secondary.length === 0) {
+    Logger.println('No secondary address to remove');
+    return;
+  }
+
+  const results = await Promise.all(
+    addresses.secondary.map((addressToRemove) => {
+      const addressToRemoveEncoded = encodeURIComponent(addressToRemove);
+      return removeEmailAddress({ email: addressToRemoveEncoded }).then(sendToApi)
+        .then(() => [true, addressToRemove])
+        .catch(() => [false, addressToRemove]);
+    }),
+  );
+
+  if (results.every(([isRemoved]) => isRemoved)) {
+    Logger.printSuccess('All secondary addresses were removed successfully');
+  }
+  else {
+    const addressesWithErrors = results
+      .filter(([isRemoved]) => !isRemoved)
+      .map(([_, address]) => address)
+      .join(', ');
+    throw new Error(`Some errors occured while removing these addresses: ${addressesWithErrors}`);
+  }
+}
+
+/**
+ * Open the email addresses management page of the Console in your browser
+ * @returns {Promise<void>} A promise that resolves when the page is opened
+ */
+export function openConsole () {
+  return openBrowser('/users/me/emails', 'Opening the email addresses management page of the Console in your browser');
+}
+
+/**
+ * Get the primary and secondary email addresses of the current user
+ * @returns {Promise<{ primary: string, secondary: string[] }>} The primary and secondary email addresses of the current user
+ */
+async function getUserEmailAddresses () {
+  const currentUser = await User.getCurrent();
+  const secondaryAddresses = await getEmailAddresses().then(sendToApi);
+  return {
+    primary: currentUser.email,
+    secondary: secondaryAddresses.sort(),
+  };
+}

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,8 +1,6 @@
-import openPage from 'open';
-
 import * as Application from '../models/application.js';
 import * as Domain from '../models/domain.js';
-import { Logger } from '../logger.js';
+import { openBrowser } from '../models/utils.js';
 
 export async function open (params) {
   const { alias, app: appIdOrName } = params.options;
@@ -11,6 +9,5 @@ export async function open (params) {
   const vhost = await Domain.getBest(appId, ownerId);
   const url = 'https://' + vhost.fqdn;
 
-  Logger.println('Opening the application in your browser');
-  await openPage(url, { wait: false });
+  await openBrowser(url, 'Opening the application in your browser');
 }

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -1,5 +1,5 @@
 import colors from 'colors/safe.js';
-import openPage from 'open';
+import { openBrowser } from '../models/utils.js';
 import { Logger } from '../logger.js';
 import * as User from '../models/user.js';
 import dedent from 'dedent';
@@ -51,7 +51,5 @@ export async function profile (params) {
 };
 
 export async function openProfile () {
-  const URL = 'https://console.clever-cloud.com/users/me/information';
-  Logger.debug('Opening the profile page in your browser');
-  await openPage(URL, { wait: false });
+  await openBrowser('/users/me/information', 'Opening the profile page in your browser');
 }

--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -1,3 +1,7 @@
+import { Logger } from '../logger.js';
+import { conf } from './configuration.js';
+import openPage from 'open';
+
 // Inspirations:
 // https://github.com/sindresorhus/p-defer/blob/master/index.js
 // https://github.com/ljharb/promise-deferred/blob/master/index.js
@@ -11,6 +15,23 @@ export class Deferred {
       this.reject = reject;
     });
   }
+}
+
+/**
+ * Open an absolute URL or a console path in the default browser
+ * @param {string} urlOrPath The URL to open
+ * @param {string} message The message to display before opening the URL
+ * @returns {Promise<void>} A promise that resolves when the URL is opened
+ */
+export function openBrowser (urlOrPath, message) {
+  const url = urlOrPath.startsWith('/')
+    ? `${conf.CONSOLE_URL}${urlOrPath}`
+    : urlOrPath;
+
+  Logger.debug(`Opening URL "${url}" in browser`);
+  Logger.println(message);
+
+  return openPage(url, { wait: false });
 }
 
 export function truncateWithEllipsis (length, string) {

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -69,6 +69,16 @@ export function futureDateOrDuration (dateString) {
   return duration;
 }
 
+// This simple regex is enough for our use cases
+const emailRegex = /^\S+@\S+\.\S+$/g;
+
+export function email (string) {
+  if (string.match(emailRegex)) {
+    return cliparse.parsers.success(string);
+  }
+  return cliparse.parsers.error('Invalid email');
+}
+
 const appIdRegex = /^app_[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function appIdOrName (string) {


### PR DESCRIPTION
This PR adds an `emails` commands to add, remove(-all) secondary emails to a user account, set the primary email, list emails, and open the emails management page in the Console. 

I've added an email parser to validate emails. It uses a simple regex to avoid corner cases. There is another proposition in comment, chose the one you prefer. 

This PR includes a new utils to open a browser page.