### PR TITLE
Add JSON format to emails/ssh-keys list command

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -766,6 +766,7 @@ async function run () {
   }, emails.openConsole);
   const emailsCommands = cliparse.command('emails', {
     description: 'Manage email addresses of the current user',
+    privateOptions: [opts.humanJsonOutputFormat],
     commands: [emailsAddCommand, emailsPrimaryCommand, emailsRemoveCommand, emailsClearCommand, emailsOpenConsoleCommand],
   }, emails.list);
 

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1022,6 +1022,7 @@ async function run () {
   }, sshKeys.openConsole);
   const sshKeysCommands = cliparse.command('ssh-keys', {
     description: 'Manage SSH keys of the current user',
+    privateOptions: [opts.humanJsonOutputFormat],
     commands: [sshKeysAddCommand, sshKeysRemoveCommand, sshKeysRemoveAllCommand, sshKeysOpenConsoleCommand],
   }, sshKeys.list);
 


### PR DESCRIPTION
As we removed the `list` command, we should add `format` as private option to `emails` and `ssh-keys` to be able to `clever emails -F json` or `clever ssh-keys --format json`