### PR TITLE
feat(drain): add --addon option to target add-on drains

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1048,6 +1048,7 @@ clever drain [options]
 
 **Options**
 ```
+    --addon <addon-id>         Add-on ID or real ID
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 -F, --format <format>          Output format (human, json) (default: human)
@@ -1072,6 +1073,7 @@ drain-url                            Drain URL
 
 **Options**
 ```
+    --addon <addon-id>               Add-on ID or real ID
 -a, --alias <alias>                  Short name for the application
 -k, --api-key <api-key>              API key (for newrelic)
     --app <app-id|app-name>          Application to manage by its ID (or name, if unambiguous)
@@ -1099,6 +1101,7 @@ drain-id                       Drain ID
 
 **Options**
 ```
+    --addon <addon-id>         Add-on ID or real ID
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 ```
@@ -1121,6 +1124,7 @@ drain-id                       Drain ID
 
 **Options**
 ```
+    --addon <addon-id>         Add-on ID or real ID
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 ```
@@ -1143,6 +1147,7 @@ drain-id                       Drain ID
 
 **Options**
 ```
+    --addon <addon-id>         Add-on ID or real ID
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 -F, --format <format>          Output format (human, json) (default: human)
@@ -1166,6 +1171,7 @@ drain-id                       Drain ID
 
 **Options**
 ```
+    --addon <addon-id>         Add-on ID or real ID
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 ```

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -370,7 +370,7 @@ addon-id                                Add-on ID or real ID
 **Options**
 ```
 -F, --format <format>                   Output format (human, json, shell) (default: human)
--o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous) (deprecated, organisation is now resolved automatically)
 ```
 
 ### addon list
@@ -797,7 +797,7 @@ database-id|addon-id                    Any database ID (format: addon_UUID, pos
 **Options**
 ```
 -F, --format <format>                   Output format (human, json) (default: human)
--o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous) (deprecated, organisation is now resolved automatically)
 ```
 
 #### database backups download
@@ -819,7 +819,7 @@ backup-id                               A Database backup ID (format: UUID)
 
 **Options**
 ```
--o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous) (deprecated, organisation is now resolved automatically)
     --output, --out <file-path>         Redirect the output of the command in a file
 ```
 

--- a/src/clever-client/drains.js
+++ b/src/clever-client/drains.js
@@ -1,10 +1,10 @@
 // TODO: Move this to the Clever Cloud JS Client
 
 /**
- * GET /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains?status={status}&executionStatus={executionStatus}&executionStatusNotIn={executionStatusNotIn}
+ * GET /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains?status={status}&executionStatus={executionStatus}&executionStatusNotIn={executionStatusNotIn}
  * @param {Object} params
  * @param {String} params.ownerId
- * @param {String} params.applicationId
+ * @param {String} params.resourceId
  * @param {String} params.status
  * @param {String} params.executionStatus
  * @param {String} params.executionStatusNotIn
@@ -13,7 +13,7 @@ export function getDrains(params) {
   // no multipath for /self or /organisations/{id}
   return Promise.resolve({
     method: 'get',
-    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains`,
+    url: `/v4/drains/organisations/${params.ownerId}/resources/${params.resourceId}/drains`,
     headers: { Accept: 'application/json' },
     queryParams: {
       status: params.status,
@@ -25,85 +25,85 @@ export function getDrains(params) {
 }
 
 /**
- * POST /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains
+ * POST /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains
  * @param {Object} params
  * @param {String} params.ownerId
- * @param {String} params.applicationId
+ * @param {String} params.resourceId
  * @param {Object} params.body
  */
 export function createDrain(params) {
   // no multipath for /self or /organisations/{id}
   return Promise.resolve({
     method: 'post',
-    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains`,
+    url: `/v4/drains/organisations/${params.ownerId}/resources/${params.resourceId}/drains`,
     headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
     body: params.body,
   });
 }
 
 /**
- * DELETE /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains/{drainId}
+ * DELETE /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains/{drainId}
  * @param {Object} params
  * @param {String} params.ownerId
- * @param {String} params.applicationId
+ * @param {String} params.resourceId
  * @param {String} params.drainId
  */
 export function deleteDrain(params) {
   // no multipath for /self or /organisations/{id}
   return Promise.resolve({
     method: 'delete',
-    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains/${params.drainId}`,
+    url: `/v4/drains/organisations/${params.ownerId}/resources/${params.resourceId}/drains/${params.drainId}`,
     headers: { Accept: 'application/json' },
     // no body
   });
 }
 
 /**
- * GET /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains/{drainId}
+ * GET /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains/{drainId}
  * @param {Object} params
  * @param {String} params.ownerId
- * @param {String} params.applicationId
+ * @param {String} params.resourceId
  * @param {String} params.drainId
  */
 export function getDrain(params) {
   // no multipath for /self or /organisations/{id}
   return Promise.resolve({
     method: 'get',
-    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains/${params.drainId}`,
+    url: `/v4/drains/organisations/${params.ownerId}/resources/${params.resourceId}/drains/${params.drainId}`,
     headers: { Accept: 'application/json' },
     // no body
   });
 }
 
 /**
- * PUT /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains/{drainId}/disable
+ * PUT /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains/{drainId}/disable
  * @param {Object} params
  * @param {String} params.ownerId
- * @param {String} params.applicationId
+ * @param {String} params.resourceId
  * @param {String} params.drainId
  */
 export function disableDrain(params) {
   // no multipath for /self or /organisations/{id}
   return Promise.resolve({
     method: 'put',
-    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains/${params.drainId}/disable`,
+    url: `/v4/drains/organisations/${params.ownerId}/resources/${params.resourceId}/drains/${params.drainId}/disable`,
     headers: { Accept: 'application/json' },
     // no body
   });
 }
 
 /**
- * PUT /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains/{drainId}/enable
+ * PUT /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains/{drainId}/enable
  * @param {Object} params
  * @param {String} params.ownerId
- * @param {String} params.applicationId
+ * @param {String} params.resourceId
  * @param {String} params.drainId
  */
 export function enableDrain(params) {
   // no multipath for /self or /organisations/{id}
   return Promise.resolve({
     method: 'put',
-    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains/${params.drainId}/enable`,
+    url: `/v4/drains/organisations/${params.ownerId}/resources/${params.resourceId}/drains/${params.drainId}/enable`,
     headers: { Accept: 'application/json' },
     // no body
   });

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -8,7 +8,7 @@ import { JsonArray } from '../../models/json-array.js';
 import { getHostAndTokens } from '../../models/send-to-api.js';
 import { truncateWithEllipsis } from '../../models/utils.js';
 import {
-  addonIdOption,
+  addonIdOrRealIdOption,
   afterOption,
   aliasOption,
   appIdOrNameOption,
@@ -79,7 +79,7 @@ export const accesslogsCommand = defineCommand({
     format: logsFormatOption,
     before: beforeOption,
     after: afterOption,
-    addon: addonIdOption,
+    addon: addonIdOrRealIdOption,
   },
   args: [],
   async handler(options) {

--- a/src/commands/addon/addon.docs.md
+++ b/src/commands/addon/addon.docs.md
@@ -83,7 +83,7 @@ clever addon env <addon-id> [options]
 |Name|Description|
 |---|---|
 |`-F`, `--format` `<format>`|Output format (human, json, shell) (default: human)|
-|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous) *(deprecated, organisation is now resolved automatically)*|
 
 ## ➡️ `clever addon list` <kbd>Since 0.2.3</kbd>
 

--- a/src/commands/addon/addon.env.command.js
+++ b/src/commands/addon/addon.env.command.js
@@ -4,8 +4,7 @@ import { z } from 'zod';
 import { defineArgument } from '../../lib/define-argument.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
-import { findOwnerId } from '../../models/addon.js';
-import { resolveAddonId } from '../../models/ids-resolver.js';
+import { resolveAddon } from '../../models/ids-resolver.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import { envFormatOption, orgaIdOrNameOption } from '../global.options.js';
 
@@ -13,7 +12,7 @@ export const addonEnvCommand = defineCommand({
   description: 'List environment variables for an add-on',
   since: '2.11.0',
   options: {
-    org: orgaIdOrNameOption,
+    org: { ...orgaIdOrNameOption, deprecated: 'organisation is now resolved automatically' },
     format: envFormatOption,
   },
   args: [
@@ -24,10 +23,9 @@ export const addonEnvCommand = defineCommand({
     }),
   ],
   async handler(options, addonIdOrRealId) {
-    const { org, format } = options;
+    const { format } = options;
 
-    const addonId = await resolveAddonId(addonIdOrRealId);
-    const ownerId = await findOwnerId(org, addonId);
+    const { ownerId, addonId } = await resolveAddon(addonIdOrRealId);
 
     const envFromAddon = await getAllEnvVars({ id: ownerId, addonId }).then(sendToApi);
 

--- a/src/commands/database/database.backups.command.js
+++ b/src/commands/database/database.backups.command.js
@@ -2,8 +2,7 @@ import { getBackups } from '@clevercloud/client/esm/api/v2/backups.js';
 import { formatTable } from '../../format-table.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
-import { findOwnerId } from '../../models/addon.js';
-import { resolveAddonId, resolveRealId } from '../../models/ids-resolver.js';
+import { resolveAddon } from '../../models/ids-resolver.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
 import { databaseIdArg } from './database.args.js';
@@ -12,16 +11,14 @@ export const databaseBackupsCommand = defineCommand({
   description: 'List available database backups',
   since: '2.10.0',
   options: {
-    org: orgaIdOrNameOption,
+    org: { ...orgaIdOrNameOption, deprecated: 'organisation is now resolved automatically' },
     format: humanJsonOutputFormatOption,
   },
   args: [databaseIdArg],
   async handler(options, addonIdOrRealId) {
-    const { org, format } = options;
+    const { format } = options;
 
-    const realId = await resolveRealId(addonIdOrRealId);
-    const addonId = await resolveAddonId(addonIdOrRealId);
-    const ownerId = await findOwnerId(org, realId);
+    const { ownerId, addonId, realId } = await resolveAddon(addonIdOrRealId);
 
     const backups = await getBackups({ ownerId, ref: realId }).then(sendToApi);
 

--- a/src/commands/database/database.backups.download.command.js
+++ b/src/commands/database/database.backups.download.command.js
@@ -6,8 +6,7 @@ import { z } from 'zod';
 import { defineArgument } from '../../lib/define-argument.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { defineOption } from '../../lib/define-option.js';
-import { findOwnerId } from '../../models/addon.js';
-import { resolveRealId } from '../../models/ids-resolver.js';
+import { resolveAddon } from '../../models/ids-resolver.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import { orgaIdOrNameOption } from '../global.options.js';
 import { databaseIdArg } from './database.args.js';
@@ -23,7 +22,7 @@ export const databaseBackupsDownloadCommand = defineCommand({
       aliases: ['out'],
       placeholder: 'file-path',
     }),
-    org: orgaIdOrNameOption,
+    org: { ...orgaIdOrNameOption, deprecated: 'organisation is now resolved automatically' },
   },
   args: [
     databaseIdArg,
@@ -34,12 +33,11 @@ export const databaseBackupsDownloadCommand = defineCommand({
     }),
   ],
   async handler(options, addonIdOrRealId, backupId) {
-    const { org, output } = options;
+    const { output } = options;
 
-    const addonId = await resolveRealId(addonIdOrRealId);
-    const ownerId = await findOwnerId(org, addonId);
+    const { ownerId, realId } = await resolveAddon(addonIdOrRealId);
 
-    const backups = await getBackups({ ownerId, ref: addonId }).then(sendToApi);
+    const backups = await getBackups({ ownerId, ref: realId }).then(sendToApi);
     const backup = backups.find((backup) => backup.backup_id === backupId);
 
     if (backup == null) {

--- a/src/commands/database/database.docs.md
+++ b/src/commands/database/database.docs.md
@@ -27,7 +27,7 @@ clever database backups <database-id|addon-id> [options]
 |Name|Description|
 |---|---|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
-|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous) *(deprecated, organisation is now resolved automatically)*|
 
 ## ➡️ `clever database backups download` <kbd>Since 2.10.0</kbd>
 
@@ -48,5 +48,5 @@ clever database backups download <database-id|addon-id> <backup-id> [options]
 
 |Name|Description|
 |---|---|
-|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous) *(deprecated, organisation is now resolved automatically)*|
 |`--output`, `--out` `<file-path>`|Redirect the output of the command in a file|

--- a/src/commands/drain/drain.command.js
+++ b/src/commands/drain/drain.command.js
@@ -1,26 +1,30 @@
 import { getDrains } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
-import * as Application from '../../models/application.js';
-import { formatDrain } from '../../models/drain.js';
+import { formatDrain, resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import { aliasOption, appIdOrNameOption, humanJsonOutputFormatOption } from '../global.options.js';
+import {
+  addonIdOrRealIdOption,
+  aliasOption,
+  appIdOrNameOption,
+  humanJsonOutputFormatOption,
+} from '../global.options.js';
 
 export const drainCommand = defineCommand({
   description: 'Manage drains',
   since: '0.9.0',
   options: {
     alias: aliasOption,
-    app: appIdOrNameOption,
+    appIdOrName: appIdOrNameOption,
+    addonIdOrRealId: addonIdOrRealIdOption,
     format: humanJsonOutputFormatOption,
   },
   args: [],
   async handler(options) {
-    const { alias, app: appIdOrName, format } = options;
+    const { alias, appIdOrName, addonIdOrRealId, format } = options;
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
-
-    const drains = await getDrains({ ownerId, applicationId }).then(sendToApi);
+    const drains = await getDrains({ ownerId, resourceId }).then(sendToApi);
 
     switch (format) {
       case 'json': {
@@ -30,7 +34,8 @@ export const drainCommand = defineCommand({
       case 'human':
       default: {
         if (drains.length === 0) {
-          Logger.println(`There are no drains for ${applicationId}`);
+          const resourceLabel = addonIdOrRealId ?? appIdOrName ?? resourceId;
+          Logger.println(`There are no drains for ${resourceLabel}`);
           return;
         }
 

--- a/src/commands/drain/drain.create.command.js
+++ b/src/commands/drain/drain.create.command.js
@@ -5,10 +5,9 @@ import { defineCommand } from '../../lib/define-command.js';
 import { defineOption } from '../../lib/define-option.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import * as Application from '../../models/application.js';
-import { DRAIN_TYPE_CLI_CODES, DRAIN_TYPES } from '../../models/drain.js';
+import { DRAIN_TYPE_CLI_CODES, DRAIN_TYPES, resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import { aliasOption, appIdOrNameOption } from '../global.options.js';
+import { addonIdOrRealIdOption, aliasOption, appIdOrNameOption } from '../global.options.js';
 
 export const drainCreateCommand = defineCommand({
   description: 'Create a drain',
@@ -50,7 +49,8 @@ export const drainCreateCommand = defineCommand({
       placeholder: 'sd-params',
     }),
     alias: aliasOption,
-    app: appIdOrNameOption,
+    appIdOrName: appIdOrNameOption,
+    addonIdOrRealId: addonIdOrRealIdOption,
   },
   args: [
     defineArgument({
@@ -65,12 +65,12 @@ export const drainCreateCommand = defineCommand({
     }),
   ],
   async handler(options, drainTypeCliCode, url) {
-    const { alias, app: appIdOrName } = options;
+    const { alias, appIdOrName, addonIdOrRealId } = options;
     const { username, password, apiKey, indexPrefix, rfc5424StructuredDataParameters } = options;
 
     const drainType = Object.values(DRAIN_TYPES).find((drainType) => drainType.cliCode === drainTypeCliCode);
 
-    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
     const body = {
       kind: 'LOG',
@@ -118,7 +118,7 @@ export const drainCreateCommand = defineCommand({
       }
     }
 
-    const drain = await createDrain({ ownerId, applicationId, body }).then(sendToApi);
+    const drain = await createDrain({ ownerId, resourceId, body }).then(sendToApi);
     Logger.printSuccess(`Drain ${styleText(['bold', 'green'], drain.id)} has been successfully created and enabled!`);
   },
 });

--- a/src/commands/drain/drain.disable.command.js
+++ b/src/commands/drain/drain.disable.command.js
@@ -2,9 +2,9 @@ import { disableDrain } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import * as Application from '../../models/application.js';
+import { resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import { aliasOption, appIdOrNameOption } from '../global.options.js';
+import { addonIdOrRealIdOption, aliasOption, appIdOrNameOption } from '../global.options.js';
 import { drainIdArg } from './drain.args.js';
 
 export const drainDisableCommand = defineCommand({
@@ -12,15 +12,15 @@ export const drainDisableCommand = defineCommand({
   since: '0.9.0',
   options: {
     alias: aliasOption,
-    app: appIdOrNameOption,
+    appIdOrName: appIdOrNameOption,
+    addonIdOrRealId: addonIdOrRealIdOption,
   },
   args: [drainIdArg],
   async handler(options, drainId) {
-    const { alias, app: appIdOrName } = options;
+    const { alias, appIdOrName, addonIdOrRealId } = options;
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
-
-    await disableDrain({ ownerId, applicationId, drainId }).then(sendToApi);
+    await disableDrain({ ownerId, resourceId, drainId }).then(sendToApi);
 
     Logger.printSuccess(`Drain ${styleText(['bold', 'green'], drainId)} has been successfully disabled!`);
   },

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -12,6 +12,7 @@ clever drain [options]
 
 |Name|Description|
 |---|---|
+|`--addon` `<addon-id>`|Add-on ID or real ID|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
@@ -35,6 +36,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 |Name|Description|
 |---|---|
+|`--addon` `<addon-id>`|Add-on ID or real ID|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`-k`, `--api-key` `<api-key>`|API key (for newrelic)|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
@@ -61,6 +63,7 @@ clever drain disable <drain-id> [options]
 
 |Name|Description|
 |---|---|
+|`--addon` `<addon-id>`|Add-on ID or real ID|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 
@@ -82,6 +85,7 @@ clever drain enable <drain-id> [options]
 
 |Name|Description|
 |---|---|
+|`--addon` `<addon-id>`|Add-on ID or real ID|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 
@@ -103,6 +107,7 @@ clever drain get <drain-id> [options]
 
 |Name|Description|
 |---|---|
+|`--addon` `<addon-id>`|Add-on ID or real ID|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
@@ -125,5 +130,6 @@ clever drain remove <drain-id> [options]
 
 |Name|Description|
 |---|---|
+|`--addon` `<addon-id>`|Add-on ID or real ID|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|

--- a/src/commands/drain/drain.enable.command.js
+++ b/src/commands/drain/drain.enable.command.js
@@ -2,9 +2,9 @@ import { enableDrain } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import * as Application from '../../models/application.js';
+import { resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import { aliasOption, appIdOrNameOption } from '../global.options.js';
+import { addonIdOrRealIdOption, aliasOption, appIdOrNameOption } from '../global.options.js';
 import { drainIdArg } from './drain.args.js';
 
 export const drainEnableCommand = defineCommand({
@@ -12,15 +12,15 @@ export const drainEnableCommand = defineCommand({
   since: '0.9.0',
   options: {
     alias: aliasOption,
-    app: appIdOrNameOption,
+    appIdOrName: appIdOrNameOption,
+    addonIdOrRealId: addonIdOrRealIdOption,
   },
   args: [drainIdArg],
   async handler(options, drainId) {
-    const { alias, app: appIdOrName } = options;
+    const { alias, appIdOrName, addonIdOrRealId } = options;
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
-
-    await enableDrain({ ownerId, applicationId, drainId }).then(sendToApi);
+    await enableDrain({ ownerId, resourceId, drainId }).then(sendToApi);
 
     Logger.printSuccess(`Drain ${styleText(['bold', 'green'], drainId)} has been successfully enabled!`);
   },

--- a/src/commands/drain/drain.get.command.js
+++ b/src/commands/drain/drain.get.command.js
@@ -1,10 +1,14 @@
 import { getDrain } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
-import * as Application from '../../models/application.js';
-import { formatDrain } from '../../models/drain.js';
+import { formatDrain, resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import { aliasOption, appIdOrNameOption, humanJsonOutputFormatOption } from '../global.options.js';
+import {
+  addonIdOrRealIdOption,
+  aliasOption,
+  appIdOrNameOption,
+  humanJsonOutputFormatOption,
+} from '../global.options.js';
 import { drainIdArg } from './drain.args.js';
 
 export const drainGetCommand = defineCommand({
@@ -12,16 +16,16 @@ export const drainGetCommand = defineCommand({
   since: '0.9.0',
   options: {
     alias: aliasOption,
-    app: appIdOrNameOption,
+    appIdOrName: appIdOrNameOption,
+    addonIdOrRealId: addonIdOrRealIdOption,
     format: humanJsonOutputFormatOption,
   },
   args: [drainIdArg],
   async handler(options, drainId) {
-    const { alias, app: appIdOrName, format } = options;
+    const { alias, appIdOrName, addonIdOrRealId, format } = options;
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
-
-    const drain = await getDrain({ ownerId, applicationId, drainId }).then(sendToApi);
+    const drain = await getDrain({ ownerId, resourceId, drainId }).then(sendToApi);
 
     switch (format) {
       case 'json': {

--- a/src/commands/drain/drain.remove.command.js
+++ b/src/commands/drain/drain.remove.command.js
@@ -2,9 +2,9 @@ import { deleteDrain } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import * as Application from '../../models/application.js';
+import { resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import { aliasOption, appIdOrNameOption } from '../global.options.js';
+import { addonIdOrRealIdOption, aliasOption, appIdOrNameOption } from '../global.options.js';
 import { drainIdArg } from './drain.args.js';
 
 export const drainRemoveCommand = defineCommand({
@@ -12,15 +12,15 @@ export const drainRemoveCommand = defineCommand({
   since: '0.9.0',
   options: {
     alias: aliasOption,
-    app: appIdOrNameOption,
+    appIdOrName: appIdOrNameOption,
+    addonIdOrRealId: addonIdOrRealIdOption,
   },
   args: [drainIdArg],
   async handler(options, drainId) {
-    const { alias, app: appIdOrName } = options;
+    const { alias, appIdOrName, addonIdOrRealId } = options;
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
-
-    await deleteDrain({ ownerId, applicationId, drainId }).then(sendToApi);
+    await deleteDrain({ ownerId, resourceId, drainId }).then(sendToApi);
     Logger.printSuccess(`Drain ${styleText(['bold', 'green'], drainId)} has been successfully removed!`);
   },
 });

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -44,7 +44,7 @@ export const afterOption = defineOption({
   placeholder: 'after',
 });
 
-export const addonIdOption = defineOption({
+export const addonIdOrRealIdOption = defineOption({
   name: 'addon',
   schema: z.string().optional(),
   description: 'Add-on ID or real ID',

--- a/src/commands/logs/logs.command.js
+++ b/src/commands/logs/logs.command.js
@@ -4,11 +4,11 @@ import { defineOption } from '../../lib/define-option.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import * as Application from '../../models/application.js';
-import { resolveOwnerId, resolveRealId } from '../../models/ids-resolver.js';
+import { resolveAddon } from '../../models/ids-resolver.js';
 import * as Log from '../../models/log.js';
 import { Deferred } from '../../models/utils.js';
 import {
-  addonIdOption,
+  addonIdOrRealIdOption,
   afterOption,
   aliasOption,
   appIdOrNameOption,
@@ -36,7 +36,7 @@ export const logsCommand = defineCommand({
     app: appIdOrNameOption,
     before: beforeOption,
     after: afterOption,
-    addon: addonIdOption,
+    addon: addonIdOrRealIdOption,
     format: logsFormatOption,
   },
   args: [],
@@ -57,8 +57,7 @@ export const logsCommand = defineCommand({
     const isForHuman = format === 'human';
 
     if (addonIdOrRealId != null) {
-      const realId = await resolveRealId(addonIdOrRealId);
-      const ownerId = await resolveOwnerId(realId);
+      const { ownerId, realId } = await resolveAddon(addonIdOrRealId);
       if (isForHuman) {
         Logger.println(styleText('blue', 'Waiting for addon logs…'));
       }

--- a/src/models/drain.js
+++ b/src/models/drain.js
@@ -1,3 +1,20 @@
+import * as Application from './application.js';
+import { resolveAddon } from './ids-resolver.js';
+
+export async function resolveDrainResource(alias, appIdOrName, addonIdOrRealId) {
+  if (addonIdOrRealId != null && (appIdOrName != null || alias != null)) {
+    throw new Error('`--addon` cannot be combined with `--app` or `--alias`');
+  }
+
+  if (addonIdOrRealId != null) {
+    const { ownerId, realId } = await resolveAddon(addonIdOrRealId);
+    return { ownerId, resourceId: realId };
+  }
+
+  const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
+  return { ownerId, resourceId: appId };
+}
+
 export const DRAIN_TYPES = {
   DATADOG: { apiCode: 'DATADOG', cliCode: 'datadog', label: 'Datadog' },
   ELASTICSEARCH: { apiCode: 'ELASTICSEARCH', cliCode: 'elasticsearch', label: 'Elasticsearch' },

--- a/src/models/ids-resolver.js
+++ b/src/models/ids-resolver.js
@@ -31,28 +31,17 @@ export async function resolveOwnerId(id) {
   return getIdFromCacheOrSummary((ids) => ids.owners[id]);
 }
 
-export async function resolveAddonId(id) {
-  const addonId = await getIdFromCacheOrSummary((ids) => {
-    return ids.addons[id] != null ? ids.addons[id].addonId : null;
+export async function resolveAddon(addonIdOrRealId) {
+  const result = await getIdFromCacheOrSummary((ids) => {
+    const addon = ids.addons[addonIdOrRealId];
+    if (addon == null) return null;
+    const ownerId = ids.owners[addon.realId];
+    return { ownerId, addonId: addon.addonId, realId: addon.realId };
   });
-
-  if (addonId != null) {
-    return addonId;
+  if (result == null) {
+    throw new Error(`Add-on ${addonIdOrRealId} does not exist`);
   }
-
-  throw new Error(`Add-on ${id} does not exist`);
-}
-
-export async function resolveRealId(id) {
-  const realId = await getIdFromCacheOrSummary((ids) => {
-    return ids.addons[id] != null ? ids.addons[id].realId : null;
-  });
-
-  if (realId != null) {
-    return realId;
-  }
-
-  throw new Error(`Add-on ${id} does not exist foo`);
+  return result;
 }
 
 async function getIdFromCacheOrSummary(callback) {


### PR DESCRIPTION
## Context

The backend drain API (ovd!1778) now supports generic resource IDs instead of application-only IDs, enabling drain management on add-ons. This PR adapts the CLI to leverage this capability.

This work was initiated by @KannarFr and has been restructured into incremental refactoring steps to align with the current codebase conventions.

## Proposal

- Unify addon resolution into a single `resolveAddon()` function in `ids-resolver.js` returning `{ownerId, addonId, realId}`
- Update all drain API endpoints from `/applications/{applicationId}` to `/resources/{resourceId}`
- Add `resolveDrainResource()` helper for transparent app or addon resolution
- Add `--addon` option to all drain subcommands (`drain`, `create`, `disable`, `enable`, `get`, `remove`)
- `--addon` and `--app`/`--alias` are mutually exclusive

## How to test

- [x] `clever drain --addon <addon-id>` — list drains for an addon by ID
- [x] `clever drain --addon <addon-real-id>` — list drains for an addon by real ID
- [x] `clever drain --app <app>` — backward compat still works
- [x] `clever drain --alias <alias>` — list drains for a linked app by alias
- [x] `clever drain` — list drains for the default linked app
- [x] `clever drain create --addon <addon-id> datadog <url>` — create drain on addon
- [x] `--addon` and `--app` are mutually exclusive (error when both provided)
- [x] `npm run validate` passes