### PR TITLE
fix: respect CONFIGURATION_FILE env var override

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,7 +4,7 @@ import { readJsonSync, writeJson } from '../lib/fs.js';
 import { Logger } from '../logger.js';
 import { getConfigPath } from './paths.js';
 
-const CONFIGURATION_FILE = getConfigPath('clever-tools.json');
+const CONFIGURATION_FILE = process.env.CONFIGURATION_FILE ?? getConfigPath('clever-tools.json');
 
 const ConfigSchema = z
   .object({
@@ -56,9 +56,9 @@ function loadConfig() {
   /** @type {z.input<typeof ConfigSchema>} */
   const rawConfig = {
     ...configFromFile,
-    ...process.env,
     CONFIGURATION_FILE,
     EXPERIMENTAL_FEATURES_FILE: getConfigPath('clever-tools-experimental-features.json'),
+    ...process.env,
   };
 
   if (process.env.CLEVER_TOKEN != null && process.env.CLEVER_SECRET != null) {


### PR DESCRIPTION
## Summary
- The config refactor (`de9244ad`) introduced a regression where the `CONFIGURATION_FILE` env var was ignored
- The hardcoded constant was placed **after** `...process.env` in the spread, always overriding any env var value
- The module-level constant also never checked `process.env.CONFIGURATION_FILE`

## Fix
- The module-level constant now falls back to `getConfigPath()` only if the env var is not set
- Reordered the spread in `loadConfig()` so `...process.env` comes last and wins over defaults (also fixes `EXPERIMENTAL_FEATURES_FILE`)

## Test plan
- [x] Set `CONFIGURATION_FILE=/tmp/test-config.json` and verify clever-tools reads/writes to that path
- [x] Verify default behavior (no env var) is unchanged