### PR TITLE
fix(drain): add type in argument description

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1066,7 +1066,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 **Arguments**
 ```
-drain-type                           No description available
+drain-type                           Drain type (datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)
 drain-url                            Drain URL
 ```
 

--- a/src/commands/drain/drain.create.command.js
+++ b/src/commands/drain/drain.create.command.js
@@ -55,7 +55,7 @@ export const drainCreateCommand = defineCommand({
   args: [
     defineArgument({
       schema: z.string(),
-      description: 'No description available',
+      description: `Drain type (${DRAIN_TYPE_CLI_CODES.join(', ')})`,
       placeholder: 'drain-type',
       complete: DRAIN_TYPE_CLI_CODES,
     }),

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -28,7 +28,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 |Name|Description|
 |---|---|
-|`drain-type`|No description available|
+|`drain-type`|Drain type (datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)|
 |`drain-url`|Drain URL|
 
 ### ⚙️ Options


### PR DESCRIPTION
This pull request improves the clarity of the `drain-type` argument documentation for the `clever drain create` command by specifying the possible drain types. This change is reflected consistently across the CLI documentation, code, and reference materials.

Documentation updates:

* Updated the description of the `drain-type` argument in `skills/clever-tools/references/full-documentation.md` to list all supported drain types.
* Updated the description of the `drain-type` argument in `src/commands/drain/drain.docs.md` to specify the supported drain types.

Code improvements:

* Updated the `drainCreateCommand` argument description in `src/commands/drain/drain.create.command.js` to dynamically include the list of supported drain types.