### PR TITLE
docs update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,53 +2,51 @@
 
 Welcome to the clever-tools project! We're happy you're interested in contributing. This guide will help you get started with development and explain our contribution process.
 
-## Prerequisites & Setup
+## Table of Contents
 
-### Requirements
+- [Requirements](#requirements)
+- [Quick Start](#getting-started)
+- [Development Workflow](#development-workflow)
+- [Project Structure](#project-structure)
+- [Development Standards](#development-standards)
+- [Pull Request Process](#pull-request-process)
+- [CI/CD & Release Process](#cicd--release-process)
+- [Getting Help](#getting-help)
 
-- Node.js 22 or higher (includes npm)
-- A Clever Cloud account (needed to test CLI commands)
+## Requirements
+
 - Git
+- Node.js 22 or higher (includes npm)
 - System tools for local builds: `tar`, `zip` (usually pre-installed)
+- A [Clever Cloud account](https://console.clever-cloud.com/users/me/information) (needed to test CLI commands)
 
-### Getting Started
+## Getting Started
 
-1. **Fork and clone the repository**
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/clever-tools.git
-   cd clever-tools
-   ```
+```bash
+# 1. Fork and clone
+git clone https://github.com/CleverCloud/clever-tools.git
+cd clever-tools
 
-2. **Install dependencies**
-   ```bash
-   npm install
-   ```
+# 2. Install and setup
+npm install
+git config core.hooksPath '.githooks'
 
-3. **Set up local development**
-   
-   To use your local development version anywhere on your system, create an alias:
-   ```bash
-   # Add to your .bashrc, .zshrc, or equivalent
-   alias cleverr='node /path/to/clever-tools/bin/clever.js'
-   ```
-   
-   Some developers use `cleverr` (with two Rs), others prefer `clever-local` or similar. Choose what works for you!
+# 3. Create development alias
+echo "alias cleverr='node $(pwd)/bin/clever.js'" >> ~/.bashrc
+source ~/.bashrc
 
-4. **Configure Git hooks** (recommended)
-   
-   To ensure your commits follow our conventions:
-   ```bash
-   git config core.hooksPath '.githooks'
-   ```
+# 4. Verify setup
+cleverr version
+```
 
 ## Development Workflow
 
 ### Before you start
 
-**Always create an issue before starting work on a PR.** This helps us:
-- Discuss the feature/fix before implementation
+**Always create an issue before starting work on a PR**, it helps us to:
 - Avoid duplicate work
 - Ensure the change aligns with project goals
+- Discuss the feature/fix before implementation
 
 ### Branch Strategy
 
@@ -70,21 +68,61 @@ We maintain a conservative approach to dependencies:
 
 ### API Integration
 
-All communication with Clever Cloud's platform uses the `@clevercloud/client` library:
+All communication with Clever Cloud's platform uses the [@clevercloud/client](https://www.npmjs.com/package/@clevercloud/client) library:
 - Handles authentication and API requests
 - Provides typed interfaces for all API endpoints
 - Ensures consistent error handling across commands
+
+### Development Scripts and Tools
+
+We provide several utility scripts to streamline development (located in `/scripts`):
+
+#### Profile Management
+- **`scripts/switch-profile.js`**: Interactive tool for managing multiple Clever Cloud accounts
+  ```bash
+  # Interactive profile selection
+  node scripts/switch-profile.js
+  
+  # Direct profile switching
+  node scripts/switch-profile.js --profile "user@example.com"
+  ```
+
+#### GitHub Actions Validation  
+- **`scripts/check-github-actions.js`**: Validates CI/CD configuration
+  ```bash
+  node scripts/check-github-actions.js
+  ```
+
+#### Preview Management
+- **`scripts/preview.js`**: Build and manage PR preview versions
+  ```bash
+  # Build local preview
+  scripts/preview.js build [branch-name]
+  
+  # List remote previews
+  scripts/preview.js update
+  ```
+
+All scripts are written in TypeScript with JSDoc enforcement and include comprehensive usage examples.
 
 ## Project Structure
 
 Understanding the codebase structure will help you navigate and contribute effectively:
 
-- **`bin/clever.js`** - Main entry point for the CLI
-- **`src/commands/`** - All CLI commands are defined here
-- **`src/`** - Core libraries and utilities
-- **`src/lib/`** - Additional utility libraries
-- **`src/models/`** - Business logic and API interactions (a bit of a mixed bag)
-- **`scripts/`** - Build and CI scripts (TypeScript with JSDoc enforced)
+```text
+clever-tools/
+├── bin/
+│   └── clever.js            # Main entry point for the CLI
+├── src/
+│   ├── commands/            # All CLI commands are defined here
+│   ├── lib/                 # Additional utility libraries
+│   ├── models/              # Business logic and API interactions (a bit of a mixed bag)
+│   └── ...                  # Core libraries and utilities
+├── scripts/                 # Build and CI scripts (TypeScript with JSDoc enforced)
+│   ├── lib/                 # Shared utilities for scripts
+│   └── templates/           # Templates for package managers (AUR, Homebrew, etc.)
+└── ...
+```
 
 ## Development Standards
 
@@ -130,6 +168,13 @@ npm run typecheck
 ```
 
 We use TypeScript through JSDoc comments for type safety without transpilation.
+
+#### Development Environment
+
+The project supports multiple development approaches:
+- **Local debugging**: Use Node.js remote debugger with `--inspect` flag
+- **Script development**: All `/scripts` files support `--help` for usage information
+- **Profile switching**: Use the profile utility for testing with different Clever Cloud accounts
 
 ### Commit Guidelines
 
@@ -177,22 +222,17 @@ For changes affecting multiple commands:
 
 ### 1. Before Creating a PR
 
-- Ensure an issue exists for your change
-- Run all quality checks locally (these will also be automatically validated on your PR):
-  ```bash
-  npm run lint
-  npm run format:check
-  npm run typecheck
-  ```
 - Test your changes thoroughly
+- Ensure an issue exists for your change
 - Ensure your branch is rebased on the latest `master` and contains no fixup/squash commits
+- Run all quality checks locally with `npm run validate` (it will also be run automatically on your PR)
 
 ### 2. Creating Your PR
 
-- Reference the issue in your PR description
 - Provide clear description of changes
-- Include testing instructions if applicable
 - Mark as draft if work is in progress
+- Reference the issue in your PR description
+- Include testing instructions if applicable
 
 ### 3. Preview Builds
 
@@ -224,7 +264,7 @@ scripts/preview.js delete [branch-name]
 scripts/preview.js pr-comment [branch-name]
 ```
 
-The script provides terminal-based preview listing and management with download progress reporting. For publish/delete operations, you'll need Cellar credentials:
+The script provides terminal-based preview listing and management with download progress reporting. For publish/delete operations, you'll need admin Cellar credentials:
 
 ```bash
 export CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET="your-bucket"
@@ -255,14 +295,14 @@ Our CI/CD pipeline ensures quality and automates releases:
 - Conventional commits drive changelog generation
 - Release-please manages versioning
 - Automated publishing to multiple platforms:
-  - **npm**: Published on npmjs.org
-  - **GitHub Releases**: Binary archives and release notes
-  - **Docker Hub**: Official Docker images
-  - **Cellar**: Clever Cloud's object storage for direct downloads
-  - **Nexus**: RPM and DEB packages for Linux distributions
   - **AUR**: Arch Linux User Repository
-  - **Homebrew**: macOS package manager
+  - **Cellar**: Clever Cloud's object storage for direct downloads
+  - **Docker Hub**: Official Docker images
   - **Exherbo**: Linux distribution packages
+  - **Homebrew**: macOS package manager
+  - **GitHub Releases**: Binary archives and release notes
+  - **Nexus**: RPM and DEB packages for Linux distributions
+  - **npm**: Published on npmjs.org
   - **WinGet**: Windows Package Manager
 
 Key workflows:
@@ -326,10 +366,11 @@ graph LR
 
 ### Build System
 
-The build process creates self-contained binaries for all platforms:
-- **Bundling**: Rollup creates a single CommonJS file
-- **Compilation**: @yao-pkg/pkg compiles the single CommonJS file into binaries for Linux, macOS, and Windows
-- **Packaging**: Scripts generate platform-specific archives (.tar.gz, .zip) and packages (.deb, .rpm)
+The build process creates self-contained binaries for all platforms using modern tooling:
+- **Bundling**: Rollup creates a single CommonJS file from the ESM source
+- **Compilation**: @yao-pkg/pkg (successor to vercel/pkg) compiles binaries for Linux, macOS, and Windows
+- **Packaging**: Node.js scripts generate platform-specific archives (.tar.gz, .zip) and packages (.deb, .rpm)
+- **Distribution**: Automated publishing to 10+ channels including npm, Homebrew, Docker Hub, and Linux repositories
 
 ### Script-Based Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,10 @@ npm run lint
 
 # Auto-fix fixable issues
 npm run lint:fix
+
+# Run all quality checks and try to auto-fix them
+npm run validate
+npm run fix-all
 ```
 
 #### Prettier

--- a/README.md
+++ b/README.md
@@ -1,81 +1,159 @@
 # Clever Tools
 
-Deploy on Clever Cloud and control your applications, add-ons, services from command line.
+[![npm version](https://img.shields.io/npm/v/clever-tools.svg)](https://www.npmjs.com/package/clever-tools)
+[![Node.js requirement](https://img.shields.io/node/v/clever-tools.svg)](https://nodejs.org)
 
-- [Create a Clever Cloud account](https://console.clever-cloud.com)
+The official CLI for [Clever Cloud](https://www.clever.cloud) - Deploy and manage your applications, add-ons, and services from the command line with modern tooling and automated workflows. The perfect developer companion, complementing the [Clever Cloud Console](https://console.clever-cloud.com).
 
-## Installation
+## Quick Start
 
-Clever Tools are available from many channels. The simpler way to install them, if you already have Node.js on your system, is through `npm` package manager:
+**Prerequisites:** Node.js 22+ 
 
 ```bash
+# Install globally
 npm install -g clever-tools
-```
 
-You can use it through `npx` or `npm exec` without installing it globally:
-
-```bash
-# Set/Export CLEVER_TOKEN and CLEVER_SECRET to login with a given account
-# --yes is used to skip the interactive prompts
+# Or use directly without installation
 npx --yes clever-tools@latest version
-npm exec -- clever-tools@3.14 profile --format json
 ```
 
-We also distribute binaries and packages for multiple systems and tools:
-
-* [GNU/Linux](docs/setup-systems.md#gnulinux)
-  * [Arch Linux (AUR)](docs/setup-systems.md#arch-linux-aur)
-  * [CentOS/Fedora (.rpm)](docs/setup-systems.md#centosfedora-rpm)
-  * [Debian/Ubuntu (.deb)](docs/setup-systems.md#debianubuntu-deb)
-  * [Exherbo](docs/setup-systems.md#exherbo)
-  * [Binary (.tar.gz)](docs/setup-systems.md#other-distributions-targz)
-* [macOS](docs/setup-systems.md#macos)
-  * [Homebrew](docs/setup-systems.md#homebrew)
-  * [Binary (.tar.gz)](docs/setup-systems.md#binary-zip)
-* [Windows](docs/setup-systems.md#windows)
-  * [Chocolatey](docs/setup-systems.md#chocolatey)
-  * [Binary (.zip)](docs/setup-systems.md#binary-zip)
-* [Docker](docs/setup-systems.md#docker)
-* [Nix package manager](docs/setup-systems.md#nix-package-manager)
-
-## Enabling autocompletion
-
-The clever-tools CLI comes with a comprehensive auto-completion system. Some installation methods through package managers will try to enable it automatically. If not, use this for bash:
-
-```bash
-clever --bash-autocomplete-script $(which clever) | sudo tee /usr/share/bash-completion/completions/clever
-```
-
-or that for zsh:
-
-```bash
-clever --zsh-autocomplete-script $(which clever) | sudo tee /usr/share/zsh/site-functions
-```
-
-## How to use
-
-You can then login and check everything is working:
-
+**First steps:**
 ```bash
 clever login
 clever profile
 ```
 
-Discover how to use Clever Tools through [our documentation](docs/).
+## Key Features
 
-## Examples
+- **Complete Platform Control**: Manage applications, add-ons, domains, and services from the command line
+- **Real-time Monitoring**: Stream logs, monitor deployments, and check application status
+- **Seamless Deployment**: Deploy directly from your local environment or CI/CD pipelines
+- **Cross-platform**: Available for Linux, macOS, Windows via multiple package managers
+- **API Integration**: Direct access to Clever Cloud's API with authenticated commands
 
-Discover how to deploy many applications on Clever Cloud within [our guides](https://www.clever-cloud.com/developers/guides/).
+## Installation Options
 
-## How to send feedback?
+For Node.js users, npm is the fastest way. For other installation methods including:
 
-[Send us an email!](mailto:support@clever-cloud.com) or [submit an issue](https://github.com/CleverCloud/clever-tools/issues).
+- Docker images
+- Binary downloads
+- Native packages (RPM, DEB)  
+- Package managers (Homebrew, Chocolatey, AUR)
 
-## Automated releases
+See our complete [setup guide](docs/setup-systems.md).
 
-This project uses GitHub Actions to build binaries, package them and release them automatically on the various repositories.
-If you want to know more or if you need to release a new version, please read [RELEASE.md](./RELEASE.md) carefully.
+### Autocompletion
+
+Enable smart autocompletion for bash or zsh:
+
+```bash
+# Bash
+clever --bash-autocomplete-script $(which clever) | sudo tee /usr/share/bash-completion/completions/clever
+
+# Zsh  
+clever --zsh-autocomplete-script $(which clever) | sudo tee /usr/share/zsh/site-functions/_clever
+```
+
+## Documentation
+
+- **[Complete CLI Documentation](https://www.clever-cloud.com/developers/doc/cli/)** - Official user guide
+- **[CLI Reference](https://www.clever-cloud.com/developers/doc/reference/cli/)** - Complete command reference
+- **[Deployment Examples](https://www.clever-cloud.com/developers/guides/)** - Real-world tutorials
+
+## Basic Usage
+
+### Authentication
+```bash
+# Interactive login
+clever login
+
+# Non-interactive login
+clever login --token <your-token> --secret <your-secret>
+
+# Or use environment variables, idéal for CI/CD
+export CLEVER_TOKEN="your-token"
+export CLEVER_SECRET="your-secret"
+clever profile
+```
+
+### Application Management
+```bash
+# List applications
+clever applications list
+
+# Create a new Node.js/Bun application
+clever applications create --type node
+
+# Link existing app to the current directory
+clever link <app_id>
+
+# Deploy current directory
+clever deploy
+
+# Monitor logs
+clever logs --since 1h
+
+# Restart an application
+clever restart --app <app_id>
+```
+
+Learn more in our [Application Management Guide](https://www.clever-cloud.com/developers/doc/cli/applications/).
+
+### Add-ons & Services Management
+```bash
+# List add-ons
+clever addon
+
+# Create a PostgreSQL add-on
+clever addon create postgresql-addon myPG
+
+# Create a Cellar (S3-compatible storage) add-on
+clever addon create cellar-addon  myCellar
+
+# Create and manage a Keycloak service
+clever addon create keycloak myKeycloak
+
+clever features enable operatos
+clever keycloak get myKetcloak
+```
+Learn more in our [Add-ons & Services Guide](https://www.clever-cloud.com/developers/doc/cli/addons/).
+
+# Create and manage
+
+### API Access with clever curl and clever tokens
+
+Access Clever Cloud's API directly through authenticated commands:
+
+```bash
+# Get your user information
+clever curl https://api.clever-cloud.com/v2/self
+
+# Get platform summary
+clever curl https://api.clever-cloud.com/v2/summary
+
+# List your applications (with jq for filtering)
+clever curl https://api.clever-cloud.com/v2/organisations/<ORG_ID>/applications | jq '.[].id'
+
+# Create API tokens for external tools
+clever tokens create myTokenName
+clever tokens create myTokenName --expiration 2w --format json
+```
+
+Learn more about API integration in our [API How-to Guide](https://www.clever-cloud.com/developers/api/howto).
+
+### Get Help
+```bash
+clever help                    # List all commands
+clever <command> --help        # Get specific help
+clever --format json <command> # JSON output for scripting
+```
+
+## Support & Contributing
+
+- **Issues & Questions**: [GitHub Issues](https://github.com/CleverCloud/clever-tools/issues)
+- **Email Support**: [Ticket Center](https://console.clever-cloud.com/ticket-center-choice)
+- **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines
 
 ## License
 
-This project is licensed under the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html).
+This project is licensed under the [Apache-2.0](LICENSE).

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "lint:fix": "eslint --fix",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "validate": "npm run lint && npm run format:check && npm run typecheck",
+    "fix-all": "npm run lint:fix && npm run format"
   },
   "dependencies": {
     "@clevercloud/client": "11.0.1",


### PR DESCRIPTION
This PR adds change to new `CONTRIBUTING.md` and adapts `README.md` to recent project change.

It also adds:
- `npm run validate` : run all quality check scripts
- `npm run fix-all` : run all fix scripts

And document them. It's easier to run only one command for all checks on a regular development workflow, and use dedicated commands when we need to run a specific tool. 

Maybe we could change something about : `npm run format/:check` but `npm run lint/:fix`. I understand the logic here, but maybe we should have a `:check` for checking scripts, and fix with the verb command (`format`, `lint`). I didn't change anything about it.

Preview is here: https://github.com/CleverCloud/clever-tools/tree/davlgd-new-contributing