### PR TITLE
refactor(logger): remove lodash, add types

### DIFF
--- a/src/logger.types.d.ts
+++ b/src/logger.types.d.ts
@@ -1,0 +1,5 @@
+export interface ApiError {
+  id?: string;
+  message?: string;
+  fields?: Record<string, string>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "lib": ["ES2024", "ESNext.Collection"],
     "useUnknownInCatchVariables": false
   },
-  "include": ["scripts", "src/lib/define-**"],
+  "include": ["scripts", "src/lib/define-**", "src/logger.js"],
   "exclude": ["build", "docs", "node_modules", "scripts/generate-docs.js"]
 }


### PR DESCRIPTION
## Context

The logger module is imported throughout the codebase. Since it wasn't typechecked, **it was blocking the addition of many files to `tsconfig.json`**.

Other issues:
- **Lodash dependency**: used `_.map()`, `_.get()`, `_.repeat()`, `_.noop()`, `_.fromPairs()` for trivial operations that can be done with native JS
- **Dynamically generated code**: the `debug/info/warn/error` methods were generated via a lodash chain, making the code hard to read and impossible to type properly

## Changes

- **Add JSDoc types**: all functions are now typed with proper annotations
- **Add `logger.types.d.ts`**: defines the `ApiError` interface for API errors
- **Remove lodash**: replaced with native JS (`Object.entries()`, `' '.repeat()`, `instanceof`, etc.)
- **Explicit code**: each Logger method is now defined explicitly instead of being dynamically generated

## Later

This refactor is intentionally **iso-functional**. The goal is to clean up without going down an endless refactoring rabbit hole.

Possible improvements for later:
- Rename `Logger` to `logger` (lowercase convention for singletons) — not done because it would generate a large diff across all importing files, and we have several PRs in progress
- Use a more powerful logger shared across Clever Cloud JS projects