### PR TITLE
fix(domains/overview): Avoid throwing an error if the user is not allowed to view application domains (accountants for instance)

### DIFF
--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -182,7 +182,16 @@ export async function overview (params) {
 
   const applicationsWithDomains = await Promise.all(
     applications.map(async (app) => {
-      const domains = await getAllDomains({ id: app.ownerId, appId: app.id }).then(sendToApi);
+      const domains = await getAllDomains({ id: app.ownerId, appId: app.id })
+        .then(sendToApi)
+        .catch((error) => {
+          // if the user cannot access application domains, we simply act as if there were no domains
+          if (error?.response?.status === 403) {
+            Logger.printErrorLine(`You cannot list domains for application ${app.name} (${app.id})`);
+            return [];
+          }
+          throw error;
+        });
       return { app, domains };
     }),
   );


### PR DESCRIPTION
Fixes #881

## What does this PR do?

- Catches 403 errors when trying to list domains of an app.
- Returns an empty array in such cases (apps with no domains are filtered out from the command output).

Note that the Clever access management is weird: accountants may list applications but they cannot access info about them.
This is a quick and easy solution.

We could try and do better by printing messages for apps that users cannot access but this would require heavier refactoring and it's not a very interesting thing to do with the current Clever Cloud roles.
Only people with the Accountant role are really impacted by this and they are not really the audience of the CLI and this specific command.

## How to review?

- Set yourself as an "accountant" in one of your orgs,
- Try to run the `clever domain overview` with the prod CLI
  - You get an error,
- Try to run the same command with this branch / preview,
  - You see all apps you can access and no error :tada:  