### PR TITLE
fix: remove duplicate --format option for operators version check

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -872,7 +872,7 @@ async function run () {
   const keycloakVersionsCommands = cliparse.command('version', {
     description: 'Check Keycloak deployed version',
     args: [args.addonIdOrName],
-    options: [opts.humanJsonOutputFormat],
+    privateOptions: [opts.humanJsonOutputFormat],
     commands: [keycloakVersionCheckCommand, keycloakVersionUpdateCommand],
   }, keycloak.checkVersion);
   const keycloakCommand = cliparse.command('keycloak', {
@@ -991,7 +991,7 @@ async function run () {
   const metabaseVersionsCommands = cliparse.command('version', {
     description: 'Manage Metabase deployed version',
     args: [args.addonIdOrName],
-    options: [opts.humanJsonOutputFormat],
+    privateOptions: [opts.humanJsonOutputFormat],
     commands: [metabaseVersionCheckCommand, metabaseVersionUpdateCommand],
   }, metabase.checkVersion);
   const metabaseCommand = cliparse.command('metabase', {
@@ -1121,7 +1121,7 @@ async function run () {
   const otoroshiVersionsCommands = cliparse.command('version', {
     description: 'Manage Otoroshi deployed version',
     args: [args.addonIdOrName],
-    options: [opts.humanJsonOutputFormat],
+    privateOptions: [opts.humanJsonOutputFormat],
     commands: [otoroshiVersionCheckCommand, otoroshiVersionUpdateCommand],
   }, otoroshi.checkVersion);
   const otoroshiCommand = cliparse.command('otoroshi', {


### PR DESCRIPTION
This PR remove duplicate `--format` option for operators `version check command`. 

For example: 

```
clever otoroshi version check --help
Usage: check  ADDON-ID
Check Otoroshi deployed version

Arguments:
ADDON-ID                  Add-on ID (or name, if unambiguous)

Options:
[--help, -?]              Display help about this program (default: false)
[--version, -V]           Display the version of this program (default: false)
[--color]                 Choose whether to print colors or not. You can also use --no-color (default: true)
[--update-notifier]       Choose whether to use update notifier or not. You can also use --no-update-notifier (default: true)
[--verbose, -v]           Verbose output (default: false)
[--format, -F] FORMAT     Output format (human, json) (default: human)
[--format, -F] FORMAT     Output format (human, json) (default: human)
```

The `--format` option is only available for `version` and `version check`, not `version update` which is only human/interactive