### PR TITLE
fix: show help context when no callback is set for command

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1331,10 +1331,6 @@ async function run () {
   const databaseCommand = cliparse.command('database', {
     description: 'List available databases',
     commands: [backupsCommand],
-  }, async () => {
-    console.info('This command is not available, you can try the following commands:');
-    console.info('clever database backups');
-    console.info('clever database backups download');
   });
 
   // Patch help command description

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -81,10 +81,16 @@ process.stdout.on('error', (error) => {
 const cliparseCommand = cliparse.command;
 
 cliparse.command = function (name, options, commandFunction) {
-  return cliparseCommand(name, options, (...args) => {
-    const promise = commandFunction(...args);
-    handleCommandPromise(promise);
-  });
+  let callback;
+
+  if (commandFunction !== undefined) {
+    callback = (...args) => {
+      const promise = commandFunction(...args);
+      handleCommandPromise(promise);
+    };
+  }
+
+  return cliparseCommand(name, options, callback);
 };
 
 // Add a yellow color and status tag to the description of an experimental command


### PR DESCRIPTION
Fixes #949 

The `cliparse.command` patch to catch errors expects the command callback to be defined, but it is not always wanted (e.g. we might not want the parent command of a group to do anything). To fix this, we need to skip the patch when the callback is `undefined`.