### PR TITLE
ci(release): sync winget-pkgs fork before publishing to WinGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-node
+      - name: 'Sync winget-pkgs fork with upstream'
+        shell: bash
+        run: gh repo sync clevercloud-ci/winget-pkgs --source microsoft/winget-pkgs
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
       - name: 'Install WingetCreate'
         shell: powershell
         run: |


### PR DESCRIPTION
## Summary
- Add automatic sync of the `clevercloud-ci/winget-pkgs` fork with `microsoft/winget-pkgs` before running `wingetcreate`
- Prevents the "forked repository could not be synced with upstream" error that caused the 4.5.0 release to fail

## Test plan
- [ ] Verify the sync step runs successfully on next release