### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "16.0.3",
         "@types/mime-types": "3.0.1",
+        "@types/picomatch": "4.0.2",
         "@yao-pkg/pkg": "6.10.1",
         "eslint": "9.39.1",
         "globals": "16.5.0",
@@ -3504,6 +3505,13 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@types/mime-types": "3.0.1",
+    "@types/picomatch": "4.0.2",
     "@yao-pkg/pkg": "6.10.1",
     "eslint": "9.39.1",
     "globals": "16.5.0",


### PR DESCRIPTION
## Summary
- Update patch-level dependencies
- Update minor-level dependencies  
- Override js-yaml to 4.1.1 to fix prototype pollution vulnerability (CVE-2023-2251)

## Test plan
- [x] `npm run lint` passes
- [x] CI tests pass