### PR TITLE
fix: use node pipelines instead of fetch

### DIFF
--- a/src/commands/database/database.backups.download.command.js
+++ b/src/commands/database/database.backups.download.command.js
@@ -1,6 +1,7 @@
 import { getBackups } from '@clevercloud/client/esm/api/v2/backups.js';
 import fs from 'node:fs';
-import { Writable } from 'node:stream';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { z } from 'zod';
 import { defineArgument } from '../../lib/define-argument.js';
 import { defineCommand } from '../../lib/define-command.js';
@@ -50,6 +51,7 @@ export const databaseBackupsDownloadCommand = defineCommand({
       throw new Error('Failed to download backup');
     }
 
-    await response.body.pipeTo(Writable.toWeb(output ? fs.createWriteStream(output) : process.stdout));
+    const nodeReadable = Readable.fromWeb(response.body);
+    await pipeline(nodeReadable, output ? fs.createWriteStream(output) : process.stdout);
   },
 });


### PR DESCRIPTION
## Fix: memory buildup during `database backups download` when piping to stdout

### Problem

When piping `clever database backups download` to another process (e.g. `pg_restore`), the Node.js process memory (RSS) grows unboundedly until the machine runs out of RAM.

```bash
# This causes the node process to consume all available memory
clever database backups download <db-id> <backup-id> | pg_restore --no-owner -d <target_db>
```

On machines with limited RAM, this makes it impossible to stream large database backups directly to `pg_restore`, even though the command is designed to stream.

### Root cause

The current implementation uses `response.body.pipeTo(Writable.toWeb(process.stdout))`, which bridges the Web Streams API (`fetch` response body) to Node.js streams via `Writable.toWeb()`. When the downstream consumer (`pg_restore`) is slower than the network download, backpressure does not propagate tightly enough across the Web Streams ↔ Node.js Streams bridge, causing internal buffers to accumulate in memory.

**Before:**
```javascript
await response.body.pipeTo(Writable.toWeb(output ? fs.createWriteStream(output) : process.stdout));
```

### Fix

Replace with `Readable.fromWeb()` + `stream.pipeline()`, which stays entirely in the Node.js streams world where backpressure is handled natively:

**After:**
```javascript
const nodeReadable = Readable.fromWeb(response.body);
await pipeline(nodeReadable, output ? fs.createWriteStream(output) : process.stdout);
```

### How I diagnosed this

Monitored RSS (Resident Set Size) of both `node` and `pg_restore` processes during the download:

```bash
while true; do
  echo "=== $(date) ==="
  ps -o pid,rss,vsz,comm -p $(pgrep -f "clever database|pg_restore" | tr '\n' ',') 2>/dev/null
  sleep 2
done
```

Observed the `node` process RSS growing from ~50MB to hundreds of MB and beyond, while `pg_restore` RSS remained stable. This confirmed the issue is on the clever-tools side, not `pg_restore`.