### PR TITLE
feat(ssh): add interactive instance selection and --command option

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -3065,6 +3065,7 @@ clever ssh [options]
 ```
 -a, --alias <alias>                    Short name for the application
     --app <app-id|app-name>            Application to manage by its ID (or name, if unambiguous)
+-c, --command <command>                Execute a command on the remote instance and exit
 -i, --identity-file <identity-file>    SSH identity file
 ```
 

--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -1,5 +1,6 @@
 import { getAllInstances } from '@clevercloud/client/esm/api/v2/application.js';
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { config } from '../../config/config.js';
 import { defineCommand } from '../../lib/define-command.js';
@@ -20,12 +21,19 @@ export const sshCommand = defineCommand({
       aliases: ['i'],
       placeholder: 'identity-file',
     }),
+    command: defineOption({
+      name: 'command',
+      schema: z.string().optional(),
+      description: 'Execute a command on the remote instance and exit',
+      aliases: ['c'],
+      placeholder: 'command',
+    }),
     alias: aliasOption,
     app: appIdOrNameOption,
   },
   args: [],
   async handler(options) {
-    const { alias, app: appIdOrName, identityFile } = options;
+    const { alias, app: appIdOrName, identityFile, command } = options;
     const { appId, ownerId } = await Application.resolveId(appIdOrName, alias);
 
     const instances = await getAllInstances({ id: ownerId, appId }).then(sendToApi);
@@ -51,16 +59,64 @@ export const sshCommand = defineCommand({
 
     const sshParams = [];
     // -t: force PTY allocation (SSH skips it by default because appId is passed as a command for gateway routing)
-    sshParams.push('-t');
+    if (command == null) {
+      sshParams.push('-t');
+    }
     if (identityFile != null) {
       sshParams.push('-i', identityFile);
     }
     sshParams.push(config.SSH_GATEWAY, sshTarget);
 
-    return new Promise((resolve, reject) => {
-      const sshProcess = spawn('ssh', sshParams, { stdio: 'inherit' });
-      sshProcess.on('exit', resolve);
-      sshProcess.on('error', reject);
+    // Interactive session mode (spawn SSH with inherited stdio)
+    if (command == null) {
+      return new Promise((resolve, reject) => {
+        const sshProcess = spawn('ssh', sshParams, { stdio: 'inherit' });
+        sshProcess.on('exit', resolve);
+        sshProcess.on('error', reject);
+      });
+    }
+
+    // Single command mode (pipe stdio to filter gateway noise via a marker)
+    const sshProcess = spawn('ssh', sshParams, { stdio: 'pipe' });
+
+    // We can't pass the command directly via `ssh gateway 'cmd'` because appId already occupies
+    // the remote command slot (used by the gateway for routing). So we write into stdin and use
+    // a marker to delimit the start of real output from gateway/login noise.
+    const marker = `__CLEVER_${randomUUID()}__`;
+    sshProcess.stdin.write(`echo '${marker}'\n`);
+
+    // `exec $SHELL --login -c` ensures the full login environment is loaded (.bashrc, env vars)
+    // while keeping stdout clean (no PTY = no prompt/ANSI noise).
+    const escapedCommand = command.replaceAll("'", "'\\''");
+    sshProcess.stdin.write(`exec $SHELL --login -c '${escapedCommand}'\n`);
+    sshProcess.stdin.end();
+
+    // Skip gateway/login noise on both stdout and stderr, stream after the marker
+    let started = false;
+    let buf = '';
+    sshProcess.stdout.on('data', (chunk) => {
+      if (started) {
+        process.stdout.write(chunk);
+        return;
+      }
+      buf += chunk.toString();
+      const idx = buf.indexOf(marker + '\n');
+      if (idx !== -1) {
+        started = true;
+        const rest = buf.slice(idx + marker.length + 1);
+        if (rest) process.stdout.write(rest);
+        buf = '';
+      }
     });
+
+    // Discard stderr noise before the marker, forward after
+    sshProcess.stderr.on('data', (chunk) => {
+      if (started) {
+        process.stderr.write(chunk);
+      }
+    });
+
+    const exitCode = await new Promise((resolve) => sshProcess.on('exit', resolve));
+    process.exit(exitCode);
   },
 });

--- a/src/commands/ssh/ssh.docs.md
+++ b/src/commands/ssh/ssh.docs.md
@@ -14,4 +14,5 @@ clever ssh [options]
 |---|---|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
+|`-c`, `--command` `<command>`|Execute a command on the remote instance and exit|
 |`-i`, `--identity-file` `<identity-file>`|SSH identity file|


### PR DESCRIPTION
## Context

The SSH proxy's built-in instance selection relies on a raw number input, which is a poor UX. Additionally, this mechanism is incompatible with non-interactive command execution (piped stdin). Both issues are solved by moving instance selection client-side via the API.

## Proposal

Three incremental changes:

1. **Refactor SSH params construction** — build the params array progressively to prepare for conditional flags (`-t`, `-i`, target)

2. **Client-side instance selection** — query running instances via the API instead of relying on the SSH proxy's number-based prompt:
   - Single instance → connect directly
   - Multiple instances in TTY → interactive select prompt
   - Multiple instances in non-TTY → error out
   - No instances → error out

3. **`-c, --command` option** — execute a single command on the remote instance and exit. Since the gateway uses the remote command slot for routing (appId), the command is written to stdin. A UUID marker delimits real output from gateway/login noise. PTY allocation is skipped in this mode to keep stdout clean.

## How to review

All changes are in `src/commands/ssh/ssh.command.js`:
- Start with the refactor (param building logic)
- Then the instance selection block (API call + prompt)
- Then the command execution branch (marker-based output filtering)

## How to test

- `clever ssh` with a single running instance → connects directly
- `clever ssh` with multiple instances → shows a selection prompt
- `clever ssh -c 'echo $APP_ID'` → prints the command output and exits
- `clever ssh -c 'echo $APP_ID'` with multiple instances → prompts then executes
- Pipe mode: `clever ssh -c 'echo $APP_ID' | cat` → works without TTY