### PR TITLE
refactor: improve help message behavior for root commands without implementation

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -79,6 +79,10 @@ process.stdout.on('error', (error) => {
 const cliparseCommand = cliparse.command;
 
 cliparse.command = function (name, options, commandFunction) {
+  if (commandFunction == null) {
+    return cliparseCommand(name, options);
+  }
+
   return cliparseCommand(name, options, (...args) => {
     const promise = commandFunction(...args);
     handleCommandPromise(promise);

--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1981,18 +1981,10 @@ async function run() {
     },
     database.listBackups,
   );
-  const databaseCommand = cliparse.command(
-    'database',
-    {
-      description: 'List available databases',
-      commands: [backupsCommand],
-    },
-    async () => {
-      console.info('This command is not available, you can try the following commands:');
-      console.info('clever database backups');
-      console.info('clever database backups download');
-    },
-  );
+  const databaseCommand = cliparse.command('database', {
+    description: 'Manage databases and backups',
+    commands: [backupsCommand],
+  });
 
   // Patch help command description
   cliparseCommands.helpCommand.description = 'Display help about the Clever Cloud CLI';


### PR DESCRIPTION
Closes https://github.com/CleverCloud/clever-tools/issues/949

Mostly based on #950, thank you @sehnryr :+1: :muscle: 

- Show help automatically when no callback is set for a command
- Replace custom console.info with standard help message display in database commands

This refactoring standardizes help message handling across the CLI and provides more consistent user guidance.

@sehnryr Here's what I changed:

- rebase on latest master (the big summer changes introduced prettier so there were merge conflicts :p)
- rename commits to refactor as for users it's not a fix
- I reworked some JS here and there
- I updated the description of the `clever database` command since it does not list