### PR TITLE
feat(tokens): add "state" in tokens list

### DIFF
--- a/src/commands/tokens.js
+++ b/src/commands/tokens.js
@@ -112,6 +112,7 @@ export async function list (params) {
           'Creation IP address': token.ip,
           Creation: formatDate(token.creationDate),
           Expiration: formatDate(token.expirationDate),
+          State: token.state,
         };
       }));
     }


### PR DESCRIPTION
This PR uses the latest update from the auth-backend: the `state` property for each token. Once an API token is expired, the associated OAuth tokens are revoked but the API token is still stored in the store so we can list it with a `EXPIRED` state.

This PR adds a `state` column in the `human` format of `clever tokens`.
FYI, the `json` format already displays the `state`.

Before:

```
┌─────────┬──────────────────────────────────────────────────┬────────┬─────────────────────┬────────────────────┬────────────────────┐
│ (index) │                   API token ID                   │  Name  │ Creation IP address │      Creation      │     Expiration     │
├─────────┼──────────────────────────────────────────────────┼────────┼─────────────────────┼────────────────────┼────────────────────┤
│    0    │ 'api_token_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' │ 'test' │  'aaa.bb.ccc.ddd'   │ '2025-05-21 14:37' │ '2026-05-21 14:37' │
└─────────┴──────────────────────────────────────────────────┴────────┴─────────────────────┴────────────────────┴────────────────────┘
```

After:

```
┌─────────┬──────────────────────────────────────────────────┬────────┬─────────────────────┬────────────────────┬────────────────────┬──────────┐
│ (index) │                   API token ID                   │  Name  │ Creation IP address │      Creation      │     Expiration     │  State   │
├─────────┼──────────────────────────────────────────────────┼────────┼─────────────────────┼────────────────────┼────────────────────┼──────────┤
│    0    │ 'api_token_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' │ 'test' │  'aaa.bb.ccc.ddd'   │ '2025-05-21 14:37' │ '2026-05-21 14:37' │ 'ACTIVE' │
└─────────┴──────────────────────────────────────────────────┴────────┴─────────────────────┴────────────────────┴────────────────────┴──────────┘
```