### PR TITLE
fix(ci): add missing AUR package template with metadata

### DIFF
--- a/scripts/templates/aur/.SRCINFO
+++ b/scripts/templates/aur/.SRCINFO
@@ -1,0 +1,12 @@
+pkgbase = <%= pkgbase %>
+	pkgdesc = <%= description %>
+	pkgver = <%= version %>
+	pkgrel = 1
+	url = <%= url %>
+	arch = x86_64
+	license = <%= license %>
+	options = !strip
+	source = clever-tools-<%= version %>_linux.tar.gz::https://clever-tools.clever-cloud.com/releases/<%= version %>/clever-tools-<%= version %>_linux.tar.gz
+	sha256sums = <%= sha256 %>
+
+pkgname = <%= pkgbase %>


### PR DESCRIPTION
## Summary

- Add missing AUR package template with metadata and source configuration 
- Include .SRCINFO template for Arch User Repository packaging 
- Add placeholder variables for package metadata, version, and source URL

## Changes

- Added `scripts/templates/aur/.SRCINFO` template file 
- Template includes proper AUR package metadata structure 
- Enables automated AUR package generation in CI pipeline

## Impact

- Fixes missing AUR packaging template in CI process 
- Improves distribution support for Arch Linux users