### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       version:
         required: true
         type: string
+      isPreview:
+        required: true
+        type: boolean
+        description: 'Whether this is a preview build'
       include-windows:
         type: boolean
         default: true
@@ -19,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - name: 'Bundle to single clever.cjs'
-        run: ./scripts/bundle-cjs.js ${{ inputs.version }}
+        run: ./scripts/bundle-cjs.js ${{ inputs.version }} ${{ inputs.isPreview }}
       - uses: ./.github/actions/upload-artifact
         with:
           artifact-name: bundle-cjs

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ github.event.pull_request.head.ref }}
+      isPreview: true
       include-windows: ${{ contains(github.event.pull_request.labels.*.name, 'build:win') }}
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,10 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: 'Add AUR to known hosts'
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/download-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ github.ref_name }}
+      isPreview: false
 
   package-rpm:
     name: 'Build .rpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,6 @@ jobs:
         shell: bash
         run: ./scripts/publish-winget.js ${{ github.ref_name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_TOKEN: ${{ secrets.CI_TOKEN }}
           CC_CLEVER_TOOLS_RELEASES_CELLAR_BUCKET: ${{ vars.CC_CLEVER_TOOLS_RELEASES_CELLAR_BUCKET }}
           WINGET_PACKAGE_ID: ${{ vars.WINGET_PACKAGE_ID }}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,11 @@ export default defineConfig({
     // When distributing previews, we want to replace the version with the preview name
     {
       transform(code, id) {
-        if (id.includes('/package.json')) {
+        if (
+          id.includes('/package.json') &&
+          process.env.CLEVER_TOOLS_PREVIEW_VERSION &&
+          process.env.CLEVER_TOOLS_COMMIT_ID
+        ) {
           const packageData = JSON.parse(code);
           packageData.version = `preview-${process.env.CLEVER_TOOLS_PREVIEW_VERSION}`;
           packageData.commitId = process.env.CLEVER_TOOLS_COMMIT_ID;

--- a/scripts/bundle-cjs.js
+++ b/scripts/bundle-cjs.js
@@ -5,28 +5,34 @@
 // This script creates a self-contained CJS bundle from the application source,
 // which is used as input for binary compilation.
 //
-// USAGE: bundle-cjs.js <version>
+// USAGE: bundle-cjs.js <version> <isPreview>
 //
 // ARGUMENTS:
 //   version         Version string (e.g., "1.2.3")
+//   isPreview       Whether this is a preview build (true/false)
 //
 // REQUIRED SYSTEM BINARIES:
 //   npx             For running bundling tools
 //
 // EXAMPLES:
-//   bundle-cjs.js 1.2.3
+//   bundle-cjs.js 1.2.3 false
+//   bundle-cjs.js preview-feature true
 
 import { bundleToSingleCjs } from './lib/bundle-cjs.js';
 import { ArgumentError, runCommand } from './lib/command.js';
 import { getVersion } from './lib/utils.js';
 
 runCommand(async () => {
-  const [rawVersion] = process.argv.slice(2);
+  const [rawVersion, rawIsPreview] = process.argv.slice(2);
   if (rawVersion == null) {
     throw new ArgumentError('version');
   }
+  if (rawIsPreview == null) {
+    throw new ArgumentError('isPreview');
+  }
 
   const version = getVersion(rawVersion);
+  const isPreview = rawIsPreview === 'true';
 
-  await bundleToSingleCjs(version);
+  await bundleToSingleCjs(version, isPreview);
 });

--- a/scripts/lib/bundle-cjs.js
+++ b/scripts/lib/bundle-cjs.js
@@ -5,14 +5,15 @@ import { exec } from './process.js';
 /**
  * Bundle the whole project to a single CommonJS file with Rollup
  * @param {string} version - The version to build
+ * @param {boolean} isPreview - Whether this is a preview build
  * @returns {Promise<void>}
  */
-export async function bundleToSingleCjs(version) {
+export async function bundleToSingleCjs(version, isPreview) {
   const filename = getAssetPath('bundle', version, 'build');
-  await exec(`npx rollup -c rollup.config.js -o ${filename}`, {
-    env: {
-      CLEVER_TOOLS_PREVIEW_VERSION: version,
-      CLEVER_TOOLS_COMMIT_ID: await getCurrentCommit(),
-    },
-  });
+  const env = {};
+  if (isPreview) {
+    env.CLEVER_TOOLS_PREVIEW_VERSION = version;
+    env.CLEVER_TOOLS_COMMIT_ID = await getCurrentCommit();
+  }
+  await exec(`npx rollup -c rollup.config.js -o ${filename}`, { env });
 }

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -128,7 +128,7 @@ runCommand(async () => {
 async function buildPreview(previewName, os) {
   const binaryParts = getAssetParts('binary', previewName, 'build', os);
   await fs.mkdir(binaryParts.directory, { recursive: true });
-  await bundleToSingleCjs(previewName);
+  await bundleToSingleCjs(previewName, true);
   await buildBinary(previewName, os);
   await createArchive(previewName, os);
   await installBinary(previewName, os, false);

--- a/scripts/publish-winget.js
+++ b/scripts/publish-winget.js
@@ -11,9 +11,9 @@
 //   version         Version string (e.g., "1.2.3")
 //
 // ENVIRONMENT VARIABLES:
-//   GITHUB_TOKEN                GitHub token with public_repo scope
+//   CI_TOKEN                                GitHub token with public_repo scope
 //   CC_CLEVER_TOOLS_RELEASES_CELLAR_BUCKET  Cellar bucket for Windows archive
-//   WINGET_PACKAGE_ID           Windows Package Manager package ID
+//   WINGET_PACKAGE_ID                       Windows Package Manager package ID
 //
 // REQUIRED SYSTEM BINARIES:
 //   winget          Windows Package Manager CLI
@@ -34,8 +34,8 @@ runCommand(async () => {
     throw new ArgumentError('version');
   }
 
-  const [githubToken, cellarBucket, packageId] = readEnvVars([
-    'GITHUB_TOKEN',
+  const [ciToken, cellarBucket, packageId] = readEnvVars([
+    'CI_TOKEN',
     'CC_CLEVER_TOOLS_RELEASES_CELLAR_BUCKET',
     'WINGET_PACKAGE_ID',
   ]);
@@ -51,7 +51,7 @@ runCommand(async () => {
 
   try {
     console.log('=> Attempting to update existing package...');
-    await exec(`wingetcreate update ${packageId} -u "${windowsArchiveUrl}" -v ${version} -t ${githubToken} --submit`);
+    await exec(`wingetcreate update ${packageId} -u "${windowsArchiveUrl}" -v ${version} -t ${ciToken} --submit`);
     console.log(highlight`=> Successfully submitted winget manifest update for ${packageId} v${version}`);
   } catch (updateError) {
     console.error('Failed to update winget manifest');


### PR DESCRIPTION
CI fixes

- add isPreview parameter to build workflow so we only get `preview-` in preview builds
- add AUR to known hosts in release workflow so we can publish to AUR
- use `CI_TOKEN` instead of `GITHUB_TOKEN` for Winget publication