### PR TITLE
feat(generate): generate terraform imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3562,7 +3562,6 @@
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -3994,7 +3993,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4865,7 +4863,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5335,7 +5332,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5704,7 +5700,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
       "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -8026,7 +8021,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8315,7 +8309,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8984,7 +8977,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9109,7 +9101,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -158,6 +158,8 @@ import { tcpRedirsAddCommand } from './tcp-redirs/tcp-redirs.add.command.js';
 import { tcpRedirsCommand } from './tcp-redirs/tcp-redirs.command.js';
 import { tcpRedirsListNamespacesCommand } from './tcp-redirs/tcp-redirs.list-namespaces.command.js';
 import { tcpRedirsRemoveCommand } from './tcp-redirs/tcp-redirs.remove.command.js';
+import { terraformCommand } from './terraform/terraform.command.js';
+import { terraformGenerateCommand } from './terraform/terraform.generate.command.js';
 import { tokensCommand } from './tokens/tokens.command.js';
 import { tokensCreateCommand } from './tokens/tokens.create.command.js';
 import { tokensRevokeCommand } from './tokens/tokens.revoke.command.js';
@@ -462,6 +464,12 @@ export const globalCommands = {
       add: tcpRedirsAddCommand,
       'list-namespaces': tcpRedirsListNamespacesCommand,
       remove: tcpRedirsRemoveCommand,
+    },
+  ],
+  terraform: [
+    terraformCommand,
+    {
+      generate: terraformGenerateCommand,
     },
   ],
   tokens: [

--- a/src/commands/terraform/terraform.command.js
+++ b/src/commands/terraform/terraform.command.js
@@ -1,0 +1,10 @@
+import { defineCommand } from '../../lib/define-command.js';
+
+export const terraformCommand = defineCommand({
+  description: 'Terraform commands',
+  since: '14.0.0',
+  options: {},
+  args: [],
+  // Parent command - no handler, only contains subcommands
+  handler: null,
+});

--- a/src/commands/terraform/terraform.generate.command.js
+++ b/src/commands/terraform/terraform.generate.command.js
@@ -1,0 +1,153 @@
+import { getSummary } from '@clevercloud/client/esm/api/v2/user.js';
+import dedent from 'dedent';
+import slugify from 'slugify';
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import { resolveId } from '../../models/application.js';
+import { getOrgaIdOrUserId } from '../../models/notification.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { tag } from '../../parsers.js';
+import { appIdOrNameOption, orgaIdOrNameOption } from '../global.options.js';
+import { defineOption } from '../../lib/define-option.js';
+
+// TODO: get supported addons/app from some Hashicorp registry api
+const SUPPORTED_ADDONS = ['addon', 'cellar', 'keycloak', 'materia_kv', 'metabase', 'mongodb', 'postgresql', 'redis'];
+const SUPPORTED_APPS = ['docker', 'go', 'java_war', 'nodejs', 'php', 'python', 'scala', 'static'];
+
+const tagOption = defineOption({
+  name: 'tag',
+  schema: z.string().transform(tag).optional(),
+  description: 'Filter resources by tag',
+  aliases: ['t'],
+  placeholder: 'tag',
+});
+
+export const terraformGenerateCommand = defineCommand({
+  description: 'Generate terraform import file',
+  since: '14.0.0',
+  options: {
+    org: orgaIdOrNameOption,
+    app: appIdOrNameOption,
+    tag: tagOption,
+  },
+  args: [],
+  async handler(options) {
+    const { org, app, tag: tagFilter } = options;
+    const ownerId = await getOrgaIdOrUserId(org);
+    const summary = await getSummary({ id: ownerId }).then(sendToApi);
+    const orga = summary.organisations.find((orga) => orga.id === ownerId);
+    if (!orga) {
+      throw new Error(`Could not find organisation with ID: ${ownerId}`);
+    }
+
+    let applications = orga.applications;
+    let addons = orga.addons;
+
+    if (app) {
+      const { appId } = await resolveId(app, null);
+      applications = applications.filter((app) => app.id === appId);
+      addons = [];
+    }
+
+    const appToImport = prepareApps(applications, tagFilter);
+    const addonToImport = prepareAddons(addons, tagFilter);
+    const out = appToImport
+      .concat(addonToImport)
+      .map((app) => {
+        return {
+          ...app,
+          name: slugify(app.name, { lower: true, strict: true, trim: true }),
+        };
+      })
+      .filter(({ name }) => {
+        if (name.match(/^\d.*/)) {
+          Logger.printErrorLine(`Skipping ${name}: name cannot starts with number`);
+          return false;
+        }
+        return true;
+      })
+      .map(({ name, resourceKind, id }) => {
+        return dedent`# ${name}
+        import {
+          to = clevercloud_${resourceKind}.${name}
+          id = "${id}"
+        }`;
+      })
+      .join('\n\n');
+
+    Logger.println(out);
+  },
+});
+
+function prepareApps(applications, tag = null) {
+  return applications
+    .map((app) => {
+      let instanceType = app.instanceType;
+      if (instanceType === 'node') {
+        instanceType = 'nodejs';
+      }
+      if (instanceType === 'java' && app.variantSlug === 'sbt') {
+        instanceType = 'scala';
+      }
+
+      return {
+        resourceKind: instanceType,
+        id: app.id,
+        name: app.name || app.id,
+        tags: app.systemTags.concat(app.customerTags),
+      };
+    })
+    .filter((app) => {
+      const supported = SUPPORTED_APPS.includes(app.resourceKind);
+      if (!supported) {
+        Logger.printErrorLine(`Skipping unsupported app: ${app.resourceKind}/${app.name}`);
+        return false;
+      }
+
+      if (tag && !app.tags.includes(tag)) {
+        return false;
+      }
+
+      return true;
+    });
+}
+
+function prepareAddons(addons, tag = null) {
+  return addons
+    .map((addon) => {
+      let providerId = addon.providerId;
+      if (providerId === 'kv') {
+        providerId = 'materia_kv';
+      }
+
+      let id = addon.realId;
+      if (addon.resourceKind === 'mongodb') {
+        id = addon.id;
+      }
+
+      return {
+        resourceKind: providerId.replaceAll('-addon', '').replaceAll('addon-', ''),
+        id,
+        name: addon.name || addon.realId,
+        tags: addon.systemTags.concat(addon.customerTags),
+      };
+    })
+    .filter((addon) => {
+      if (addon.name.startsWith('[SYSTEM]')) {
+        return false;
+      }
+
+      const supported = SUPPORTED_ADDONS.includes(addon.resourceKind);
+      if (!supported) {
+        Logger.printErrorLine(`Skipping unsupported addon: ${addon.resourceKind}/${addon.name}`);
+        return false;
+      }
+
+      if (tag && !addon.tags.includes(tag)) {
+        return false;
+      }
+
+      return true;
+    });
+}


### PR DESCRIPTION
 * install clever-tools from this PR
 * install TF
 * write provider.tf
 * run `terraform init`
 * run `clever-tools generate terraform -o orga_xxx > import.tf`
 * terraform plan -generate-config-out=generated.tf
 * generated.tf must have all your resources

provider.tf
```hcl
terraform {  
  required_providers {
    clevercloud = {
      source = "CleverCloud/clevercloud"
      version = "0.7.1"
    }
  }
}
 
provider "clevercloud" {
   # Configuration options
}

```


Some imports fails see https://github.com/CleverCloud/terraform-provider-clevercloud/issues/134