### PR TITLE
fix(ng): adapt to @clevercloud/client v12 API change for peer config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/traverse": "7.28.5",
-        "@clevercloud/client": "11.3.0",
+        "@clevercloud/client": "12.0.0",
         "@inquirer/prompts": "7.8.4",
         "char-regex": "2.0.2",
         "cliparse": "0.5.0",
@@ -1115,9 +1115,9 @@
       }
     },
     "node_modules/@clevercloud/client": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-11.3.0.tgz",
-      "integrity": "sha512-rvuUr9VQcRmwU8q7j9wZGxbuxDb0xURV65ELpT1iRZRSZiluC5m979mRXkh1QvH1A4O5x4ZxR/XmLvgHY7bqkQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.0.0.tgz",
+      "integrity": "sha512-NINttu2qH6FvxAlTYIxk9TMej+fHvqjwadymrAVUnqNzP0m+CKSak4Z7bOF56GpRQeug1P9MNO8sy2jKxKdRCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "component-emitter": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@babel/traverse": "7.28.5",
-    "@clevercloud/client": "11.3.0",
+    "@clevercloud/client": "12.0.0",
     "@inquirer/prompts": "7.8.4",
     "char-regex": "2.0.2",
     "cliparse": "0.5.0",

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -2375,7 +2375,6 @@ ng-id|ng-label                          Network Group ID or label
 
 **Options**
 ```
--F, --format <format>                   Output format (human, json) (default: human)
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 

--- a/src/commands/ng/ng.docs.md
+++ b/src/commands/ng/ng.docs.md
@@ -146,7 +146,6 @@ clever ng get-config <peer-id|peer-label> <ng-id|ng-label> [options]
 
 |Name|Description|
 |---|---|
-|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 
 ## ➡️ `clever ng link` <kbd>Since 3.12.0</kbd>

--- a/src/commands/ng/ng.get-config.command.js
+++ b/src/commands/ng/ng.get-config.command.js
@@ -1,7 +1,7 @@
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
 import * as networkGroup from '../../models/ng.js';
-import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { orgaIdOrNameOption } from '../global.options.js';
 import { ngExternalIdOrLabelArg, ngIdOrLabelArg } from './ng.args.js';
 
 export const ngGetConfigCommand = defineCommand({
@@ -9,24 +9,13 @@ export const ngGetConfigCommand = defineCommand({
   since: '3.12.0',
   options: {
     org: orgaIdOrNameOption,
-    format: humanJsonOutputFormatOption,
   },
   args: [ngExternalIdOrLabelArg, ngIdOrLabelArg],
   async handler(options, peerIdOrLabel, ngIdOrLabel) {
-    const { org, format } = options;
+    const { org } = options;
 
     const peerConfig = await networkGroup.getPeerConfig(peerIdOrLabel, ngIdOrLabel, org);
 
-    switch (format) {
-      case 'json': {
-        Logger.printJson(peerConfig);
-        break;
-      }
-      case 'human':
-      default: {
-        const decodedConfiguration = Buffer.from(peerConfig.configuration, 'base64').toString('utf8');
-        Logger.println(decodedConfiguration);
-      }
-    }
+    Logger.println(peerConfig);
   },
 });

--- a/src/models/ng.js
+++ b/src/models/ng.js
@@ -79,7 +79,7 @@ export async function destroy(ngIdOrLabel, orgaIdOrName) {
  * @param {object} peerIdOrLabel The Peer ID or Label
  * @param {object} ngIdOrLabel The Network Group ID or Label
  * @param {object} orgaIdOrName The owner ID or name
- * @returns {Promise<Object>} The Peer WireGuard configuration
+ * @returns {Promise<string>} The Peer WireGuard configuration
  * @throws {Error} If the Peer is not found
  * @throws {Error} If the Network Group is not found
  * @throws {Error} If the Peer is not in the Network Group
@@ -113,7 +113,7 @@ export async function getPeerConfig(peerIdOrLabel, ngIdOrLabel, orgaIdOrName) {
     networkGroupId: parentNg.id,
     peerId: peer.id,
   }).then(sendToApi);
-  Logger.debug(`Received from API:\n${JSON.stringify(result, null, 2)}`);
+  Logger.debug(`Received from API:\n${result}`);
 
   return result;
 }


### PR DESCRIPTION
## Summary
- Upgrade `@clevercloud/client` from v11.3.0 to v12.0.0
- Adapt NG peer config handling to the new API response format (plain text instead of base64-encoded JSON)
- Remove the --format option (no JSON format anymore)

## Test plan
- [ ] Run `clever ng get-config` and verify the WireGuard configuration is displayed as plain text