### PR TITLE
feat: add 'clever-tools' as binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "Apache-2.0",
   "bin": {
     "clever": "bin/clever.js",
+    "clever-tools": "bin/clever.js",
     "install-clever-completion": "scripts/install-autocomplete.sh",
     "uninstall-clever-completion": "scripts/uninstall-autocomplete.sh"
   },


### PR DESCRIPTION
Currently, if a user want to use from `npm exec` or `npx`, he should:

```
npm exec --package clever-tools@version clever version
```

or 

```
npx --package clever-tools@version -c 'clever version'
npx --package clever-tools@version -- clever version
```

This PR introduces `clever-tools` as binary for Clever Tools. As package name corresponds to an available binary, users will be able to launch it with:

```
npx clever-tools@version version
```

From `npm help exec` :

> If no --package options are provided, then npm will attempt to determine the executable name from the package specifier provided as the first positional argument according to the following heuristic:
> 
> - If the package has a single entry in its bin field in package.json, or if all entries are aliases of the same command, then that command will be used.
> - If the package has multiple bin entries, and one of them matches the unscoped portion of the name field, then that command will be used.
> - If this does not result in exactly one option (either because there are no bin entries, or none of them match the name of the package), then npm exec exits  with an error.