### PR TITLE
fix(deploy): prevent unwanted refs/remotes/origin/master creation

### DIFF
--- a/src/commands/deploy/deploy.command.js
+++ b/src/commands/deploy/deploy.command.js
@@ -3,6 +3,7 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { defineCommand } from '../../lib/define-command.js';
 import { defineOption } from '../../lib/define-option.js';
+import { slugify } from '../../lib/slugify.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import * as AppConfig from '../../models/app_configuration.js';
@@ -141,7 +142,7 @@ export const deployCommand = defineCommand({
            ${styleText('blue', '→ Pushing source code to Clever Cloud…')}
       `);
 
-    await git.push(appData.deployUrl, commitIdToPush, force).catch(async (e) => {
+    await git.push(appData.deployUrl, commitIdToPush, force, slugify(appData.alias)).catch(async (e) => {
       const isShallow = await git.isShallow();
       if (isShallow) {
         throw new Error(

--- a/src/models/git.js
+++ b/src/models/git.js
@@ -86,7 +86,7 @@ export async function isExistingTag(tag) {
   return tags.includes(tag);
 }
 
-export async function push(remoteUrl, branchRefspec, force) {
+export async function push(remoteUrl, branchRefspec, force, remoteName) {
   const repo = await getRepo();
   try {
     const push = await git.push({
@@ -95,6 +95,7 @@ export async function push(remoteUrl, branchRefspec, force) {
       url: remoteUrl,
       ref: branchRefspec,
       remoteRef: 'master',
+      remote: remoteName,
       force,
     });
     if (push.errors != null) {


### PR DESCRIPTION
Closes #933

## Summary

- Pass the correct remote name (slugified alias) to isomorphic-git's `push()` function
- Previously, when `remote` was not specified, isomorphic-git defaulted to `'origin'`, causing it to create/update `refs/remotes/origin/master` even when no `origin` remote existed

## Test plan

- [x] Create a fresh git repo with an `origin` remote pointing to GitHub
- [x] Link to a Clever Cloud app (creates a different remote name)
- [x] Run `clever deploy`
- [x] Verify `refs/remotes/origin/master` is NOT updated by the deploy
- [x] Verify the app's remote tracking ref IS updated correctly