### PR TITLE
feat(config-provider): add commands to manage configuration providers

### DIFF
--- a/docs/llms-documentation.md
+++ b/docs/llms-documentation.md
@@ -591,6 +591,127 @@ clever config update [options]
     --name <name>                  Set application name
 ```
 
+## config-provider
+
+**Description:** Manage configuration providers
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider
+```
+
+### config-provider get
+
+**Description:** List environment variables of a configuration provider
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider get <addon-id|config-provider-id|addon-name> [options]
+```
+
+**Arguments**
+```
+addon-id|config-provider-id|addon-name    Add-on ID, real ID (config_xxx) or name (if unambiguous)
+```
+
+**Options**
+```
+-F, --format <format>                     Output format (human, json, shell) (default: human)
+```
+
+### config-provider import
+
+**Description:** Load environment variables from STDIN
+(WARNING: this deletes all current variables and replaces them with the new list loaded from STDIN)
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider import <addon-id|config-provider-id|addon-name> [options]
+```
+
+**Arguments**
+```
+addon-id|config-provider-id|addon-name    Add-on ID, real ID (config_xxx) or name (if unambiguous)
+```
+
+**Options**
+```
+-F, --format <format>                     Input format (name-equals-value, json) (default: name-equals-value)
+```
+
+### config-provider list
+
+**Description:** List configuration providers
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider list [options]
+```
+
+**Options**
+```
+-F, --format <format>    Output format (human, json) (default: human)
+```
+
+### config-provider open
+
+**Description:** Open the configuration provider in Clever Cloud Console
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider open <addon-id|config-provider-id|addon-name>
+```
+
+**Arguments**
+```
+addon-id|config-provider-id|addon-name    Add-on ID, real ID (config_xxx) or name (if unambiguous)
+```
+
+### config-provider rm
+
+**Description:** Remove an environment variable from a configuration provider
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider rm <addon-id|config-provider-id|addon-name> <variable-name>
+```
+
+**Arguments**
+```
+addon-id|config-provider-id|addon-name    Add-on ID, real ID (config_xxx) or name (if unambiguous)
+variable-name                             Name of the environment variable
+```
+
+### config-provider set
+
+**Description:** Add or update an environment variable named <variable-name> with the value <variable-value>
+
+**Since:** unreleased
+
+**Usage**
+```
+clever config-provider set <addon-id|config-provider-id|addon-name> <variable-name> <variable-value>
+```
+
+**Arguments**
+```
+addon-id|config-provider-id|addon-name    Add-on ID, real ID (config_xxx) or name (if unambiguous)
+variable-name                             Name of the environment variable
+variable-value                            Value of the environment variable
+```
+
 ## console
 
 **Description:** Open an application in the Console

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -22,6 +22,7 @@ These options are available for all commands:
 |[`clever applications`](./applications/applications.docs.md)|List linked applications|
 |[`clever cancel-deploy`](./cancel-deploy/cancel-deploy.docs.md)|Cancel an ongoing deployment|
 |[`clever config`](./config/config.docs.md)|Display or edit the configuration of your application|
+|[`clever config-provider`](./config-provider/config-provider.docs.md)|Manage configuration providers|
 |[`clever console`](./console/console.docs.md)|Open an application in the Console|
 |[`clever create`](./create/create.docs.md)|Create an application|
 |[`clever curl`](./curl/curl.docs.md)|Query Clever Cloud's API using Clever Tools credentials|

--- a/src/commands/config-provider/config-provider.args.js
+++ b/src/commands/config-provider/config-provider.args.js
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { defineArgument } from '../../lib/define-argument.js';
+
+export const configProviderIdOrNameArg = defineArgument({
+  schema: z.string(),
+  description: 'Add-on ID, real ID (config_xxx) or name (if unambiguous)',
+  placeholder: 'addon-id|config-provider-id|addon-name',
+});

--- a/src/commands/config-provider/config-provider.command.js
+++ b/src/commands/config-provider/config-provider.command.js
@@ -1,0 +1,10 @@
+import { defineCommand } from '../../lib/define-command.js';
+
+export const configProviderCommand = defineCommand({
+  description: 'Manage configuration providers',
+  since: 'unreleased',
+  options: {},
+  args: [],
+  // Parent command - no handler, only contains subcommands
+  handler: null,
+});

--- a/src/commands/config-provider/config-provider.docs.md
+++ b/src/commands/config-provider/config-provider.docs.md
@@ -1,0 +1,109 @@
+# 📖 `clever config-provider` command reference
+
+## ➡️ `clever config-provider` <kbd>Since unreleased</kbd>
+
+Manage configuration providers
+
+```bash
+clever config-provider
+```
+
+## ➡️ `clever config-provider get` <kbd>Since unreleased</kbd>
+
+List environment variables of a configuration provider
+
+```bash
+clever config-provider get <addon-id|config-provider-id|addon-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json, shell) (default: human)|
+
+## ➡️ `clever config-provider import` <kbd>Since unreleased</kbd>
+
+Load environment variables from STDIN
+(WARNING: this deletes all current variables and replaces them with the new list loaded from STDIN)
+
+```bash
+clever config-provider import <addon-id|config-provider-id|addon-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Input format (name-equals-value, json) (default: name-equals-value)|
+
+## ➡️ `clever config-provider list` <kbd>Since unreleased</kbd>
+
+List configuration providers
+
+```bash
+clever config-provider list [options]
+```
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+
+## ➡️ `clever config-provider open` <kbd>Since unreleased</kbd>
+
+Open the configuration provider in Clever Cloud Console
+
+```bash
+clever config-provider open <addon-id|config-provider-id|addon-name>
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+
+## ➡️ `clever config-provider rm` <kbd>Since unreleased</kbd>
+
+Remove an environment variable from a configuration provider
+
+```bash
+clever config-provider rm <addon-id|config-provider-id|addon-name> <variable-name>
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`variable-name`|Name of the environment variable|
+
+## ➡️ `clever config-provider set` <kbd>Since unreleased</kbd>
+
+Add or update an environment variable named <variable-name> with the value <variable-value>
+
+```bash
+clever config-provider set <addon-id|config-provider-id|addon-name> <variable-name> <variable-value>
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`variable-name`|Name of the environment variable|
+|`variable-value`|Value of the environment variable|

--- a/src/commands/config-provider/config-provider.get.command.js
+++ b/src/commands/config-provider/config-provider.get.command.js
@@ -1,0 +1,36 @@
+import { getConfigProviderEnv } from '@clevercloud/client/esm/api/v4/addon.js';
+import { toNameEqualsValueString } from '@clevercloud/client/esm/utils/env-vars.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import { resolveConfigProviderId } from '../../models/config-provider.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { envFormatOption } from '../global.options.js';
+import { configProviderIdOrNameArg } from './config-provider.args.js';
+
+export const configProviderGetCommand = defineCommand({
+  description: 'List environment variables of a configuration provider',
+  since: 'unreleased',
+  options: {
+    format: envFormatOption,
+  },
+  args: [configProviderIdOrNameArg],
+  async handler(options, addonIdOrRealIdOrName) {
+    const { format } = options;
+    const { realId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
+
+    // API returns an array of { name, value } objects
+    const envVars = await getConfigProviderEnv({ configurationProviderId: realId }).then(sendToApi);
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(envVars);
+        break;
+      case 'shell':
+        Logger.println(toNameEqualsValueString(envVars, { addExports: true }));
+        break;
+      case 'human':
+      default:
+        Logger.println(toNameEqualsValueString(envVars, { addExports: false }));
+    }
+  },
+});

--- a/src/commands/config-provider/config-provider.import.command.js
+++ b/src/commands/config-provider/config-provider.import.command.js
@@ -1,0 +1,40 @@
+import { updateConfigProviderEnv } from '@clevercloud/client/esm/api/v4/addon.js';
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { Logger } from '../../logger.js';
+import { resolveConfigProviderId } from '../../models/config-provider.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import * as variables from '../../models/variables.js';
+import { configProviderIdOrNameArg } from './config-provider.args.js';
+
+const importFormatOption = defineOption({
+  name: 'format',
+  schema: z.enum(['name-equals-value', 'json']).default('name-equals-value'),
+  description: 'Input format (name-equals-value, json)',
+  aliases: ['F'],
+  placeholder: 'format',
+});
+
+export const configProviderImportCommand = defineCommand({
+  description:
+    'Load environment variables from STDIN\n(WARNING: this deletes all current variables and replaces them with the new list loaded from STDIN)',
+  since: 'unreleased',
+  options: {
+    format: importFormatOption,
+  },
+  args: [configProviderIdOrNameArg],
+  async handler(options, addonIdOrRealIdOrName) {
+    const { format } = options;
+    const { realId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
+
+    // readVariablesFromStdin returns { NAME: "value" } format
+    // but the API expects [{ name, value }] format
+    const envVarsObject = await variables.readVariablesFromStdin(format);
+    const envVarsArray = Object.entries(envVarsObject).map(([name, value]) => ({ name, value }));
+
+    await updateConfigProviderEnv({ configurationProviderId: realId }, envVarsArray).then(sendToApi);
+
+    Logger.println('Environment variables have been set');
+  },
+});

--- a/src/commands/config-provider/config-provider.list.command.js
+++ b/src/commands/config-provider/config-provider.list.command.js
@@ -1,0 +1,45 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { findAddonsByAddonProvider } from '../../models/ids-resolver.js';
+import { humanJsonOutputFormatOption } from '../global.options.js';
+
+export const configProviderListCommand = defineCommand({
+  description: 'List configuration providers',
+  since: 'unreleased',
+  options: {
+    format: humanJsonOutputFormatOption,
+  },
+  args: [],
+  async handler(options) {
+    const { format } = options;
+    const deployed = await findAddonsByAddonProvider('config-provider');
+    const providersPerOwner = Object.groupBy(deployed, (provider) => provider.ownerId);
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(providersPerOwner);
+        break;
+      case 'human':
+      default:
+        if (deployed.length === 0) {
+          Logger.println(
+            `No configuration provider found, create one with ${styleText('blue', 'clever addon create config-provider')} command`,
+          );
+          return;
+        }
+
+        Logger.println(`Found ${deployed.length} configuration provider${deployed.length > 1 ? 's' : ''}:`);
+        Logger.println();
+
+        Object.values(providersPerOwner).forEach((providers) => {
+          Logger.println(`${styleText('bold', `${providers[0].ownerId} (${providers[0].ownerName})`)}`);
+          providers.forEach((provider) => {
+            Logger.println(`  ${provider.name} ${styleText('grey', `(${provider.realId})`)}`);
+          });
+          Logger.println();
+        });
+        break;
+    }
+  },
+});

--- a/src/commands/config-provider/config-provider.open.command.js
+++ b/src/commands/config-provider/config-provider.open.command.js
@@ -1,0 +1,17 @@
+import { config } from '../../config/config.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { styleText } from '../../lib/style-text.js';
+import { resolveConfigProviderId } from '../../models/config-provider.js';
+import { openBrowser } from '../../models/utils.js';
+import { configProviderIdOrNameArg } from './config-provider.args.js';
+
+export const configProviderOpenCommand = defineCommand({
+  description: 'Open the configuration provider in Clever Cloud Console',
+  since: 'unreleased',
+  options: {},
+  args: [configProviderIdOrNameArg],
+  async handler(_options, addonIdOrRealIdOrName) {
+    const { addonId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
+    await openBrowser(`${config.GOTO_URL}/${addonId}`, `Opening ${styleText('blue', addonId)} in the browser...`);
+  },
+});

--- a/src/commands/config-provider/config-provider.rm.command.js
+++ b/src/commands/config-provider/config-provider.rm.command.js
@@ -1,0 +1,25 @@
+import { getConfigProviderEnv, updateConfigProviderEnv } from '@clevercloud/client/esm/api/v4/addon.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import { resolveConfigProviderId } from '../../models/config-provider.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { envVariableNameArg } from '../global.args.js';
+import { configProviderIdOrNameArg } from './config-provider.args.js';
+
+export const configProviderRmCommand = defineCommand({
+  description: 'Remove an environment variable from a configuration provider',
+  since: 'unreleased',
+  options: {},
+  args: [configProviderIdOrNameArg, envVariableNameArg],
+  async handler(_options, addonIdOrRealIdOrName, varName) {
+    const { realId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
+
+    // API returns an array of { name, value } objects
+    const envVars = await getConfigProviderEnv({ configurationProviderId: realId }).then(sendToApi);
+    const filteredEnvVars = envVars.filter((v) => v.name !== varName);
+
+    await updateConfigProviderEnv({ configurationProviderId: realId }, filteredEnvVars).then(sendToApi);
+
+    Logger.println('Environment variable has been removed');
+  },
+});

--- a/src/commands/config-provider/config-provider.set.command.js
+++ b/src/commands/config-provider/config-provider.set.command.js
@@ -1,0 +1,37 @@
+import { getConfigProviderEnv, updateConfigProviderEnv } from '@clevercloud/client/esm/api/v4/addon.js';
+import { validateName } from '@clevercloud/client/esm/utils/env-vars.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import { resolveConfigProviderId } from '../../models/config-provider.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { envVariableNameArg, envVariableValueArg } from '../global.args.js';
+import { configProviderIdOrNameArg } from './config-provider.args.js';
+
+export const configProviderSetCommand = defineCommand({
+  description: 'Add or update an environment variable named <variable-name> with the value <variable-value>',
+  since: 'unreleased',
+  options: {},
+  args: [configProviderIdOrNameArg, envVariableNameArg, envVariableValueArg],
+  async handler(_options, addonIdOrRealIdOrName, varName, varValue) {
+    const nameIsValid = validateName(varName);
+    if (!nameIsValid) {
+      throw new Error(`Variable name '${varName}' is invalid`);
+    }
+
+    const { realId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
+
+    // API returns an array of { name, value } objects
+    const envVars = await getConfigProviderEnv({ configurationProviderId: realId }).then(sendToApi);
+    const existingIndex = envVars.findIndex((v) => v.name === varName);
+
+    if (existingIndex >= 0) {
+      envVars[existingIndex].value = varValue;
+    } else {
+      envVars.push({ name: varName, value: varValue });
+    }
+
+    await updateConfigProviderEnv({ configurationProviderId: realId }, envVars).then(sendToApi);
+
+    Logger.println('Environment variable has been set');
+  },
+});

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -11,6 +11,13 @@ import { addonRenameCommand } from './addon/addon.rename.command.js';
 import { applicationsCommand } from './applications/applications.command.js';
 import { applicationsListCommand } from './applications/applications.list.command.js';
 import { cancelDeployCommand } from './cancel-deploy/cancel-deploy.command.js';
+import { configProviderCommand } from './config-provider/config-provider.command.js';
+import { configProviderGetCommand } from './config-provider/config-provider.get.command.js';
+import { configProviderImportCommand } from './config-provider/config-provider.import.command.js';
+import { configProviderListCommand } from './config-provider/config-provider.list.command.js';
+import { configProviderOpenCommand } from './config-provider/config-provider.open.command.js';
+import { configProviderRmCommand } from './config-provider/config-provider.rm.command.js';
+import { configProviderSetCommand } from './config-provider/config-provider.set.command.js';
 import { configCommand } from './config/config.command.js';
 import { configGetCommand } from './config/config.get.command.js';
 import { configSetCommand } from './config/config.set.command.js';
@@ -190,6 +197,17 @@ export const globalCommands = {
       get: configGetCommand,
       set: configSetCommand,
       update: configUpdateCommand,
+    },
+  ],
+  'config-provider': [
+    configProviderCommand,
+    {
+      get: configProviderGetCommand,
+      import: configProviderImportCommand,
+      list: configProviderListCommand,
+      open: configProviderOpenCommand,
+      rm: configProviderRmCommand,
+      set: configProviderSetCommand,
     },
   ],
   console: consoleCommand,

--- a/src/models/config-provider.js
+++ b/src/models/config-provider.js
@@ -1,0 +1,34 @@
+import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+import { findAddonsByNameOrId } from './ids-resolver.js';
+import { sendToApi } from './send-to-api.js';
+
+/**
+ * Resolve a config provider ID from a name, ID or real ID
+ * @param {string} addonIdOrRealIdOrName The add-on ID (addon_xxx), real ID (config_xxx) or name
+ * @returns {Promise<{ ownerId: string, realId: string, addonId: string }>} The owner ID, real ID and addon ID
+ * @throws {Error} If the add-on is not found
+ * @throws {Error} If multiple add-ons are found with the same name
+ * @throws {Error} If the add-on is not a configuration provider
+ */
+export async function resolveConfigProviderId(addonIdOrRealIdOrName) {
+  const candidates = await findAddonsByNameOrId(addonIdOrRealIdOrName);
+
+  if (candidates.length === 0) {
+    throw new Error(`Config provider not found: ${addonIdOrRealIdOrName}`);
+  }
+
+  if (candidates.length > 1) {
+    throw new Error(`Ambiguous config provider name '${addonIdOrRealIdOrName}', please use the ID`);
+  }
+
+  const { ownerId, addonId, realId } = candidates[0];
+
+  // Verify that the addon is a config provider
+  const addon = await getAddon({ id: ownerId, addonId }).then(sendToApi);
+
+  if (addon.provider.id !== 'config-provider') {
+    throw new Error(`The add-on '${addonIdOrRealIdOrName}' is not a configuration provider`);
+  }
+
+  return { ownerId, realId, addonId };
+}


### PR DESCRIPTION
Closes #1027

## Context

Configuration providers are a special type of add-on on Clever Cloud that allow users to store and manage environment variables independently from applications. These variables can then be linked to one or more applications, making it easy to share configuration across multiple services.

Unlike regular add-ons (databases, caches, etc.), configuration providers don't run any service - they simply hold key-value pairs that get injected as environment variables into linked applications.

## Proposal

This PR adds a new `clever config-provider` command group to manage configuration providers from the CLI.

### Commands

| Command | Description |
|---------|-------------|
| `clever config-provider` | Display help (doc-only) |
| `clever config-provider list` | List all configuration providers |
| `clever config-provider get <id>` | List environment variables |
| `clever config-provider set <id> <name> <value>` | Add or update a variable |
| `clever config-provider rm <id> <name>` | Remove a variable |
| `clever config-provider import <id>` | Import variables from stdin |
| `clever config-provider open <id>` | Open in Clever Cloud Console |

### Design decisions

**Command structure**: We use a flat structure (`clever config-provider get/set/rm/...`) for simplicity and ease of use, similar to how `clever env` works for applications.

**Identifier support**: The `<id>` argument accepts three formats (similar to operators):
- Add-on ID: `addon_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
- Real ID (config provider ID): `config_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
- Add-on name (if unambiguous)

**Consistency**: The commands follow the same patterns as `clever env` and `clever addon env`:
- Same output formats (human, json, shell)
- Same import behavior (replaces all variables)
- Same error handling

Also, the list display follows the same format as the operators.

## QA Testing

```bash
# List all configuration providers
clever config-provider list
clever config-provider list --format json

# Test with different ID formats
clever config-provider get <addon-id>
clever config-provider get <config_xxx-real-id>
clever config-provider get <addon-name>

# Set and remove variables
clever config-provider set <id> MY_VAR "my value"
clever config-provider get <id>  # verify it's set
clever config-provider rm <id> MY_VAR
clever config-provider get <id>  # verify it's removed

# Import from stdin (replaces all variables)
echo 'FOO="bar"' | clever config-provider import <id>
echo '[{"name": "BAZ", "value": "qux"}]' | clever config-provider import <id> --format json

# Open in browser
clever config-provider open <id>
```

### Expected behavior
- All three ID formats (addon_id, config_id, name) should work
- Import replaces all existing variables (with warning in help text)
- Error if the add-on is not a configuration provider
- Error if name is ambiguous (multiple matches)