### PR TITLE
fix(logs): increase retryConfiguration

### DIFF
--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -17,7 +17,8 @@ const THROTTLE_PER_IN_MILLISECONDS = 100;
 
 const retryConfiguration = {
   enabled: true,
-  maxRetryCount: 6,
+  initRetryTimeout: 3000,
+  maxRetryCount: 10,
 };
 
 export async function displayLogs(params) {


### PR DESCRIPTION
Sometimes, it takes longer to get logs at 1st deployment and it leads to an error. 

After some tests, I found a way to prevent this: 
- Define `initRetryTimeout` to increase wait between retries
- Increase try count