### PR TITLE
fix(addon): fix Matomo add-on creation

### DIFF
--- a/src/commands/addon/addon.create.command.js
+++ b/src/commands/addon/addon.create.command.js
@@ -20,12 +20,11 @@ import { addonNameArg, addonProviderArg } from './addon.args.js';
 const ADDON_PROVIDERS = {
   keycloak: {
     name: 'Keycloak',
-    isOperator: true,
+    operatorProvider: 'keycloak',
     postCreateInstructions: `Learn more about Keycloak on Clever Cloud: ${config.DOC_URL}/addons/keycloak/`,
   },
   kv: {
     name: 'Materia KV',
-    isOperator: false,
     status: 'beta',
     postCreateInstructions: (addonId) => dedent`
       ${styleText('yellow', "You can easily use Materia KV with 'redis-cli', with such commands:")}
@@ -36,22 +35,21 @@ const ADDON_PROVIDERS = {
   },
   'addon-matomo': {
     name: 'Matomo',
-    isOperator: true,
+    operatorProvider: 'matomo',
     postCreateInstructions: `Learn more about Matomo on Clever Cloud: ${config.DOC_URL}/addons/matomo/`,
   },
   metabase: {
     name: 'Metabase',
-    isOperator: true,
+    operatorProvider: 'metabase',
     postCreateInstructions: `Learn more about Metabase on Clever Cloud: ${config.DOC_URL}/addons/metabase/`,
   },
   otoroshi: {
     name: 'Otoroshi with LLM',
-    isOperator: true,
+    operatorProvider: 'otoroshi',
     postCreateInstructions: `Learn more about Otoroshi with LLM on Clever Cloud: ${config.DOC_URL}/addons/otoroshi/`,
   },
   'addon-pulsar': {
     name: 'Pulsar',
-    isOperator: false,
     postCreateInstructions: `Learn more about Pulsar on Clever Cloud: ${config.DOC_URL}/addons/pulsar/`,
   },
 };
@@ -187,12 +185,14 @@ export const addonCreateCommand = defineCommand({
     Logger.println(`Real ID: ${newAddon.realId}`);
     Logger.println(`Name: ${newAddon.name}`);
 
-    const operator = ADDON_PROVIDERS[providerName]?.isOperator
-      ? await getOperator({ provider: providerName, realId: newAddon.realId }).then(sendToApi)
-      : null;
+    const operatorProvider = ADDON_PROVIDERS[providerName]?.operatorProvider;
+    const operator =
+      operatorProvider != null
+        ? await getOperator({ provider: operatorProvider, realId: newAddon.realId }).then(sendToApi)
+        : null;
 
-    if (operator) {
-      if (operator.accessUrl) {
+    if (operator != null) {
+      if (operator.accessUrl != null) {
         Logger.println();
         Logger.println(`Your ${ADDON_PROVIDERS[providerName].name} is starting:`);
         Logger.println(` - Access it: ${operator.accessUrl}`);


### PR DESCRIPTION
Closes #1042

## Context

Creating a Matomo addon failed with a 404 error because the operator API path was constructed incorrectly. The v4 operator APIs use paths like `/v4/addon-providers/addon-${provider}/addons/...`, which adds an `addon-` prefix. For
providers like `addon-matomo`, passing the full provider name resulted in `addon-addon-matomo`.

This inconsistency in provider naming only affects Matomo among the operators (keycloak, metabase, otoroshi don't have the `addon-` prefix in their keys).

## Solution

Replace the `isOperator` boolean with an explicit `operatorProvider` string that specifies the exact provider name to use in API calls. This allows each provider to declare the correct string needed for the operator API path, avoiding the duplicate prefix issue.

- `addon-matomo` → `operatorProvider: 'matomo'`
- `keycloak` → `operatorProvider: 'keycloak'` (unchanged behavior)
- Non-operator addons (`kv`, `addon-pulsar`) simply omit the property