### PR TITLE
fix: handle undefined deploymentEnded in log watchers

### DIFF
--- a/src/models/log-v4.js
+++ b/src/models/log-v4.js
@@ -133,6 +133,11 @@ export async function watchDeploymentAndDisplayLogs(options) {
     logsStream.close(quiet ? 'quiet' : 'follow');
   }
 
+  // deploymentEnded can be undefined if deferred resolved (e.g., stream closed via SIGINT)
+  if (deploymentEnded == null) {
+    return;
+  }
+
   if (deploymentEnded.state === 'OK') {
     Logger.println('');
 

--- a/src/models/log.js
+++ b/src/models/log.js
@@ -133,6 +133,11 @@ export async function watchDeploymentAndDisplayLogs({
     logsStream.close();
   }
 
+  // deploymentEnded can be undefined if deferred resolved (e.g., stream closed via SIGINT)
+  if (deploymentEnded == null) {
+    return;
+  }
+
   if (deploymentEnded.state === 'OK') {
     Logger.println(styleText(['bold', 'green'], 'Deployment successful'));
   } else if (deploymentEnded.state === 'CANCELLED') {


### PR DESCRIPTION
## Summary

Fixes the `Cannot read properties of undefined (reading 'state')` error that occurs when interrupting `clever logs` with Ctrl+C.

When a user presses Ctrl+C during log streaming, the deferred promise resolves without a value, causing `deploymentEnded` to be `undefined`. The code then tries to access `.state` on `undefined`, throwing an error.

## Changes

- Added null check before accessing `deploymentEnded.state` in both `src/models/log-v4.js` and `src/models/log.js`
- Gracefully returns when stream is interrupted instead of crashing

Closes #707