### PR TITLE
Fix error on doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ clever login --secret SECRET --token TOKEN
 ```
 
 > [!TIP]
-> If environment variables `CC_SECRET` and `CC_TOKEN` are set, Clever Tools will use them, `login` is not needed.
+> If environment variables `CLEVER_SECRET` and `CLEVER_TOKEN` are set, Clever Tools will use them, `login` is not needed.
 
 To log out, delete this file or use:
 


### PR DESCRIPTION
I use version 3.11.0 on mac OS I try to follow the doc but env var are not working.

If I use 
- CC_TOKEN -> CLEVER_TOKEN
- CC_SECRET -> CLEVER_SECRET

Everything is ok ;)