### PR TITLE
chore: update `@clevercloud/client` to `11.2.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "11.0.1",
+        "@clevercloud/client": "11.2.0",
         "@inquirer/prompts": "7.8.4",
         "char-regex": "2.0.2",
         "cliparse": "0.5.0",
@@ -1046,15 +1046,15 @@
       }
     },
     "node_modules/@clevercloud/client": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-11.0.1.tgz",
-      "integrity": "sha512-uvTAfNACltDDTPsW98rqACGPkwd+IgmtLJiKmmQLP6FvA1Kh0e7u5kDl0e6HWcQvvTd8DhcFu44wSDu7Cco0kg==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-11.2.0.tgz",
+      "integrity": "sha512-CtOykaAb2KPZJDiEsT3dbXaxYIeMP1n/1SKWRoeZyzr+wHfG47i1MwfD9lItK7NMZ/XiF31r1BVMeOeq+o+TTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "component-emitter": "^1.3.0"
       },
       "engines": {
-        "node": "22"
+        "node": ">=22"
       },
       "peerDependencies": {
         "eventsource": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@clevercloud/client": "11.0.1",
+    "@clevercloud/client": "11.2.0",
     "@inquirer/prompts": "7.8.4",
     "char-regex": "2.0.2",
     "cliparse": "0.5.0",


### PR DESCRIPTION
Updates the `@clevercloud/client` dependency to version `11.2.0` to remove the Node.js 24 warning.
