### PR TITLE
fix(webhooks): require --org when using --service

### DIFF
--- a/docs/llms-documentation.md
+++ b/docs/llms-documentation.md
@@ -1605,7 +1605,7 @@ name                                                 Notification name
     --notify <email-address|user-id|organisation>    Notify a user, a specific email address or the whole organisation (multiple values allowed, comma separated) (required)
     --event <event-type>                             Restrict notifications to specific event types
 -o, --org, --owner <org-id|org-name>                 Organisation to target by its ID (or name, if unambiguous)
-    --service <service-id>                           Restrict notifications to specific applications and add-ons
+    --service <service-id>                           Restrict notifications to specific applications and add-ons (requires --org)
 
 ### notify-email remove
 
@@ -2161,7 +2161,7 @@ url                                     Webhook URL
     --event <event-type>                Restrict notifications to specific event types
     --format <format>                   Format of the body sent to the webhook ('raw', 'slack', 'gitter', or 'flowdock') (default: raw)
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
-    --service <service-id>              Restrict notifications to specific applications and add-ons
+    --service <service-id>              Restrict notifications to specific applications and add-ons (requires --org)
 
 ### webhooks remove
 

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -148,7 +148,7 @@ export const notificationScopeOption = defineOption({
     .string()
     .transform((v) => v.split(','))
     .optional(),
-  description: 'Restrict notifications to specific applications and add-ons',
+  description: 'Restrict notifications to specific applications and add-ons (requires --org)',
   placeholder: 'service-id',
 });
 

--- a/src/commands/notify-email/notify-email.add.command.js
+++ b/src/commands/notify-email/notify-email.add.command.js
@@ -48,8 +48,11 @@ export const notifyEmailAddCommand = defineCommand({
   async handler(options, name) {
     const { org, event: events, service, notify: notifTargets } = options;
 
-    // TODO: fix alias option
-    const { ownerId, appId } = await getOwnerAndApp(null, org, !org && !service);
+    if (service != null && org == null) {
+      throw new Error('--org is required when using --service');
+    }
+
+    const { ownerId, appId } = await getOwnerAndApp(org, org == null && service == null);
 
     const body = {
       name,

--- a/src/commands/notify-email/notify-email.command.js
+++ b/src/commands/notify-email/notify-email.command.js
@@ -18,8 +18,7 @@ export const notifyEmailCommand = defineCommand({
   async handler(options) {
     const { org, listAll, format } = options;
 
-    // TODO: fix alias option
-    const { ownerId, appId } = await getOwnerAndApp(null, org, !listAll);
+    const { ownerId, appId } = await getOwnerAndApp(org, org == null && !listAll);
     const hooks = await getEmailhooks({ ownerId }).then(sendToApi);
 
     const formattedHooks = hooks

--- a/src/commands/notify-email/notify-email.docs.md
+++ b/src/commands/notify-email/notify-email.docs.md
@@ -37,7 +37,7 @@ clever notify-email add --notify <email-address|user-id|organisation> <name> [op
 |`--notify` `<email-address\|user-id\|organisation>`|Notify a user, a specific email address or the whole organisation (multiple values allowed, comma separated) **(required)**|
 |`--event` `<event-type>`|Restrict notifications to specific event types|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
-|`--service` `<service-id>`|Restrict notifications to specific applications and add-ons|
+|`--service` `<service-id>`|Restrict notifications to specific applications and add-ons (requires --org)|
 
 ## ➡️ `clever notify-email remove` <kbd>Since 0.6.1</kbd>
 

--- a/src/commands/webhooks/webhooks.add.command.js
+++ b/src/commands/webhooks/webhooks.add.command.js
@@ -34,8 +34,11 @@ export const webhooksAddCommand = defineCommand({
   async handler(options, name, hookUrl) {
     const { org, format, event: events, service } = options;
 
-    // TODO: fix alias option
-    const { ownerId, appId } = await getOwnerAndApp(null, org, !org && !service);
+    if (service != null && org == null) {
+      throw new Error('--org is required when using --service');
+    }
+
+    const { ownerId, appId } = await getOwnerAndApp(org, org == null && service == null);
 
     const body = {
       name,

--- a/src/commands/webhooks/webhooks.command.js
+++ b/src/commands/webhooks/webhooks.command.js
@@ -18,8 +18,7 @@ export const webhooksCommand = defineCommand({
   async handler(options) {
     const { org, listAll, format } = options;
 
-    // TODO: fix alias option
-    const { ownerId, appId } = await getOwnerAndApp(null, org, !listAll);
+    const { ownerId, appId } = await getOwnerAndApp(org, org == null && !listAll);
     const hooks = await getWebhooks({ ownerId }).then(sendToApi);
 
     const formattedHooks = hooks

--- a/src/commands/webhooks/webhooks.docs.md
+++ b/src/commands/webhooks/webhooks.docs.md
@@ -38,7 +38,7 @@ clever webhooks add <name> <url> [options]
 |`--event` `<event-type>`|Restrict notifications to specific event types|
 |`--format` `<format>`|Format of the body sent to the webhook ('raw', 'slack', 'gitter', or 'flowdock') (default: raw)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
-|`--service` `<service-id>`|Restrict notifications to specific applications and add-ons|
+|`--service` `<service-id>`|Restrict notifications to specific applications and add-ons (requires --org)|
 
 ## ➡️ `clever webhooks remove` <kbd>Since 0.6.0</kbd>
 

--- a/src/models/notification.js
+++ b/src/models/notification.js
@@ -10,11 +10,12 @@ export function getOrgaIdOrUserId(orgIdOrName) {
   return orgIdOrName == null ? User.getCurrentId() : Organisation.getId(orgIdOrName);
 }
 
-export async function getOwnerAndApp(alias, org, useLinkedApp) {
-  if (!useLinkedApp) {
-    const ownerId = await getOrgaIdOrUserId(org);
-    return { ownerId };
+export async function getOwnerAndApp(org, useLinkedApp) {
+  if (org != null) {
+    return { ownerId: await Organisation.getId(org) };
   }
-
-  return AppConfig.getAppDetails({ alias });
+  if (useLinkedApp) {
+    return AppConfig.getAppDetails({});
+  }
+  return { ownerId: await User.getCurrentId() };
 }


### PR DESCRIPTION
## Summary
- When creating a webhook or email notification with `--service`, the `--org` option is now required
- This prevents the confusing "You're not logged in" error when the service belongs to an organization

## Context
When a user tried to create a webhook with `--service app_xxx` where the app belongs to an organization, the CLI would resolve the owner as the user's personal space instead of the organization. This caused the API to return an error because the app wasn't found in the personal space.

## Test plan
- [x] `clever webhooks add test https://example.com --service app_xxx` → should error with "--org is required when using --service"
- [x] `clever webhooks add test https://example.com --service app_xxx --org <org>` → should work
- [x] `clever webhooks` (in a folder with linked app) → should list webhooks for linked app
- [x] `clever webhooks --list-all` → should list all webhooks for personal space
- [x] `clever webhooks --org <org>` → should list all webhooks for org