### PR TITLE
fix: ignore org ID when using an app_id

### DIFF
--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -7,9 +7,11 @@ export async function link (params) {
 
   if (app.app_id != null && orgaIdOrName != null) {
     Logger.warn('You\'ve specified a unique application ID, organisation option will be ignored');
+    await Application.linkRepo(app, null, alias);
   }
-
-  await Application.linkRepo(app, orgaIdOrName, alias);
+  else {
+    await Application.linkRepo(app, orgaIdOrName, alias);
+  }
 
   Logger.println('Your application has been successfully linked!');
 }


### PR DESCRIPTION
Try to link an app with and app ID and an empty or (in)valid org. The user is warned the org is ignored as before, but it works even if the org doesn't exist. 

fixes #889 