### PR TITLE
fix(tokens): fix token creation with default value (1y)

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -190,7 +190,9 @@ function convertOption(option) {
   }
   const optionDefault = getDefault(option.schema);
   if (optionDefault != null) {
-    cliparseConfig.default = optionDefault;
+    // Parse the default value through the schema to apply transforms
+    const parsed = option.schema.safeParse(optionDefault);
+    cliparseConfig.default = parsed.success ? parsed.data : optionDefault;
   }
   if (option.placeholder != null) {
     cliparseConfig.metavar = option.placeholder;
@@ -253,7 +255,9 @@ function convertArgument(arg) {
 
   const argDefault = getDefault(arg.schema);
   if (argDefault != null) {
-    cliparseConfig.default = argDefault;
+    // Parse the default value through the schema to apply transforms
+    const parsed = arg.schema.safeParse(argDefault);
+    cliparseConfig.default = parsed.success ? parsed.data : argDefault;
   } else if (!isRequired(arg.schema)) {
     cliparseConfig.default = '';
   }


### PR DESCRIPTION
Closes #1040

## Problem

Default values extracted from Zod schemas were used directly without passing through
schema transforms. When a schema defined both a default and a transform (e.g., the token
expiration duration with case normalization), the transform was never applied to the
default value.

This caused token creation to fail when relying on the default expiration value (1y).

## Solution

Parse default values through `safeParse` before passing them to cliparse. This ensures
transforms like case conversion or normalization are consistently applied, matching the
behavior when users explicitly provide values.