### PR TITLE
refactor: improve z.enum support in CLI framework

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -17,7 +17,7 @@ import {
 import { EXPERIMENTAL_FEATURES, getFeatures } from '../src/config/features.js';
 import { cliparse } from '../src/lib/cliparse-patched.js';
 import { styleText } from '../src/lib/style-text.js';
-import { getDefault, isBoolean, isRequired } from '../src/lib/zod-utils.js';
+import { getDefault, getEnumValues, isBoolean, isRequired } from '../src/lib/zod-utils.js';
 
 /**
  * @typedef {import('../src/lib/define-command.types.js').CommandDefinition} CommandDefinition
@@ -199,6 +199,11 @@ function convertOption(option) {
   }
   if (option.complete != null) {
     cliparseConfig.complete = option.complete;
+  } else {
+    const enumValues = getEnumValues(option.schema);
+    if (enumValues != null) {
+      cliparseConfig.complete = enumValues;
+    }
   }
 
   // Use Zod's safeParse for validation (handles coercion, enums, refinements, etc.)
@@ -242,6 +247,11 @@ function convertArgument(arg) {
 
   if (arg.complete) {
     cliparseConfig.complete = arg.complete;
+  } else {
+    const enumValues = getEnumValues(arg.schema);
+    if (enumValues != null) {
+      cliparseConfig.complete = enumValues;
+    }
   }
 
   // Use Zod's safeParse for validation (handles coercion, enums, refinements, etc.)

--- a/scripts/lib/docs-llm.js
+++ b/scripts/lib/docs-llm.js
@@ -241,6 +241,7 @@ function getCommandSection(heading, path, definition) {
   if (commandInfo.args) {
     argumentsRows = commandInfo.args.map((arg) => {
       let description = arg.description;
+      if (arg.enumValues) description += ` (${arg.enumValues.join(', ')})`;
       if (arg.optional) description += ` ${arg.optional}`;
       return [arg.name, description];
     });
@@ -254,6 +255,7 @@ function getCommandSection(heading, path, definition) {
       const aliasesPadding = opt.aliases[0].length === 2 ? '' : '    ';
       const aliases = aliasesPadding + opt.aliases.join(', ') + placeholder;
       let description = opt.description;
+      if (opt.enumValues) description += ` (${opt.enumValues.join(', ')})`;
       if (opt.deprecated) description += ` ${opt.deprecated}`;
       if (opt.required) description += ` ${opt.required}`;
       if (opt.default) description += ` ${opt.default}`;

--- a/scripts/lib/docs-reference.js
+++ b/scripts/lib/docs-reference.js
@@ -205,6 +205,7 @@ export function getSubCommandMarkdown(path, definition, subCommandNodes) {
   if (commandInfo.args) {
     const rows = commandInfo.args.map((arg) => {
       let description = arg.description;
+      if (arg.enumValues) description += ` (${arg.enumValues.join(', ')})`;
       if (arg.optional) description += ` *${arg.optional}*`;
       return `|\`${arg.name}\`|${escapeTableCell(description)}|`;
     });
@@ -223,6 +224,7 @@ export function getSubCommandMarkdown(path, definition, subCommandNodes) {
         const placeholder = opt.placeholder ? ` \`${opt.placeholder}\`` : '';
         const aliases = formatCodeList(opt.aliases) + placeholder;
         let description = opt.description;
+        if (opt.enumValues) description += ` (${opt.enumValues.join(', ')})`;
         if (opt.deprecated) description += ` *${opt.deprecated}*`;
         if (opt.required) description += ` **${opt.required}**`;
         if (opt.default) description += ` ${opt.default}`;

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -856,7 +856,7 @@ clever deploy [options]
 ```
 -a, --alias <alias>                  Short name for the application
 -b, --branch <branch>                Branch to push (current branch by default)
--e, --exit-on <step>                 Step at which the logs streaming is ended, steps are: deploy-start, deploy-end, never (default: deploy-end)
+-e, --exit-on <step>                 Step at which the logs streaming is ended (deploy-start, deploy-end, never) (default: deploy-end)
     --follow                         Continue to follow logs after deployment has ended (deprecated, use `--exit-on never` instead)
 -f, --force                          Force deploy even if it's not fast-forwardable
 -q, --quiet                          Don't show logs during deployment
@@ -2911,7 +2911,7 @@ clever restart [options]
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
     --commit <commit-id>       Restart the application with a specific commit ID
--e, --exit-on <step>           Step at which the logs streaming is ended, steps are: deploy-start, deploy-end, never (default: deploy-end)
+-e, --exit-on <step>           Step at which the logs streaming is ended (deploy-start, deploy-end, never) (default: deploy-end)
     --follow                   Continue to follow logs after deployment has ended (deprecated, use `--exit-on never` instead)
 -q, --quiet                    Don't show logs during deployment
     --without-cache            Restart the application without using cache

--- a/src/commands/activity/activity.command.js
+++ b/src/commands/activity/activity.command.js
@@ -174,7 +174,7 @@ export const activityCommand = defineCommand({
     format: defineOption({
       name: 'format',
       schema: z.enum(['human', 'json', 'json-stream']).default('human'),
-      description: 'Output format (human, json, json-stream)',
+      description: 'Output format',
       aliases: ['F'],
       placeholder: 'format',
     }),

--- a/src/commands/config-provider/config-provider.import.command.js
+++ b/src/commands/config-provider/config-provider.import.command.js
@@ -11,7 +11,7 @@ import { configProviderIdOrNameArg } from './config-provider.args.js';
 const importFormatOption = defineOption({
   name: 'format',
   schema: z.enum(['name-equals-value', 'json']).default('name-equals-value'),
-  description: 'Input format (name-equals-value, json)',
+  description: 'Input format',
   aliases: ['F'],
   placeholder: 'format',
 });

--- a/src/commands/deploy/deploy.command.js
+++ b/src/commands/deploy/deploy.command.js
@@ -67,7 +67,7 @@ export const deployCommand = defineCommand({
     sameCommitPolicy: defineOption({
       name: 'same-commit-policy',
       schema: z.enum(['error', 'ignore', 'restart', 'rebuild']).default('error'),
-      description: 'What to do when local and remote commit are identical (error, ignore, restart, rebuild)',
+      description: 'What to do when local and remote commit are identical',
       aliases: ['p'],
       placeholder: 'policy',
     }),

--- a/src/commands/deploy/deploy.docs.md
+++ b/src/commands/deploy/deploy.docs.md
@@ -14,7 +14,7 @@ clever deploy [options]
 |---|---|
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`-b`, `--branch` `<branch>`|Branch to push (current branch by default)|
-|`-e`, `--exit-on` `<step>`|Step at which the logs streaming is ended, steps are: deploy-start, deploy-end, never (default: deploy-end)|
+|`-e`, `--exit-on` `<step>`|Step at which the logs streaming is ended (deploy-start, deploy-end, never) (default: deploy-end)|
 |`--follow`|Continue to follow logs after deployment has ended *(deprecated, use `--exit-on never` instead)*|
 |`-f`, `--force`|Force deploy even if it's not fast-forwardable|
 |`-q`, `--quiet`|Don't show logs during deployment|

--- a/src/commands/drain/drain.create.command.js
+++ b/src/commands/drain/drain.create.command.js
@@ -54,10 +54,9 @@ export const drainCreateCommand = defineCommand({
   },
   args: [
     defineArgument({
-      schema: z.string(),
-      description: `Drain type (${DRAIN_TYPE_CLI_CODES.join(', ')})`,
+      schema: z.enum(DRAIN_TYPE_CLI_CODES),
+      description: 'Drain type',
       placeholder: 'drain-type',
-      complete: DRAIN_TYPE_CLI_CODES,
     }),
     defineArgument({
       schema: z.string(),
@@ -70,9 +69,6 @@ export const drainCreateCommand = defineCommand({
     const { username, password, apiKey, indexPrefix, rfc5424StructuredDataParameters } = options;
 
     const drainType = Object.values(DRAIN_TYPES).find((drainType) => drainType.cliCode === drainTypeCliCode);
-    if (!drainType) {
-      throw new Error(`Invalid drain type. Supported types are: ${DRAIN_TYPE_CLI_CODES.join(', ')}`);
-    }
 
     const { ownerId, appId: applicationId } = await Application.resolveId(appIdOrName, alias);
 

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -23,7 +23,7 @@ export const appIdOrNameOption = defineOption({
 export const logsFormatOption = defineOption({
   name: 'format',
   schema: z.enum(['human', 'json', 'json-stream']).default('human'),
-  description: 'Output format (human, json, json-stream)',
+  description: 'Output format',
   aliases: ['F'],
   placeholder: 'format',
 });
@@ -62,7 +62,7 @@ export const orgaIdOrNameOption = defineOption({
 export const humanJsonOutputFormatOption = defineOption({
   name: 'format',
   schema: z.enum(['human', 'json']).default('human'),
-  description: 'Output format (human, json)',
+  description: 'Output format',
   aliases: ['F'],
   placeholder: 'format',
 });
@@ -77,7 +77,7 @@ export const confirmAddonDeletionOption = defineOption({
 export const envFormatOption = defineOption({
   name: 'format',
   schema: z.enum(['human', 'json', 'shell']).default('human'),
-  description: 'Output format (human, json, shell)',
+  description: 'Output format',
   aliases: ['F'],
   placeholder: 'format',
 });
@@ -107,7 +107,7 @@ export const followDeployLogsOption = defineOption({
 export const exitOnDeployOption = defineOption({
   name: 'exit-on',
   schema: z.enum(['deploy-start', 'deploy-end', 'never']).default('deploy-end'),
-  description: 'Step at which the logs streaming is ended, steps are: deploy-start, deploy-end, never',
+  description: 'Step at which the logs streaming is ended',
   aliases: ['e'],
   placeholder: 'step',
 });

--- a/src/commands/ng/ng.options.js
+++ b/src/commands/ng/ng.options.js
@@ -4,6 +4,6 @@ import { defineOption } from '../../lib/define-option.js';
 export const ngResourceTypeOption = defineOption({
   name: 'type',
   schema: z.enum(['NetworkGroup', 'Member', 'CleverPeer', 'ExternalPeer']).optional(),
-  description: 'Type of resource to look for (NetworkGroup, Member, CleverPeer, ExternalPeer)',
+  description: 'Type of resource to look for',
   placeholder: 'resource-type',
 });

--- a/src/commands/restart/restart.docs.md
+++ b/src/commands/restart/restart.docs.md
@@ -15,7 +15,7 @@ clever restart [options]
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`--commit` `<commit-id>`|Restart the application with a specific commit ID|
-|`-e`, `--exit-on` `<step>`|Step at which the logs streaming is ended, steps are: deploy-start, deploy-end, never (default: deploy-end)|
+|`-e`, `--exit-on` `<step>`|Step at which the logs streaming is ended (deploy-start, deploy-end, never) (default: deploy-end)|
 |`--follow`|Continue to follow logs after deployment has ended *(deprecated, use `--exit-on never` instead)*|
 |`-q`, `--quiet`|Don't show logs during deployment|
 |`--without-cache`|Restart the application without using cache|

--- a/src/lib/cliparse-patched.js
+++ b/src/lib/cliparse-patched.js
@@ -80,6 +80,7 @@ cliparseCommandModule.help = function (context) {
   if (commandInfo.args) {
     argumentsRows = commandInfo.args.map((arg) => {
       let description = arg.description;
+      if (arg.enumValues) description += ` (${arg.enumValues.join(', ')})`;
       if (arg.optional) description += ` ${styleText('dim', arg.optional)}`;
       return [arg.name, description];
     });
@@ -93,6 +94,7 @@ cliparseCommandModule.help = function (context) {
       const aliasesPadding = opt.aliases[0].length === 2 ? '' : '    ';
       const aliases = aliasesPadding + opt.aliases.join(', ') + placeholder;
       let description = opt.description;
+      if (opt.enumValues) description += ` (${opt.enumValues.join(', ')})`;
       if (opt.deprecated) description += ` ${styleText('dim', opt.deprecated)}`;
       if (opt.required) description += ` ${styleText('dim', opt.required)}`;
       if (opt.default) description += ` ${styleText('dim', opt.default)}`;

--- a/src/lib/get-command-info.js
+++ b/src/lib/get-command-info.js
@@ -1,4 +1,4 @@
-import { getDefault, isBoolean, isRequired } from './zod-utils.js';
+import { getDefault, getEnumValues, isBoolean, isRequired } from './zod-utils.js';
 
 /**
  * @typedef {import('./get-command-info.types.d.ts').ArgumentInfo} ArgumentInfo
@@ -45,6 +45,7 @@ export function getCommandInfo(path, definition) {
           name: arg.placeholder,
           description: arg.description,
           optional: isRequired(arg.schema) ? null : '(optional)',
+          enumValues: getEnumValues(arg.schema) ?? null,
         };
       })
     : null;
@@ -78,6 +79,7 @@ export function getCommandInfo(path, definition) {
                   : null,
             required: isRequired(option.schema) ? '(required)' : null,
             default: defaultValue ? `(default: ${defaultValue})` : null,
+            enumValues: getEnumValues(option.schema) ?? null,
           };
         })
     : null;

--- a/src/lib/get-command-info.types.d.ts
+++ b/src/lib/get-command-info.types.d.ts
@@ -13,6 +13,8 @@ export interface ArgumentInfo {
   description: string;
   /** '(optional)' or null */
   optional: string | null;
+  /** Enum values if the schema is a z.enum(), or null */
+  enumValues: string[] | null;
 }
 
 export interface OptionInfo {
@@ -30,6 +32,8 @@ export interface OptionInfo {
   required: string | null;
   /** '(default: value)' or null */
   default: string | null;
+  /** Enum values if the schema is a z.enum(), or null */
+  enumValues: string[] | null;
 }
 
 export interface CommandInfo {

--- a/src/lib/zod-utils.js
+++ b/src/lib/zod-utils.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} ZodSchemaLike
  * @property {{ type?: string, innerType?: ZodSchemaLike, defaultValue?: unknown, typeName?: string, in?: ZodSchemaLike }} [_def]
+ * @property {string[]} [options]
  */
 
 /**
@@ -35,6 +36,33 @@ export function isRequired(schema) {
     if (inputSchema) return isRequired(inputSchema);
   }
   return true;
+}
+
+/**
+ * Extracts enum values from a Zod schema.
+ * Handles wrapped schemas (default, optional, nullable, pipe).
+ * @param {ZodSchemaLike} schema
+ * @return {string[] | null}
+ */
+export function getEnumValues(schema) {
+  /** @type {ZodSchemaLike | undefined} */
+  let current = schema;
+  while (current) {
+    const schemaType = current._def?.type;
+    if (schemaType === 'enum') {
+      return current.options ?? null;
+    }
+    if (schemaType === 'default' || schemaType === 'optional' || schemaType === 'nullable') {
+      current = current._def?.innerType;
+      continue;
+    }
+    if (schemaType === 'pipe') {
+      current = current._def?.in;
+      continue;
+    }
+    break;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Context

Enum values defined in `z.enum()` schemas were manually duplicated in descriptions across 7 files, creating maintenance burden and fragility. When adding a new enum value, every copy had to be updated or things would silently diverge.

Additionally, explicit autocomplete arrays and manual validation were duplicated for each enum, preventing a unified approach to displaying and validating enum choices.

## Proposal

Add framework-level introspection for `z.enum()` schemas:

1. **`getEnumValues(schema)`** — unwrap Zod wrappers (default, optional, nullable, pipe) and extract enum values
2. **Integrate into `getCommandInfo()`** — add `enumValues` field to `OptionInfo` and `ArgumentInfo`
3. **Auto-display in help and docs** — enum values appear after description in `--help`, LLM docs, and markdown reference
4. **Auto-complete** — options and arguments with `z.enum()` get autocomplete for free via `bin/clever.js`
5. **Migrate drain create** — use `z.enum()` instead of manual validation, leveraging the new framework

This replaces 7 manual enum value lists in descriptions with zero duplication, and provides better UX (help text, autocomplete) without extra code.

## How to test

```bash
# Help text now shows enum values:
node bin/clever.js logs --help              # Format option shows (human, json, json-stream)
node bin/clever.js drain create --help     # drain-type shows all types
node bin/clever.js deploy --help           # exit-on and same-commit-policy show values

# Validation via Zod (not manual checks):
node bin/clever.js drain create invalid-type http://example.com
# Shows: Invalid option: expected one of "datadog"|"elasticsearch"|...

# Autocomplete works:
node bin/clever.js logs --format <TAB>     # completes with format values
```