### PR TITLE
docs: move documentation to clever.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Discover how to use Clever Tools through [our documentation](docs/).
 
 ## Examples
 
-Discover how to deploy many applications on Clever Cloud within [our guides](https://www.clever-cloud.com/developers/guides/).
+Discover how to deploy many applications on Clever Cloud within [our guides](https://www.clever.cloud/developers/guides/).
 
 ## How to send feedback?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,12 +190,12 @@ clever ssh-keys remove-all --yes
 
 To use our public API, you need to be authenticated for most endpoints. If you're logged in through Clever Tools, there is a simple way to make any request you want: `clever curl`. It's `curl`, but in an authenticated context for Clever Cloud API.
 
-- [Clever Cloud public APIv2 documentation](https://www.clever-cloud.com/developers/api/v2/)
-- [Clever Cloud public APIv4 documentation](https://www.clever-cloud.com/developers/api/v4/)
+- [Clever Cloud public APIv2 documentation](https://www.clever.cloud/developers/api/v2/)
+- [Clever Cloud public APIv4 documentation](https://www.clever.cloud/developers/api/v4/)
 
 ## tokens
 
-You can query [Clever Cloud public API](https://www.clever-cloud.com/developers/api/) with a bearer token thanks to the Auth Bridge. To create a token, use:
+You can query [Clever Cloud public API](https://www.clever.cloud/developers/api/) with a bearer token thanks to the Auth Bridge. To create a token, use:
 
 ```
 clever tokens create myTokenName

--- a/docs/addons-backups.md
+++ b/docs/addons-backups.md
@@ -63,7 +63,7 @@ clever addon env [--format, -F] FORMAT ADDON_ID
 
 For some add-ons, an interface URL, default credentials or other instructions can be displayed after creation.
 
-If you're testing [Materia KV](https://www.clever-cloud.com/developers/doc/addons/materia-kv/), our next generation of serverless distributed database, synchronously-replicated, compatible with Redis® protocol, you can create an add-on and immediately use it:
+If you're testing [Materia KV](https://www.clever.cloud/developers/doc/addons/materia-kv/), our next generation of serverless distributed database, synchronously-replicated, compatible with Redis® protocol, you can create an add-on and immediately use it:
 
 ```
 clever addon create kv ADDON_NAME

--- a/docs/applications-config.md
+++ b/docs/applications-config.md
@@ -91,7 +91,7 @@ rm                         Remove a domain name from a Clever Cloud application
 ```
 
 > [!TIP]
-> You can set the same domain with multiple apps thanks to [prefix routing](https://www.clever-cloud.com/developers/doc/administrate/domain-names/#prefix-routing). For example, you can add `mydomain.com/app1` domain to an application and `mydomain.com/app2` to another.
+> You can set the same domain with multiple apps thanks to [prefix routing](https://www.clever.cloud/developers/doc/administrate/domain-names/#prefix-routing). For example, you can add `mydomain.com/app1` domain to an application and `mydomain.com/app2` to another.
 
 To (un)set the favourite domain, use:
 
@@ -153,4 +153,4 @@ clever tcp-redirs
 clever tcp-redirs --format json
 ```
 
-- [Learn more about TCP redirections](https://www.clever-cloud.com/developers/doc/administrate/tcp-redirections/)
+- [Learn more about TCP redirections](https://www.clever.cloud/developers/doc/administrate/tcp-redirections/)

--- a/docs/kv.md
+++ b/docs/kv.md
@@ -1,6 +1,6 @@
 # Clever KV
 
-If you're using [Materia KV](https://www.clever-cloud.com/developers/doc/addons/materia-kv/), our next generation of key-value databases, serverless, distributed, synchronously-replicated, compatible with the Redis® protocol (and later DynamoDB, GraphQL), you can easily create an add-on with Clever Tools:
+If you're using [Materia KV](https://www.clever.cloud/developers/doc/addons/materia-kv/), our next generation of key-value databases, serverless, distributed, synchronously-replicated, compatible with the Redis® protocol (and later DynamoDB, GraphQL), you can easily create an add-on with Clever Tools:
 
 ```
 clever addon create kv ADDON_NAME

--- a/docs/ng.md
+++ b/docs/ng.md
@@ -1,6 +1,6 @@
 # Clever Cloud Network Groups
 
-[Network Groups](https://www.clever-cloud.com/developers/doc/develop/network-groups/) (NG) are a way to create a private secure network between resources inside Clever Cloud infrastructure, using [Wireguard](https://www.wireguard.com/). It's also possible to connect external resources to a Network Group. There are three components to this feature:
+[Network Groups](https://www.clever.cloud/developers/doc/develop/network-groups/) (NG) are a way to create a private secure network between resources inside Clever Cloud infrastructure, using [Wireguard](https://www.wireguard.com/). It's also possible to connect external resources to a Network Group. There are three components to this feature:
 
 * Network Group: a group of resources that can communicate with each through an encrypted tunnel
 * Member: a resource that can be part of a Network Group (`application`, `addon` or `external`)
@@ -13,7 +13,7 @@ A Network Group is defined by an ID (`ngId`) and a `label`. It can be completed 
 
 Tell us what you think of Network Groups and what features you need from it in [the dedicated section of our GitHub Community](https://github.com/CleverCloud/Community/discussions/categories/network-groups).
 
-- [Learn more about Network Groups](https://www.clever-cloud.com/developers/doc/develop/network-groups/)
+- [Learn more about Network Groups](https://www.clever.cloud/developers/doc/develop/network-groups/)
 
 ## How it works
 

--- a/src/experimental-features.js
+++ b/src/experimental-features.js
@@ -1,4 +1,5 @@
 import dedent from 'dedent';
+import { conf } from './models/configuration.js';
 
 export const EXPERIMENTAL_FEATURES = {
   kv: {
@@ -13,7 +14,7 @@ export const EXPERIMENTAL_FEATURES = {
           clever kv myMateriaKV -o myOrg TTL myTempKey
           clever kv redis_xxxxx --org org_xxxxx PING
 
-      Learn more about Materia KV: https://www.clever-cloud.com/developers/doc/addons/materia-kv/
+      Learn more about Materia KV: ${conf.DOC_URL}/addons/materia-kv/
     `,
   },
   ng: {
@@ -41,7 +42,7 @@ export const EXPERIMENTAL_FEATURES = {
       - Search Network Groups, members or peers:
           clever ng search myQuery
 
-      Learn more about Network Groups: https://www.clever-cloud.com/developers/doc/develop/network-groups/
+      Learn more about Network Groups: ${conf.DOC_URL}/develop/network-groups/
     `,
   },
   operators: {
@@ -51,10 +52,10 @@ export const EXPERIMENTAL_FEATURES = {
       clever keycloak
       clever keycloak get keycloak_xxx
       clever keycloak ng enable myKeycloak
-      
+
       clever metabase version check myMetabase
       clever metabase version update myMetabase 0.53
-      
+
       clever matomo open myMatomo
       clever otoroshi open logs myOtoroshi
     `,

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -134,8 +134,8 @@ export const conf = env.getOrElseAll({
   CONFIGURATION_FILE: getConfigPath(CONFIG_FILES.MAIN),
   EXPERIMENTAL_FEATURES_FILE: getConfigPath(CONFIG_FILES.EXPERIMENTAL_FEATURES_FILE),
 
-  API_DOC_URL: 'https://www.clever-cloud.com/developers/api',
-  DOC_URL: 'https://www.clever-cloud.com/developers/doc',
+  API_DOC_URL: 'https://www.clever.cloud/developers/api',
+  DOC_URL: 'https://www.clever.cloud/developers/doc',
   CONSOLE_URL: 'https://console.clever-cloud.com',
   CONSOLE_TOKEN_URL: 'https://console.clever-cloud.com/cli-oauth',
   GOTO_URL: 'https://console.clever-cloud.com/goto',


### PR DESCRIPTION
This PR uses `https://clever.cloud/developers` as base URL for the Clever Cloud documentation.

It can be merged as this domain is live.