### PR TITLE
feat(operators): add get-config command to Otoroshi

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -1620,6 +1620,14 @@ async function run() {
     },
     otoroshi.get,
   );
+  const otoroshiGetConfigCommand = cliparse.command(
+    'get-config',
+    {
+      description: 'Get configuration of a deployed Otoroshi in otoroshictl format',
+      args: [args.addonIdOrName],
+    },
+    otoroshi.getConfig,
+  );
   const otoroshiEnableNgCommand = cliparse.command(
     'enable-ng',
     {
@@ -1712,6 +1720,7 @@ async function run() {
       privateOptions: [opts.humanJsonOutputFormat],
       commands: [
         otoroshiGetCommand,
+        otoroshiGetConfigCommand,
         otoroshiEnableNgCommand,
         otoroshiDisableNgCommand,
         otoroshiOpenCommand,

--- a/src/clever-client/operators.js
+++ b/src/clever-client/operators.js
@@ -119,3 +119,19 @@ export function versionUpdate(params, body) {
     body,
   });
 }
+
+/**
+ * GET /v4/addon-providers/addon-otoroshi/addons/{realId}/config.yaml
+ * @param {Object} params
+ * @param {String} params.realId
+ */
+export function getOtoroshiConfig(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-otoroshi/addons/${params.realId}/config.yaml`,
+    // headers: { Accept: 'application/yaml' },
+    // no queryParams
+    // no body
+  });
+}

--- a/src/commands/otoroshi.js
+++ b/src/commands/otoroshi.js
@@ -51,6 +51,18 @@ export async function get(params) {
 }
 
 /**
+ * Print the configuration of an Otoroshi operator in otoroshictl format
+ * @param {object} params The command's parameters
+ * @param {string} params.args[0] The operator's name or ID
+ * @returns {Promise<void>}
+ */
+export async function getConfig(params) {
+  const [addonIdOrName] = params.args;
+  const { format } = params.options;
+  await operatorPrint('otoroshi', addonIdOrName, 'otoroshictl');
+}
+
+/**
  * List all Otoroshi operators
  * @returns {Promise<void>}
  */

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -1,6 +1,7 @@
 import dedent from 'dedent';
 import _ from 'lodash';
 import {
+  getOtoroshiConfig,
   ngDisableOperator,
   ngEnableOperator,
   rebootOperator,
@@ -248,6 +249,13 @@ export async function operatorRebuild(provider, addonIdOrName) {
  */
 export async function operatorPrint(provider, addonIdOrName, format = 'human') {
   const operator = await Operator.getDetails(provider, addonIdOrName);
+
+  if (provider === 'otoroshi' && format === 'otoroshictl') {
+    const config = await getOtoroshiConfig({ realId: operator.resourceId }).then(sendToApi);
+
+    Logger.println(config);
+    return;
+  }
 
   const dataToPrint = {
     Name: operator.name,


### PR DESCRIPTION
This PR adds `get-config` command to Otoroshi operator, to allow printing configuration of a deployed instance to import with `otoroshictl`