### PR TITLE
feat(domain): get information in JSON format

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -723,7 +723,7 @@ async function run () {
   }, domain.overview);
   const domainCommands = cliparse.command('domain', {
     description: 'Manage domain names for an application',
-    privateOptions: [opts.alias, opts.appIdOrName],
+    privateOptions: [opts.alias, opts.appIdOrName, opts.humanJsonOutputFormat],
     commands: [domainCreateCommand, domainFavouriteCommands, domainRemoveCommand, domainDiagApplicationCommand, domainOverviewCommand],
   }, domain.list);
 

--- a/src/commands/domain.js
+++ b/src/commands/domain.js
@@ -39,17 +39,36 @@ function getFavouriteDomain ({ ownerId, appId }) {
 }
 
 export async function list (params) {
-  const { alias, app: appIdOrName } = params.options;
+  const { alias, app: appIdOrName, format } = params.options;
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
 
   const app = await getApp({ id: ownerId, appId }).then(sendToApi);
   const favouriteDomain = await getFavouriteDomain({ ownerId, appId });
-  return app.vhosts.forEach(({ fqdn }) => {
-    const prefix = (fqdn === favouriteDomain)
-      ? '* '
-      : '  ';
-    Logger.println(prefix + fqdn);
+
+  const domains = {};
+  domains.favourite = favouriteDomain;
+  domains.vhosts = app.vhosts.map(({ fqdn }) => {
+    const parsed = parseDomain(fqdn, { validateHostname: false });
+    const parsedWithoutFlags = _.omit(parsed, ['isIcann', 'isIp', 'isPrivate']);
+
+    return {
+      fqdn,
+      ...parsedWithoutFlags,
+      isApex: parsed.subdomain === '',
+      pathPrefix: new URL('https://' + fqdn).pathname,
+    };
   });
+
+  switch (format) {
+    case 'json':
+      Logger.printJson(domains);
+      break;
+    default:
+      domains.vhosts.forEach(({ fqdn }) => {
+        Logger.println(`${fqdn === domains.favourite ? '* ' : '  '}${fqdn}`);
+      });
+      break;
+  }
 }
 
 export async function add (params) {


### PR DESCRIPTION
This PR adds `--format` option to `clever domain` command:
- Without any change to `human` (default) format
- With details in JSON format thanks to `parseDomain()`
  - Favourite fqdn is `response.favourite` field
  - `vhosts` field contains each fqdn with its detailed structure, which can help in scripts
