### PR TITLE
feat(drain): add test-command subcommand

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1170,6 +1170,28 @@ drain-id                       Drain ID
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 ```
 
+### drain test-command
+
+**Description:** Get a ready-to-execute shell command to test a drain recipient
+
+**Since:** 4.8.0
+
+**Usage**
+```
+clever drain test-command <drain-id> [options]
+```
+
+**Arguments**
+```
+drain-id                       Drain ID
+```
+
+**Options**
+```
+-a, --alias <alias>            Short name for the application
+    --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
+```
+
 ## emails
 
 **Description:** Manage email addresses of the current user

--- a/src/clever-client/drains.js
+++ b/src/clever-client/drains.js
@@ -108,3 +108,20 @@ export function enableDrain(params) {
     // no body
   });
 }
+
+/**
+ * GET /v4/drains/organisations/{ownerId}/applications/{applicationId}/drains/{drainId}/test-command
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.applicationId
+ * @param {String} params.drainId
+ */
+export function getDrainTestCommand(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/drains/organisations/${params.ownerId}/applications/${params.applicationId}/drains/${params.drainId}/test-command`,
+    headers: { Accept: 'text/plain' },
+    // no body
+  });
+}

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -127,3 +127,24 @@ clever drain remove <drain-id> [options]
 |---|---|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
+
+## ➡️ `clever drain test-command` <kbd>Since 4.8.0</kbd>
+
+Get a ready-to-execute shell command to test a drain recipient
+
+```bash
+clever drain test-command <drain-id> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`drain-id`|Drain ID|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-a`, `--alias` `<alias>`|Short name for the application|
+|`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|

--- a/src/commands/drain/drain.test-command.command.js
+++ b/src/commands/drain/drain.test-command.command.js
@@ -1,0 +1,26 @@
+import { getDrainTestCommand } from '../../clever-client/drains.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import * as Application from '../../models/application.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { aliasOption, appIdOrNameOption } from '../global.options.js';
+import { drainIdArg } from './drain.args.js';
+
+export const drainTestCommandCommand = defineCommand({
+  description: 'Get a ready-to-execute shell command to test a drain recipient',
+  since: '4.8.0',
+  options: {
+    app: appIdOrNameOption,
+    alias: aliasOption,
+  },
+  args: [drainIdArg],
+  async handler(options, drainId) {
+    const { app: appIdOrName, alias } = options;
+
+    const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
+
+    const testCommand = await getDrainTestCommand({ ownerId, applicationId, drainId }).then(sendToApi);
+
+    Logger.println(testCommand);
+  },
+});

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -45,6 +45,7 @@ import { drainDisableCommand } from './drain/drain.disable.command.js';
 import { drainEnableCommand } from './drain/drain.enable.command.js';
 import { drainGetCommand } from './drain/drain.get.command.js';
 import { drainRemoveCommand } from './drain/drain.remove.command.js';
+import { drainTestCommandCommand } from './drain/drain.test-command.command.js';
 import { emailsAddCommand } from './emails/emails.add.command.js';
 import { emailsCommand } from './emails/emails.command.js';
 import { emailsOpenCommand } from './emails/emails.open.command.js';
@@ -253,6 +254,7 @@ export const globalCommands = {
       enable: drainEnableCommand,
       get: drainGetCommand,
       remove: drainRemoveCommand,
+      'test-command': drainTestCommandCommand,
     },
   ],
   emails: [


### PR DESCRIPTION
## Summary

- Add `getDrainTestCommand` API client method for the `GET .../drains/{drainId}/test-command` endpoint
- Add `clever drain test-command <drain-id>` subcommand that returns a ready-to-execute shell command (curl/netcat) to manually test a drain recipient

## Test plan

- [ ] `clever drain test-command <drain-id> --app <app>` returns a valid shell command for HTTP drains (curl)
- [ ] `clever drain test-command <drain-id> --app <app>` returns a valid shell command for syslog drains (netcat)
- [ ] `clever drain test-command --help` displays correct usage
- [ ] Other drain commands (`create`, `get`, `disable`, `enable`, `remove`) still work with `--app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)