### PR TITLE
fix(ci): use lowercase options in AUR PKGBUILD template

### DIFF
--- a/scripts/templates/aur/PKGBUILD
+++ b/scripts/templates/aur/PKGBUILD
@@ -8,7 +8,7 @@ arch=('x86_64')
 url="<%= url %>"
 license=('<%= license %>')
 
-OPTIONS=(!strip)
+options=(!strip)
 
 source=("clever-tools-<%= version %>_linux.tar.gz::https://clever-tools.clever-cloud.com/releases/<%= version %>/clever-tools-<%= version %>_linux.tar.gz")
 sha256sums=('<%= sha256 %>')


### PR DESCRIPTION
## Summary

This is a regression of #708. The original fix changed `options=('!strip')` to `OPTIONS=(!strip)`, which seemed to work at the time. However, `OPTIONS` (uppercase) is a read-only shell variable and is not recognized by makepkg.

It's unclear why the original fix appeared to work, but the current behavior is that makepkg ignores `OPTIONS` entirely, causing the binary to be stripped and resulting in "Pkg: Error reading from file." errors.

The correct syntax is `options=(!strip)` (lowercase, without quotes around `!strip`) which makepkg properly recognizes to prevent stripping the pkg-compiled Node.js binary.