### PR TITLE
fix(service): only print linked add-ons if --show-all is not true

### DIFF
--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -1,3 +1,4 @@
+import colors from 'colors/safe.js';
 import * as Addon from '../models/addon.js';
 import * as Application from '../models/application.js';
 import { Logger } from '../logger.js';
@@ -38,14 +39,21 @@ export async function list (params) {
     }
     case 'human':
     default: {
-      if (formattedServices.applications) {
-        Logger.println('Applications:');
-        formattedServices.applications.forEach(({ isLinked, name }) => Logger.println(`${isLinked ? '*' : ' '} ${name}`));
+      const { applications = [], addons = [] } = formattedServices;
+
+      if (applications.length === 0 && addons.length === 0) {
+        Logger.printInfo(`No linked services found, use ${colors.bold.blue('clever service link-app')} or ${colors.bold.blue('clever service link-addon')} to link services to an application`);
+        return;
       }
 
-      if (formattedServices.addons) {
+      if (applications.length > 0) {
+        Logger.println('Applications:');
+        applications.forEach(({ isLinked, name }) => Logger.println(`${isLinked ? '*' : ' '} ${name}`));
+      }
+
+      if (addons.length > 0) {
         Logger.println('Addons:');
-        formattedServices.addons.forEach(({ isLinked, name, realId }) => Logger.println(`${isLinked ? '*' : ' '} ${name} (${realId})`));
+        addons.forEach(({ isLinked, name, realId }) => Logger.println(`${isLinked ? '*' : ' '} ${name} (${realId})`));
       }
     }
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -58,6 +58,9 @@ Logger.println = console.log;
 // Logger for success with a green check before the message
 Logger.printSuccess = (message) => console.log(`${colors.bold.green('✓')} ${message}`);
 
+// Logger for information with a blue 'i' before the message
+Logger.printInfo = (message) => console.log(`${colors.bold.blue('i')} ${message}`);
+
 // No decoration for Logger.println
 Logger.printJson = (obj) => {
   console.log(JSON.stringify(obj, null, 2));

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -43,9 +43,8 @@ export async function list (ownerId, appId, showAll) {
   }
 
   const myAddons = await getAllLinkedAddons({ id: ownerId, appId }).then(sendToApi);
-
-  if (showAll == null) {
-    return myAddons;
+  if (!showAll) {
+    return myAddons.map((addon) => ({ ...addon, isLinked: true }));
   }
 
   const myAddonIds = myAddons.map((addon) => addon.id);


### PR DESCRIPTION
Currently, `clever service` responds with linked apps but all add-ons (linked or not) by default. It should be linked apps and linked add-ons, except if `--show-all` is `true`.

This PR:
- returns only linked add-ons, except if `--show-all` is `true` (currently it's only if it's `null`)
- adds `isLinked: true` property to linked add-ons (to print the `*` in the human format list)

To reproduce, use `clever service --app app_id` with/without `--show-all` option

The modified function is only used by this `clever service` feature, so there won't be any other changes linked to this.

I've also added a clearer `human` message if nothing is found (which will now be the common case) with a `Logger.printInfo()` we could use in other commands later. 

Fixes #934 