### PR TITLE
chore(build): enable system CA trust in pkg binary

### DIFF
--- a/scripts/lib/build-binary.js
+++ b/scripts/lib/build-binary.js
@@ -34,5 +34,5 @@ export async function buildBinary(version, os) {
     highlight`=> Build script ${input} into binary ${output} for ${platform}-${arch} with Node.js ${nodeMajorVersion}`,
   );
 
-  await pkg.exec([input, '--target', target, '--output', output]);
+  await pkg.exec([input, '--target', target, '--output', output, '--options', 'use-system-ca']);
 }


### PR DESCRIPTION
## Summary

The CLI binary now uses `--options use-system-ca` when built with @yao-pkg/pkg to load CA certificates from the operating system certificate store.

This resolves SSL certificate chain errors (`Error: self signed certificate in certificate chain`) in enterprise environments where internal/corporate CAs are installed at the OS level but not recognized by Node.js's bundled Mozilla CAs.

## Technical Details

- **Node.js Feature**: `--use-system-ca` flag (available in Node.js 22.15.0+, 23.9.0+)
- **How it works**: Node.js loads system CAs from:
  - **Windows**: Windows Certificate Store
  - **macOS**: macOS Keychain  
  - **Linux**: `/etc/ssl/certs/`, `SSL_CERT_FILE`, or `SSL_CERT_DIR`
- **Build Tool**: @yao-pkg/pkg passes the option via `--options use-system-ca`
- **Project Node version**: 22.17.0 ✅ (compatible)

## Testing

The binary will now accept both bundled and system-installed CA certificates.