### PR TITLE
fix(addon): fix --addon-version option conflict with global --version flag

### DIFF
--- a/src/commands/addon/addon.create.command.js
+++ b/src/commands/addon/addon.create.command.js
@@ -90,7 +90,7 @@ export const addonCreateCommand = defineCommand({
       placeholder: 'region',
       complete: completeRegion,
     }),
-    version: defineOption({
+    addonVersion: defineOption({
       name: 'addon-version',
       schema: z.string().optional(),
       description: 'The version to use for the add-on',
@@ -115,7 +115,7 @@ export const addonCreateCommand = defineCommand({
       yes: skipConfirmation,
       org: orgaIdOrName,
       format,
-      version,
+      addonVersion,
       option: addonOptions,
     } = options;
 
@@ -125,7 +125,7 @@ export const addonCreateCommand = defineCommand({
       planName,
       region,
       skipConfirmation,
-      version: version,
+      version: addonVersion,
       addonOptions: parseAddonOptions(addonOptions),
     };
 

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -76,9 +76,7 @@ function validateAddonVersionAndOptions(region, version, addonOptions, providerI
         const availableVersions = Object.keys(providerInfos.dedicated);
         const hasVersion = availableVersions.find((availableVersion) => availableVersion === version);
         if (hasVersion == null) {
-          throw new Error(
-            `Invalid version ${addonOptions.version}, available versions are: ${availableVersions.join(', ')}`,
-          );
+          throw new Error(`Invalid version ${version}, available versions are: ${availableVersions.join(', ')}`);
         }
       }
     }


### PR DESCRIPTION
## Summary

- Fixes the `--addon-version` option not working correctly on `clever addon create`
- The option key `version` in the command definition was conflicting with the global `--version` flag, causing minimist to initialize it to `false` instead of `undefined`
- Also fixes a typo in the error message that was displaying "Invalid version undefined" instead of the actual version value

## Problem

When running commands like:
```bash
clever addon create postgresql-addon test --org orga_xxx --plan xxs_sml --yes --addon-version 17
```

Users were getting errors like:
```
[ERROR] Invalid version undefined, available versions are: 13, 14, 15, 16, 17, 18
```

Or without `--addon-version`:
```
[ERROR] Invalid version false, selected shared cluster only supports version 15
```

## Root cause

The option was defined with the key `version:` in the options object:
```javascript
options: {
  version: defineOption({
    name: 'addon-version',
    // ...
  }),
}
```

This conflicted with the global `--version` flag (defined in `global.options.js`). When cliparse builds the list of boolean flags for minimist, it includes `version`. Minimist then initializes all boolean flags to `false` by default, overwriting the `addon-version` value.

## Fix

1. Renamed the option key from `version` to `addonVersion` in `addon.create.command.js`
2. Fixed the typo in `addon.js` where `addonOptions.version` was incorrectly used instead of `version` in the error message

## Test plan

- [x] Test `clever addon create postgresql-addon test --plan xxs_sml --addon-version 17` works correctly
- [x] Test `clever addon create postgresql-addon test --plan xxs_sml` without version works correctly
- [x] Test error messages display the correct version value when invalid