### PR TITLE
feat: add oauth-consumers commands

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -348,7 +348,7 @@ addon-id|addon-name                     Add-on ID (or name, if unambiguous)
 **Options**
 ```
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
--y, --yes                               Skip confirmation and delete the add-on directly
+-y, --yes                               Skip confirmation and proceed with deletion directly
 ```
 
 ### addon env
@@ -1530,7 +1530,7 @@ cluster-id|cluster-name                 Kubernetes cluster ID or name
 **Options**
 ```
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
--y, --yes                               Skip confirmation and delete the add-on directly
+-y, --yes                               Skip confirmation and proceed with deletion directly
 ```
 
 ### k8s get

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -2508,6 +2508,146 @@ notification-id                         Notification ID
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
+## oauth-consumers
+
+**Description:** Manage OAuth consumers used with a Clever Cloud login
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers
+```
+
+### oauth-consumers create
+
+**Description:** Create an OAuth consumer
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers create <name> [options]
+```
+
+**Arguments**
+```
+name                                    Consumer name
+```
+
+**Options**
+```
+    --base-url <url>                    OAuth callback base URL
+-d, --description <description>         Consumer description
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+    --picture <url>                     Application logo URL
+    --rights <rights>                   Comma-separated list of rights (access-organisations, access-organisations-bills, access-organisations-consumption-statistics, access-organisations-credit-count, access-personal-information, manage-organisations, manage-organisations-applications, manage-organisations-members, manage-organisations-services, manage-personal-information, manage-ssh-keys, all)
+    --url <url>                         Application home URL
+```
+
+### oauth-consumers delete
+
+**Description:** Delete an OAuth consumer
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers delete <consumer-key|consumer-name> [options]
+```
+
+**Arguments**
+```
+consumer-key|consumer-name    OAuth consumer key (or name, if unambiguous)
+```
+
+**Options**
+```
+-y, --yes                     Skip confirmation and proceed with deletion directly
+```
+
+### oauth-consumers get
+
+**Description:** Get details of an OAuth consumer
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers get <consumer-key|consumer-name> [options]
+```
+
+**Arguments**
+```
+consumer-key|consumer-name    OAuth consumer key (or name, if unambiguous)
+```
+
+**Options**
+```
+-F, --format <format>         Output format (human, json) (default: human)
+    --with-secret             Include the consumer secret in the output
+```
+
+### oauth-consumers list
+
+**Description:** List OAuth consumers
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers list [options]
+```
+
+**Options**
+```
+-F, --format <format>    Output format (human, json) (default: human)
+```
+
+### oauth-consumers open
+
+**Description:** Open an OAuth consumer in the Clever Cloud Console
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers open <consumer-key|consumer-name>
+```
+
+**Arguments**
+```
+consumer-key|consumer-name    OAuth consumer key (or name, if unambiguous)
+```
+
+### oauth-consumers update
+
+**Description:** Update an OAuth consumer
+
+**Since:** unreleased
+
+**Usage**
+```
+clever oauth-consumers update <consumer-key|consumer-name> [options]
+```
+
+**Arguments**
+```
+consumer-key|consumer-name         OAuth consumer key (or name, if unambiguous)
+```
+
+**Options**
+```
+    --base-url <url>               OAuth callback base URL
+-d, --description <description>    Consumer description
+-F, --format <format>              Output format (human, json) (default: human)
+-n, --name <name>                  Consumer name
+    --picture <url>                Application logo URL
+    --rights <rights>              Comma-separated list of rights (access-organisations, access-organisations-bills, access-organisations-consumption-statistics, access-organisations-credit-count, access-personal-information, manage-organisations, manage-organisations-applications, manage-organisations-members, manage-organisations-services, manage-personal-information, manage-ssh-keys, all)
+    --url <url>                    Application home URL
+```
+
 ## open
 
 **Description:** Open an application in the Console

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -47,6 +47,7 @@ These options are available for all commands:
 |[`clever matomo`](./matomo/matomo.docs.md)|Manage Clever Cloud Matomo services|
 |[`clever metabase`](./metabase/metabase.docs.md)|Manage Clever Cloud Metabase services|
 |[`clever ng`](./ng/ng.docs.md)|List Network Groups|
+|[`clever oauth-consumers`](./oauth-consumers/oauth-consumers.docs.md)|Manage OAuth consumers used with a Clever Cloud login|
 |[`clever notify-email`](./notify-email/notify-email.docs.md)|Manage email notifications|
 |[`clever open`](./open/open.docs.md)|Open an application in the Console|
 |[`clever otoroshi`](./otoroshi/otoroshi.docs.md)|Manage Clever Cloud Otoroshi services|

--- a/src/commands/addon/addon.create.command.js
+++ b/src/commands/addon/addon.create.command.js
@@ -10,9 +10,8 @@ import * as Addon from '../../models/addon.js';
 import { completePlan, completeRegion, parseAddonOptions } from '../../models/addon.js';
 import * as AppConfig from '../../models/app_configuration.js';
 import { listAvailableAliases } from '../../models/application.js';
-import * as Organisation from '../../models/organisation.js';
+import { getOwnerIdFromOrgIdOrName } from '../../models/ids-resolver.js';
 import { sendToApi } from '../../models/send-to-api.js';
-import * as User from '../../models/user.js';
 import { addonOptions } from '../../parsers.js';
 import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
 import { addonNameArg, addonProviderArg } from './addon.args.js';
@@ -130,7 +129,7 @@ export const addonCreateCommand = defineCommand({
       addonOptions: parseAddonOptions(addonOptions),
     };
 
-    const ownerId = orgaIdOrName != null ? await Organisation.getId(orgaIdOrName) : await User.getCurrentId();
+    const ownerId = await getOwnerIdFromOrgIdOrName(orgaIdOrName);
     if (linkedAppAlias != null) {
       const linkedAppData = await AppConfig.getAppDetails({ alias: linkedAppAlias });
       if (orgaIdOrName != null && linkedAppData.ownerId !== ownerId && format === 'human') {

--- a/src/commands/addon/addon.delete.command.js
+++ b/src/commands/addon/addon.delete.command.js
@@ -3,14 +3,14 @@ import { Logger } from '../../logger.js';
 import * as Addon from '../../models/addon.js';
 import * as Organisation from '../../models/organisation.js';
 import { addonIdOrNameArg } from '../global.args.js';
-import { confirmAddonDeletionOption, orgaIdOrNameOption } from '../global.options.js';
+import { orgaIdOrNameOption, skipConfirmationOption } from '../global.options.js';
 
 export const addonDeleteCommand = defineCommand({
   description: 'Delete an add-on',
   since: '0.2.3',
   options: {
     org: orgaIdOrNameOption,
-    yes: confirmAddonDeletionOption,
+    yes: skipConfirmationOption,
   },
   args: [addonIdOrNameArg],
   async handler(options, addon) {

--- a/src/commands/addon/addon.docs.md
+++ b/src/commands/addon/addon.docs.md
@@ -62,7 +62,7 @@ clever addon delete <addon-id|addon-name> [options]
 |Name|Description|
 |---|---|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
-|`-y`, `--yes`|Skip confirmation and delete the add-on directly|
+|`-y`, `--yes`|Skip confirmation and proceed with deletion directly|
 
 ## ➡️ `clever addon env` <kbd>Since 2.11.0</kbd>
 

--- a/src/commands/config-provider/config-provider.command.js
+++ b/src/commands/config-provider/config-provider.command.js
@@ -3,8 +3,4 @@ import { defineCommand } from '../../lib/define-command.js';
 export const configProviderCommand = defineCommand({
   description: 'Manage configuration providers',
   since: '4.6.0',
-  options: {},
-  args: [],
-  // Parent command - no handler, only contains subcommands
-  handler: null,
 });

--- a/src/commands/config-provider/config-provider.list.command.js
+++ b/src/commands/config-provider/config-provider.list.command.js
@@ -1,5 +1,5 @@
 import { defineCommand } from '../../lib/define-command.js';
-import { styleText } from '../../lib/style-text.js';
+import { printItemsByOwner } from '../../lib/print-items-by-owner.js';
 import { Logger } from '../../logger.js';
 import { findAddonsByAddonProvider } from '../../models/ids-resolver.js';
 import { humanJsonOutputFormatOption } from '../global.options.js';
@@ -14,30 +14,19 @@ export const configProviderListCommand = defineCommand({
   async handler(options) {
     const { format } = options;
     const deployed = await findAddonsByAddonProvider('config-provider');
-    const providersPerOwner = Object.groupBy(deployed, (provider) => provider.ownerId);
 
     switch (format) {
-      case 'json':
+      case 'json': {
+        const providersPerOwner = Object.groupBy(deployed, (p) => p.ownerId);
         Logger.printJson(providersPerOwner);
         break;
+      }
       case 'human':
       default:
-        if (deployed.length === 0) {
-          Logger.println(
-            `No configuration provider found, create one with ${styleText('blue', 'clever addon create config-provider')} command`,
-          );
-          return;
-        }
-
-        Logger.println(`Found ${deployed.length} configuration provider${deployed.length > 1 ? 's' : ''}:`);
-        Logger.println();
-
-        Object.values(providersPerOwner).forEach((providers) => {
-          Logger.println(`${styleText('bold', `${providers[0].ownerId} (${providers[0].ownerName})`)}`);
-          providers.forEach((provider) => {
-            Logger.println(`  ${provider.name} ${styleText('grey', `(${provider.realId})`)}`);
-          });
-          Logger.println();
+        printItemsByOwner(deployed, {
+          itemName: 'configuration provider',
+          emptyCommand: 'clever addon create config-provider',
+          getItemId: (p) => p.realId,
         });
         break;
     }

--- a/src/commands/config-provider/config-provider.open.command.js
+++ b/src/commands/config-provider/config-provider.open.command.js
@@ -12,6 +12,6 @@ export const configProviderOpenCommand = defineCommand({
   args: [configProviderIdOrNameArg],
   async handler(_options, addonIdOrRealIdOrName) {
     const { addonId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
-    await openBrowser(`${config.GOTO_URL}/${addonId}`, `Opening ${styleText('blue', addonId)} in the browser...`);
+    await openBrowser(`${config.GOTO_URL}/${addonId}`, `Opening ${styleText('blue', addonId)} in the browser…`);
   },
 });

--- a/src/commands/console/console.command.js
+++ b/src/commands/console/console.command.js
@@ -1,4 +1,5 @@
 import { defineCommand } from '../../lib/define-command.js';
+import { styleText } from '../../lib/style-text.js';
 import * as AppConfig from '../../models/app_configuration.js';
 import * as Application from '../../models/application.js';
 import { openBrowser } from '../../models/utils.js';
@@ -18,7 +19,7 @@ export const consoleCommand = defineCommand({
     const { apps } = await AppConfig.loadApplicationConf();
     // If no app is linked or asked, open the Console without any context
     if (apps.length === 0 && !appIdOrName) {
-      await openBrowser('/', 'Opening the Console in your browser');
+      await openBrowser('/', 'Opening the Console in the browser…');
       return;
     }
 
@@ -26,6 +27,6 @@ export const consoleCommand = defineCommand({
     const prefixPath = ownerId.startsWith('user_') ? 'users/me' : `organisations/${ownerId}`;
     const consolePath = `/${prefixPath}/applications/${appId}`;
 
-    await openBrowser(consolePath, `Opening the Console in your browser for application ${appId}`);
+    await openBrowser(consolePath, `Opening ${styleText('blue', appId)} in the browser…`);
   },
 });

--- a/src/commands/curl/curl.command.js
+++ b/src/commands/curl/curl.command.js
@@ -73,5 +73,4 @@ export async function curl() {
 export const curlCommand = defineCommand({
   description: "Query Clever Cloud's API using Clever Tools credentials",
   since: '2.10.0',
-  handler: null,
 });

--- a/src/commands/database/database.command.js
+++ b/src/commands/database/database.command.js
@@ -3,8 +3,4 @@ import { defineCommand } from '../../lib/define-command.js';
 export const databaseCommand = defineCommand({
   description: 'Manage databases and backups',
   since: '2.10.0',
-  options: {},
-  args: [],
-  // Parent command - no handler, only contains subcommands
-  handler: null,
 });

--- a/src/commands/emails/emails.open.command.js
+++ b/src/commands/emails/emails.open.command.js
@@ -7,9 +7,6 @@ export const emailsOpenCommand = defineCommand({
   options: {},
   args: [],
   handler() {
-    return openBrowser(
-      '/users/me/emails',
-      'Opening the email addresses management page of the Console in your browser',
-    );
+    return openBrowser('/users/me/emails', 'Opening the emails page in the browser…');
   },
 });

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -117,6 +117,13 @@ import { ngUnlinkCommand } from './ng/ng.unlink.command.js';
 import { notifyEmailAddCommand } from './notify-email/notify-email.add.command.js';
 import { notifyEmailCommand } from './notify-email/notify-email.command.js';
 import { notifyEmailRemoveCommand } from './notify-email/notify-email.remove.command.js';
+import { oauthConsumersCommand } from './oauth-consumers/oauth-consumers.command.js';
+import { oauthConsumersCreateCommand } from './oauth-consumers/oauth-consumers.create.command.js';
+import { oauthConsumersDeleteCommand } from './oauth-consumers/oauth-consumers.delete.command.js';
+import { oauthConsumersGetCommand } from './oauth-consumers/oauth-consumers.get.command.js';
+import { oauthConsumersListCommand } from './oauth-consumers/oauth-consumers.list.command.js';
+import { oauthConsumersOpenCommand } from './oauth-consumers/oauth-consumers.open.command.js';
+import { oauthConsumersUpdateCommand } from './oauth-consumers/oauth-consumers.update.command.js';
 import { openCommand } from './open/open.command.js';
 import { otoroshiCommand } from './otoroshi/otoroshi.command.js';
 import { otoroshiDisableNgCommand } from './otoroshi/otoroshi.disable-ng.command.js';
@@ -382,6 +389,17 @@ export const globalCommands = {
       link: ngLinkCommand,
       search: ngSearchCommand,
       unlink: ngUnlinkCommand,
+    },
+  ],
+  'oauth-consumers': [
+    oauthConsumersCommand,
+    {
+      create: oauthConsumersCreateCommand,
+      delete: oauthConsumersDeleteCommand,
+      get: oauthConsumersGetCommand,
+      list: oauthConsumersListCommand,
+      open: oauthConsumersOpenCommand,
+      update: oauthConsumersUpdateCommand,
     },
   ],
   'notify-email': [

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -67,10 +67,10 @@ export const humanJsonOutputFormatOption = defineOption({
   placeholder: 'format',
 });
 
-export const confirmAddonDeletionOption = defineOption({
+export const skipConfirmationOption = defineOption({
   name: 'yes',
   schema: z.boolean().default(false),
-  description: 'Skip confirmation and delete the add-on directly',
+  description: 'Skip confirmation and proceed with deletion directly',
   aliases: ['y'],
 });
 

--- a/src/commands/help/help.command.js
+++ b/src/commands/help/help.command.js
@@ -3,7 +3,4 @@ import { defineCommand } from '../../lib/define-command.js';
 export const helpCommand = defineCommand({
   description: 'Display help about the Clever Cloud CLI',
   since: '0.1.0',
-  options: {},
-  args: [],
-  handler: null,
 });

--- a/src/commands/k8s/k8s.command.js
+++ b/src/commands/k8s/k8s.command.js
@@ -5,8 +5,4 @@ export const k8sCommand = defineCommand({
   since: '4.3.0',
   isExperimental: true,
   featureFlag: 'k8s',
-  options: {},
-  args: [],
-  // Parent command - no handler, only contains subcommands
-  handler: null,
 });

--- a/src/commands/k8s/k8s.delete.command.js
+++ b/src/commands/k8s/k8s.delete.command.js
@@ -3,7 +3,7 @@ import { k8sDelete } from '../../lib/k8s.js';
 import { confirm } from '../../lib/prompts.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import { confirmAddonDeletionOption, orgaIdOrNameOption } from '../global.options.js';
+import { orgaIdOrNameOption, skipConfirmationOption } from '../global.options.js';
 import { k8sIdOrNameArg } from './k8s.args.js';
 
 export const k8sDeleteCommand = defineCommand({
@@ -11,7 +11,7 @@ export const k8sDeleteCommand = defineCommand({
   since: '4.3.0',
   options: {
     org: orgaIdOrNameOption,
-    yes: confirmAddonDeletionOption,
+    yes: skipConfirmationOption,
   },
   args: [k8sIdOrNameArg],
   async handler(options, clusterIdOrName) {

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -72,7 +72,7 @@ clever k8s delete <cluster-id|cluster-name> [options]
 |Name|Description|
 |---|---|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
-|`-y`, `--yes`|Skip confirmation and delete the add-on directly|
+|`-y`, `--yes`|Skip confirmation and proceed with deletion directly|
 
 ## ➡️ `clever k8s get` <kbd>Since 4.3.0</kbd>
 

--- a/src/commands/notify-email/notify-email.remove.command.js
+++ b/src/commands/notify-email/notify-email.remove.command.js
@@ -1,7 +1,7 @@
 import { deleteEmailhook } from '@clevercloud/client/esm/api/v2/notification.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
-import { getOrgaIdOrUserId } from '../../models/notification.js';
+import { getOwnerIdFromOrgIdOrName } from '../../models/ids-resolver.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import { notificationIdArg } from '../global.args.js';
 import { orgaIdOrNameOption } from '../global.options.js';
@@ -16,7 +16,7 @@ export const notifyEmailRemoveCommand = defineCommand({
   async handler(options, notificationId) {
     const { org } = options;
 
-    const ownerId = await getOrgaIdOrUserId(org);
+    const ownerId = await getOwnerIdFromOrgIdOrName(org);
     await deleteEmailhook({ ownerId, id: notificationId }).then(sendToApi);
 
     Logger.println('The notification has been successfully removed');

--- a/src/commands/oauth-consumers/oauth-consumers.args.js
+++ b/src/commands/oauth-consumers/oauth-consumers.args.js
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { defineArgument } from '../../lib/define-argument.js';
+
+export const consumerKeyOrNameArg = defineArgument({
+  schema: z.string(),
+  description: 'OAuth consumer key (or name, if unambiguous)',
+  placeholder: 'consumer-key|consumer-name',
+});

--- a/src/commands/oauth-consumers/oauth-consumers.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.command.js
@@ -1,0 +1,6 @@
+import { defineCommand } from '../../lib/define-command.js';
+
+export const oauthConsumersCommand = defineCommand({
+  description: 'Manage OAuth consumers used with a Clever Cloud login',
+  since: 'unreleased',
+});

--- a/src/commands/oauth-consumers/oauth-consumers.create.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.create.command.js
@@ -1,0 +1,64 @@
+import { create } from '@clevercloud/client/esm/api/v2/oauth-consumer.js';
+import { z } from 'zod';
+import { defineArgument } from '../../lib/define-argument.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { promptTextOption } from '../../lib/prompts.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { getOwnerIdFromOrgIdOrName } from '../../models/ids-resolver.js';
+import { promptRights, rightsFromList } from '../../models/oauth-consumer.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { baseUrlOption, descriptionOption, pictureOption, rightsOption, urlOption } from './oauth-consumers.options.js';
+
+export const oauthConsumersCreateCommand = defineCommand({
+  description: 'Create an OAuth consumer',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    description: descriptionOption,
+    url: urlOption,
+    picture: pictureOption,
+    baseUrl: baseUrlOption,
+    rights: rightsOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [
+    defineArgument({
+      schema: z.string(),
+      description: 'Consumer name',
+      placeholder: 'name',
+    }),
+  ],
+  async handler(options, name) {
+    const { org, description, url, picture, baseUrl, rights, format } = options;
+
+    const ownerId = await getOwnerIdFromOrgIdOrName(org);
+
+    const body = {
+      name,
+      description: description ?? (await promptTextOption(descriptionOption)),
+      url: url ?? (await promptTextOption(urlOption)),
+      picture: picture ?? (await promptTextOption(pictureOption)),
+      baseUrl: baseUrl ?? (await promptTextOption(baseUrlOption)),
+      rights: rights != null ? rightsFromList(rights) : await promptRights(),
+    };
+
+    const oauthConsumer = await create({ id: ownerId }, body).then(sendToApi);
+
+    switch (format) {
+      case 'json': {
+        Logger.printJson(oauthConsumer);
+        break;
+      }
+      case 'human':
+      default: {
+        Logger.printSuccess(`OAuth consumer ${styleText(['bold', 'green'], oauthConsumer.key)} has been created!`);
+        Logger.println();
+        Logger.println(
+          `Retrieve the secret with ${styleText('blue', `clever oauth-consumers get ${oauthConsumer.key} --with-secret`)}`,
+        );
+      }
+    }
+  },
+});

--- a/src/commands/oauth-consumers/oauth-consumers.delete.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.delete.command.js
@@ -1,0 +1,33 @@
+import { remove } from '@clevercloud/client/esm/api/v2/oauth-consumer.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { confirm } from '../../lib/prompts.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { resolveOauthConsumer } from '../../models/oauth-consumer.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { skipConfirmationOption } from '../global.options.js';
+import { consumerKeyOrNameArg } from './oauth-consumers.args.js';
+
+export const oauthConsumersDeleteCommand = defineCommand({
+  description: 'Delete an OAuth consumer',
+  since: 'unreleased',
+  options: {
+    skipConfirmation: skipConfirmationOption,
+  },
+  args: [consumerKeyOrNameArg],
+  async handler(options, keyOrName) {
+    const { skipConfirmation } = options;
+
+    const oauthConsumer = await resolveOauthConsumer(keyOrName);
+
+    if (!skipConfirmation) {
+      await confirm(
+        `Are you sure you want to delete the OAuth consumer ${styleText('blue', oauthConsumer.key)}?`,
+        'OAuth consumer deletion cancelled.',
+      );
+    }
+
+    await remove({ id: oauthConsumer.ownerId, key: oauthConsumer.key }).then(sendToApi);
+    Logger.printSuccess(`OAuth consumer ${styleText(['bold', 'green'], oauthConsumer.key)} has been deleted!`);
+  },
+});

--- a/src/commands/oauth-consumers/oauth-consumers.docs.md
+++ b/src/commands/oauth-consumers/oauth-consumers.docs.md
@@ -1,0 +1,130 @@
+# 📖 `clever oauth-consumers` command reference
+
+## ➡️ `clever oauth-consumers` <kbd>Since unreleased</kbd>
+
+Manage OAuth consumers used with a Clever Cloud login
+
+```bash
+clever oauth-consumers
+```
+
+## ➡️ `clever oauth-consumers create` <kbd>Since unreleased</kbd>
+
+Create an OAuth consumer
+
+```bash
+clever oauth-consumers create <name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`name`|Consumer name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`--base-url` `<url>`|OAuth callback base URL|
+|`-d`, `--description` `<description>`|Consumer description|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--picture` `<url>`|Application logo URL|
+|`--rights` `<rights>`|Comma-separated list of rights (access-organisations, access-organisations-bills, access-organisations-consumption-statistics, access-organisations-credit-count, access-personal-information, manage-organisations, manage-organisations-applications, manage-organisations-members, manage-organisations-services, manage-personal-information, manage-ssh-keys, all)|
+|`--url` `<url>`|Application home URL|
+
+## ➡️ `clever oauth-consumers delete` <kbd>Since unreleased</kbd>
+
+Delete an OAuth consumer
+
+```bash
+clever oauth-consumers delete <consumer-key|consumer-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-y`, `--yes`|Skip confirmation and proceed with deletion directly|
+
+## ➡️ `clever oauth-consumers get` <kbd>Since unreleased</kbd>
+
+Get details of an OAuth consumer
+
+```bash
+clever oauth-consumers get <consumer-key|consumer-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`--with-secret`|Include the consumer secret in the output|
+
+## ➡️ `clever oauth-consumers list` <kbd>Since unreleased</kbd>
+
+List OAuth consumers
+
+```bash
+clever oauth-consumers list [options]
+```
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+
+## ➡️ `clever oauth-consumers open` <kbd>Since unreleased</kbd>
+
+Open an OAuth consumer in the Clever Cloud Console
+
+```bash
+clever oauth-consumers open <consumer-key|consumer-name>
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+
+## ➡️ `clever oauth-consumers update` <kbd>Since unreleased</kbd>
+
+Update an OAuth consumer
+
+```bash
+clever oauth-consumers update <consumer-key|consumer-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`--base-url` `<url>`|OAuth callback base URL|
+|`-d`, `--description` `<description>`|Consumer description|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-n`, `--name` `<name>`|Consumer name|
+|`--picture` `<url>`|Application logo URL|
+|`--rights` `<rights>`|Comma-separated list of rights (access-organisations, access-organisations-bills, access-organisations-consumption-statistics, access-organisations-credit-count, access-personal-information, manage-organisations, manage-organisations-applications, manage-organisations-members, manage-organisations-services, manage-personal-information, manage-ssh-keys, all)|
+|`--url` `<url>`|Application home URL|

--- a/src/commands/oauth-consumers/oauth-consumers.get.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.get.command.js
@@ -1,0 +1,67 @@
+import { getSecret as getOauthConsumerSecret } from '@clevercloud/client/esm/api/v2/oauth-consumer.js';
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { Logger } from '../../logger.js';
+import { OAUTH_RIGHTS, resolveOauthConsumer } from '../../models/oauth-consumer.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { humanJsonOutputFormatOption } from '../global.options.js';
+import { consumerKeyOrNameArg } from './oauth-consumers.args.js';
+
+export const oauthConsumersGetCommand = defineCommand({
+  description: 'Get details of an OAuth consumer',
+  since: 'unreleased',
+  options: {
+    format: humanJsonOutputFormatOption,
+    withSecret: defineOption({
+      name: 'with-secret',
+      schema: z.boolean().default(false),
+      description: 'Include the consumer secret in the output',
+    }),
+  },
+  args: [consumerKeyOrNameArg],
+  async handler(options, keyOrName) {
+    const { format, withSecret } = options;
+
+    const oauthConsumer = await resolveOauthConsumer(keyOrName);
+
+    const secret = withSecret
+      ? await getOauthConsumerSecret({ id: oauthConsumer.ownerId, key: oauthConsumer.key })
+          .then(sendToApi)
+          .then((c) => c.secret)
+      : null;
+
+    switch (format) {
+      case 'json': {
+        Logger.printJson({ ...oauthConsumer, ...(secret != null && { secret }) });
+        break;
+      }
+      case 'human':
+      default: {
+        const dataToPrint = {
+          Key: oauthConsumer.key,
+          Name: oauthConsumer.name || '(unnamed)',
+          Description: oauthConsumer.description || '',
+          URL: oauthConsumer.url || '',
+          Picture: oauthConsumer.picture || '',
+          'Base URL': oauthConsumer.baseUrl || '',
+        };
+
+        if (secret != null) {
+          dataToPrint.Secret = secret;
+        }
+
+        console.table(dataToPrint);
+
+        if (oauthConsumer.rights) {
+          Logger.println('');
+          const rightsData = {};
+          for (const [apiName, cliName] of Object.entries(OAUTH_RIGHTS)) {
+            rightsData[cliName] = oauthConsumer.rights[apiName] ?? false;
+          }
+          console.table(rightsData);
+        }
+      }
+    }
+  },
+});

--- a/src/commands/oauth-consumers/oauth-consumers.list.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.list.command.js
@@ -1,0 +1,34 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { printItemsByOwner } from '../../lib/print-items-by-owner.js';
+import { Logger } from '../../logger.js';
+import { getAllConsumers } from '../../models/oauth-consumer.js';
+import { humanJsonOutputFormatOption } from '../global.options.js';
+
+export const oauthConsumersListCommand = defineCommand({
+  description: 'List OAuth consumers',
+  since: 'unreleased',
+  options: {
+    format: humanJsonOutputFormatOption,
+  },
+  async handler(options) {
+    const { format } = options;
+    const oauthConsumers = await getAllConsumers();
+
+    switch (format) {
+      case 'json': {
+        const consumersPerOwner = Object.groupBy(oauthConsumers, (c) => c.ownerId);
+        Logger.printJson(consumersPerOwner);
+        break;
+      }
+      case 'human':
+      default: {
+        printItemsByOwner(oauthConsumers, {
+          itemName: 'OAuth consumer',
+          emptyCommand: 'clever oauth-consumers create',
+          getItemId: (c) => c.key,
+          getExtraLines: (c) => (c.url ? `URL: ${c.url}` : null),
+        });
+      }
+    }
+  },
+});

--- a/src/commands/oauth-consumers/oauth-consumers.open.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.open.command.js
@@ -1,0 +1,18 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { styleText } from '../../lib/style-text.js';
+import { resolveOauthConsumer } from '../../models/oauth-consumer.js';
+import { openBrowser } from '../../models/utils.js';
+import { consumerKeyOrNameArg } from './oauth-consumers.args.js';
+
+export const oauthConsumersOpenCommand = defineCommand({
+  description: 'Open an OAuth consumer in the Clever Cloud Console',
+  since: 'unreleased',
+  args: [consumerKeyOrNameArg],
+  async handler(options, keyOrName) {
+    const oauthConsumer = await resolveOauthConsumer(keyOrName);
+    await openBrowser(
+      `/organisations/${oauthConsumer.ownerId}/oauth-consumers/${oauthConsumer.key}`,
+      `Opening OAuth consumer ${styleText('blue', oauthConsumer.key)} in the browser…`,
+    );
+  },
+});

--- a/src/commands/oauth-consumers/oauth-consumers.options.js
+++ b/src/commands/oauth-consumers/oauth-consumers.options.js
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { defineOption } from '../../lib/define-option.js';
+import { OAUTH_RIGHTS } from '../../models/oauth-consumer.js';
+
+export const descriptionOption = defineOption({
+  name: 'description',
+  schema: z.string().trim().min(1).optional(),
+  description: 'Consumer description',
+  aliases: ['d'],
+  placeholder: 'description',
+});
+
+export const urlOption = defineOption({
+  name: 'url',
+  schema: z.string().url().optional(),
+  description: 'Application home URL',
+  placeholder: 'url',
+});
+
+export const pictureOption = defineOption({
+  name: 'picture',
+  schema: z.string().url().optional(),
+  description: 'Application logo URL',
+  placeholder: 'url',
+});
+
+export const baseUrlOption = defineOption({
+  name: 'base-url',
+  schema: z.string().url().optional(),
+  description: 'OAuth callback base URL',
+  placeholder: 'url',
+});
+
+/** @type {[string, ...string[]]} */
+const OAUTH_RIGHTS_WITH_ALL = [...Object.values(OAUTH_RIGHTS), 'all'];
+
+const rightsSchema = z
+  .string()
+  .transform((s) => s.split(',').map((r) => r.trim()))
+  .pipe(z.array(z.enum(OAUTH_RIGHTS_WITH_ALL)))
+  .optional();
+
+export const rightsOption = defineOption({
+  name: 'rights',
+  schema: rightsSchema,
+  description: `Comma-separated list of rights (${OAUTH_RIGHTS_WITH_ALL.join(', ')})`,
+  placeholder: 'rights',
+});

--- a/src/commands/oauth-consumers/oauth-consumers.update.command.js
+++ b/src/commands/oauth-consumers/oauth-consumers.update.command.js
@@ -1,0 +1,83 @@
+import { update as updateOauthConsumer } from '@clevercloud/client/esm/api/v2/oauth-consumer.js';
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { promptTextOption } from '../../lib/prompts.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import {
+  promptRights,
+  removeReadonlyRights,
+  resolveOauthConsumer,
+  rightsFromList,
+} from '../../models/oauth-consumer.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { humanJsonOutputFormatOption } from '../global.options.js';
+import { consumerKeyOrNameArg } from './oauth-consumers.args.js';
+import { baseUrlOption, descriptionOption, pictureOption, rightsOption, urlOption } from './oauth-consumers.options.js';
+
+const nameOption = defineOption({
+  name: 'name',
+  schema: z.string().trim().min(1).optional(),
+  description: 'Consumer name',
+  aliases: ['n'],
+  placeholder: 'name',
+});
+
+export const oauthConsumersUpdateCommand = defineCommand({
+  description: 'Update an OAuth consumer',
+  since: 'unreleased',
+  options: {
+    name: nameOption,
+    description: descriptionOption,
+    url: urlOption,
+    picture: pictureOption,
+    baseUrl: baseUrlOption,
+    rights: rightsOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [consumerKeyOrNameArg],
+  async handler(options, keyOrName) {
+    const { name, description, url, picture, baseUrl, rights, format } = options;
+
+    const oauthConsumer = await resolveOauthConsumer(keyOrName);
+
+    const hasAnyOption = [name, description, url, picture, baseUrl, rights].some((v) => v != null);
+
+    const body = hasAnyOption
+      ? {
+          name: name ?? oauthConsumer.name,
+          description: description ?? oauthConsumer.description,
+          url: url ?? oauthConsumer.url,
+          picture: picture ?? oauthConsumer.picture,
+          baseUrl: baseUrl ?? oauthConsumer.baseUrl,
+          rights: rights != null ? rightsFromList(rights) : removeReadonlyRights(oauthConsumer.rights),
+        }
+      : {
+          name: await promptTextOption(nameOption, oauthConsumer.name),
+          description: await promptTextOption(descriptionOption, oauthConsumer.description),
+          url: await promptTextOption(urlOption, oauthConsumer.url),
+          picture: await promptTextOption(pictureOption, oauthConsumer.picture),
+          baseUrl: await promptTextOption(baseUrlOption, oauthConsumer.baseUrl),
+          rights: await promptRights(oauthConsumer.rights),
+        };
+
+    const updatedOauthConsumer = await updateOauthConsumer(
+      { id: oauthConsumer.ownerId, key: oauthConsumer.key },
+      body,
+    ).then(sendToApi);
+
+    switch (format) {
+      case 'json': {
+        Logger.printJson(updatedOauthConsumer);
+        break;
+      }
+      case 'human':
+      default: {
+        Logger.printSuccess(
+          `OAuth consumer ${styleText(['bold', 'green'], updatedOauthConsumer.key)} has been updated!`,
+        );
+      }
+    }
+  },
+});

--- a/src/commands/open/open.command.js
+++ b/src/commands/open/open.command.js
@@ -19,6 +19,6 @@ export const openCommand = defineCommand({
     const vhost = await Domain.getBest(appId, ownerId);
     const url = 'https://' + vhost.fqdn;
 
-    await openBrowser(url, 'Opening the application in your browser');
+    await openBrowser(url, 'Opening the application in the browser…');
   },
 });

--- a/src/commands/profile/profile.open.command.js
+++ b/src/commands/profile/profile.open.command.js
@@ -7,6 +7,6 @@ export const profileOpenCommand = defineCommand({
   options: {},
   args: [],
   async handler() {
-    await openBrowser('/users/me/information', 'Opening the profile page in your browser');
+    await openBrowser('/users/me/information', 'Opening the profile page in the browser…');
   },
 });

--- a/src/commands/ssh-keys/ssh-keys.open.command.js
+++ b/src/commands/ssh-keys/ssh-keys.open.command.js
@@ -7,6 +7,6 @@ export const sshKeysOpenCommand = defineCommand({
   options: {},
   args: [],
   handler() {
-    return openBrowser('/users/me/ssh-keys', 'Opening the SSH keys management page of the Console in your browser');
+    return openBrowser('/users/me/ssh-keys', 'Opening the SSH keys page in the browser…');
   },
 });

--- a/src/commands/webhooks/webhooks.remove.command.js
+++ b/src/commands/webhooks/webhooks.remove.command.js
@@ -1,7 +1,7 @@
 import { deleteWebhook } from '@clevercloud/client/esm/api/v2/notification.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
-import { getOrgaIdOrUserId } from '../../models/notification.js';
+import { getOwnerIdFromOrgIdOrName } from '../../models/ids-resolver.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import { notificationIdArg } from '../global.args.js';
 import { orgaIdOrNameOption } from '../global.options.js';
@@ -16,7 +16,7 @@ export const webhooksRemoveCommand = defineCommand({
   async handler(options, notificationId) {
     const { org } = options;
 
-    const ownerId = await getOrgaIdOrUserId(org);
+    const ownerId = await getOwnerIdFromOrgIdOrName(org);
     await deleteWebhook({ ownerId, id: notificationId }).then(sendToApi);
 
     Logger.println('The notification has been successfully removed');

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -15,6 +15,7 @@ import { findAddonsByAddonProvider } from '../models/ids-resolver.js';
 import * as Operator from '../models/operator.js';
 import { sendToApi } from '../models/send-to-api.js';
 import { openBrowser } from '../models/utils.js';
+import { printItemsByOwner } from './print-items-by-owner.js';
 import { confirm, selectAnswer } from './prompts.js';
 import { styleText } from './style-text.js';
 
@@ -141,30 +142,18 @@ export async function operatorNgEnable(provider, addonIdOrName) {
 export async function operatorList(provider, format) {
   const deployed = await findAddonsByAddonProvider(provider);
   const providerName = _.capitalize(provider.replace('addon-', ''));
-  const operatorsPerOwner = _.groupBy(deployed, 'ownerId');
-
   switch (format) {
-    case 'json':
+    case 'json': {
+      const operatorsPerOwner = Object.groupBy(deployed, (o) => o.ownerId);
       Logger.printJson(operatorsPerOwner);
       break;
+    }
     case 'human':
     default:
-      if (deployed.length === 0) {
-        Logger.println(
-          `🔎 No ${providerName} found, create one with ${styleText('blue', `clever addon create ${providerName.toLocaleLowerCase()}`)} command`,
-        );
-        return;
-      }
-
-      Logger.println(`🔎 Found ${deployed.length} ${providerName} operator${deployed.length > 1 ? 's' : ''}:`);
-      Logger.println();
-
-      Object.values(operatorsPerOwner).forEach((operators) => {
-        Logger.println(`• ${styleText('bold', `${operators[0].ownerId} (${operators[0].ownerName})`)}`);
-        operators.forEach((operator) => {
-          Logger.println(`  • ${operator.name} ${styleText('grey', `(${operator.realId})`)}`);
-        });
-        Logger.println();
+      printItemsByOwner(deployed, {
+        itemName: `${providerName} operator`,
+        emptyCommand: `clever addon create ${providerName.toLocaleLowerCase()}`,
+        getItemId: (o) => o.realId,
       });
       break;
   }

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -180,7 +180,7 @@ export async function operatorOpen(provider, addonIdOrName) {
   const operator = await Operator.getDetails(provider, addonIdOrName);
   await openBrowser(
     `${config.GOTO_URL}/${operator.addonId}`,
-    `🌐 Opening ${styleText('blue', operator.addonId)} in the browser…`,
+    `Opening ${styleText('blue', operator.addonId)} in the browser…`,
   );
 }
 
@@ -194,7 +194,7 @@ export async function operatorOpenLogs(provider, addonIdOrName) {
   const operator = await Operator.getDetails(provider, addonIdOrName);
   await openBrowser(
     `/organisations/${operator.ownerId}/applications/${operator.resources.entrypoint}/logs`,
-    `🌐 Opening ${styleText('blue', operator.addonId)} logs in the Clever Cloud Console…`,
+    `Opening ${styleText('blue', operator.addonId)} logs in the browser…`,
   );
 }
 
@@ -206,10 +206,7 @@ export async function operatorOpenLogs(provider, addonIdOrName) {
  */
 export async function operatorOpenWebUi(provider, addonIdOrName) {
   const operator = await Operator.getDetails(provider, addonIdOrName);
-  await openBrowser(
-    operator.accessUrl,
-    `🌐 Opening ${styleText('blue', operator.addonId)} Management interface in the browser…`,
-  );
+  await openBrowser(operator.accessUrl, `Opening ${styleText('blue', operator.addonId)} web UI in the browser…`);
 }
 
 /**

--- a/src/lib/print-items-by-owner.js
+++ b/src/lib/print-items-by-owner.js
@@ -1,0 +1,38 @@
+import { Logger } from '../logger.js';
+import { styleText } from './style-text.js';
+
+/**
+ * Print a list of items grouped by owner with consistent formatting.
+ * Items must have ownerId, ownerName and name properties.
+ * @param {Array} items - The items to display
+ * @param {Object} options
+ * @param {string} options.itemName - Singular name for the items (e.g. "configuration provider")
+ * @param {string} options.emptyCommand - Command suggestion shown when no items are found
+ * @param {Function} options.getItemId - Function to get the item ID from an item
+ * @param {Function} [options.getExtraLines] - Function returning extra detail lines to display below the item (nulls filtered)
+ */
+export function printItemsByOwner(items, { itemName, emptyCommand, getItemId, getExtraLines }) {
+  if (items.length === 0) {
+    Logger.println(`🔎 No ${itemName} found, create one with ${styleText('blue', emptyCommand)} command`);
+    return;
+  }
+
+  const plural = items.length > 1 ? 's' : '';
+  Logger.println(`🔎 Found ${items.length} ${itemName}${plural}:`);
+  Logger.println();
+
+  const groups = Object.groupBy(items, (item) => item.ownerId);
+  for (const group of Object.values(groups)) {
+    const { ownerId, ownerName } = group[0];
+    Logger.println(`• ${styleText('bold', `${ownerId} (${ownerName})`)}`);
+    for (const item of group) {
+      Logger.println(`  • ${item.name || '(unnamed)'} ${styleText('grey', `(${getItemId(item)})`)}`);
+      if (getExtraLines != null) {
+        for (const line of [getExtraLines(item)].flat().filter(Boolean)) {
+          Logger.println(`    ${line}`);
+        }
+      }
+    }
+    Logger.println();
+  }
+}

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,4 +1,5 @@
-import { confirm as confirmPrompt, input, password, select } from '@inquirer/prompts';
+import { checkbox, confirm as confirmPrompt, input, password, select } from '@inquirer/prompts';
+import { unwrapSchema } from './zod-utils.js';
 
 export function promptSecret(message) {
   return password({ message, mask: true }).catch(exitOnPromptError);
@@ -22,6 +23,27 @@ export async function confirmAnswer(message, rejectionMessage, expectedAnswer) {
 
 export function selectAnswer(message, choices) {
   return select({ message, choices }).catch(exitOnPromptError);
+}
+
+export function promptCheckbox(message, choices) {
+  return checkbox({ message, choices }).catch(exitOnPromptError);
+}
+
+/**
+ * Prompt the user for a text value based on an option definition.
+ * Derives the prompt message from option.description and validation from option.schema.
+ * @param {import('./define-option.types.js').OptionDefinition} option
+ * @param {string} [defaultValue]
+ * @returns {Promise<string>}
+ */
+export function promptTextOption(option, defaultValue) {
+  const message = `${option.description}:`;
+  const innerSchema = unwrapSchema(option.schema);
+  const validate = (value) => {
+    const result = innerSchema.safeParse(value);
+    return result.success || result.error.issues[0]?.message || 'Invalid value';
+  };
+  return input({ message, default: defaultValue, validate }).catch(exitOnPromptError);
 }
 
 function exitOnPromptError(error) {

--- a/src/lib/zod-utils.js
+++ b/src/lib/zod-utils.js
@@ -66,6 +66,29 @@ export function getEnumValues(schema) {
 }
 
 /**
+ * Unwraps optional/nullable/default/pipe wrappers to get the inner schema.
+ * @param {ZodSchemaLike} schema
+ * @return {ZodSchemaLike}
+ */
+export function unwrapSchema(schema) {
+  /** @type {ZodSchemaLike | undefined} */
+  let current = schema;
+  while (current) {
+    const schemaType = current._def?.type;
+    if (schemaType === 'optional' || schemaType === 'nullable' || schemaType === 'default') {
+      current = current._def?.innerType;
+      continue;
+    }
+    if (schemaType === 'pipe') {
+      current = current._def?.in;
+      continue;
+    }
+    break;
+  }
+  return /** @type {ZodSchemaLike} */ (current);
+}
+
+/**
  * Extracts the default value from a Zod schema.
  * Handles wrapped schemas (optional, nullable, pipe).
  * @param {ZodSchemaLike} schema

--- a/src/models/ids-resolver.js
+++ b/src/models/ids-resolver.js
@@ -94,6 +94,9 @@ async function getIdsFromSummary() {
       ids.addons[addon.id] = addonIds;
       ids.addons[addon.realId] = addonIds;
     }
+    for (const consumer of owner.consumers) {
+      ids.owners[consumer.key] = owner.id;
+    }
   }
 
   return ids;
@@ -172,6 +175,32 @@ export async function findAddonsByAddonProvider(provider) {
   }
 
   return candidates;
+}
+
+/**
+ * Find OAuth consumers by key or name.
+ * Fast path: tries the IDs cache first (works for keys).
+ * Fallback: fetches the summary and searches by key or name.
+ * @param {string} keyOrName
+ * @returns {Promise<Array<{ ownerId: string, key: string, name: string }>>}
+ */
+export async function findOauthConsumersByKeyOrName(keyOrName) {
+  const ownerIdFromCache = await resolveOwnerId(keyOrName);
+  if (ownerIdFromCache != null) {
+    return [{ ownerId: ownerIdFromCache, key: keyOrName }];
+  }
+
+  const summary = await getSummary().then(sendToApi);
+  const consumers = [summary.user, ...summary.organisations].flatMap((owner) => {
+    return owner.consumers.map((c) => ({ ownerId: owner.id, name: c.name, key: c.key }));
+  });
+
+  const matchByKey = consumers.find((c) => c.key === keyOrName);
+  if (matchByKey) {
+    return [matchByKey];
+  }
+
+  return consumers.filter((c) => c.name === keyOrName);
 }
 
 /**

--- a/src/models/notification.js
+++ b/src/models/notification.js
@@ -6,10 +6,6 @@ export function listMetaEvents() {
   return ['META_SERVICE_LIFECYCLE', 'META_DEPLOYMENT_RESULT', 'META_SERVICE_MANAGEMENT', 'META_CREDITS'];
 }
 
-export function getOrgaIdOrUserId(orgIdOrName) {
-  return orgIdOrName == null ? User.getCurrentId() : Organisation.getId(orgIdOrName);
-}
-
 export async function getOwnerAndApp(org, useLinkedApp) {
   if (org != null) {
     return { ownerId: await Organisation.getId(org) };

--- a/src/models/oauth-consumer.js
+++ b/src/models/oauth-consumer.js
@@ -1,0 +1,77 @@
+import { get as getOauthConsumer } from '@clevercloud/client/esm/api/v2/oauth-consumer.js';
+import { getSummary } from '@clevercloud/client/esm/api/v2/user.js';
+import { promptCheckbox } from '../lib/prompts.js';
+import { styleText } from '../lib/style-text.js';
+import { findOauthConsumersByKeyOrName } from './ids-resolver.js';
+import { sendToApi } from './send-to-api.js';
+
+/* eslint-disable camelcase */
+export const OAUTH_RIGHTS = {
+  access_organisations: 'access-organisations',
+  access_organisations_bills: 'access-organisations-bills',
+  access_organisations_consumption_statistics: 'access-organisations-consumption-statistics',
+  access_organisations_credit_count: 'access-organisations-credit-count',
+  access_personal_information: 'access-personal-information',
+  manage_organisations: 'manage-organisations',
+  manage_organisations_applications: 'manage-organisations-applications',
+  manage_organisations_members: 'manage-organisations-members',
+  manage_organisations_services: 'manage-organisations-services',
+  manage_personal_information: 'manage-personal-information',
+  manage_ssh_keys: 'manage-ssh-keys',
+};
+/* eslint-enable camelcase */
+
+export function rightsFromList(requestedRights = []) {
+  const hasAll = requestedRights.includes('all');
+  return Object.fromEntries(
+    Object.entries(OAUTH_RIGHTS).map(([apiName, cliName]) => {
+      return [apiName, hasAll || requestedRights.includes(cliName)];
+    }),
+  );
+}
+
+const READONLY_RIGHTS = ['almighty'];
+
+export function removeReadonlyRights(rights) {
+  return Object.fromEntries(
+    Object.entries(rights).filter(([key]) => {
+      return !READONLY_RIGHTS.includes(key);
+    }),
+  );
+}
+
+export async function promptRights(existingRights) {
+  const choices = Object.entries(OAUTH_RIGHTS).map(([apiName, cliName]) => ({
+    name: cliName,
+    value: cliName,
+    checked: existingRights?.[apiName] ?? false,
+  }));
+
+  const selected = await promptCheckbox('Select rights', choices);
+
+  return rightsFromList(selected);
+}
+
+export async function getAllConsumers() {
+  const summary = await getSummary().then(sendToApi);
+  return [summary.user, ...summary.organisations].flatMap((owner) => {
+    return owner.consumers.map((c) => ({ ownerId: owner.id, ownerName: owner.name, ...c }));
+  });
+}
+
+export async function resolveOauthConsumer(keyOrName) {
+  const candidates = await findOauthConsumersByKeyOrName(keyOrName);
+
+  if (candidates.length === 0) {
+    throw new Error(`OAuth consumer not found: ${styleText('red', keyOrName)}`);
+  }
+
+  if (candidates.length > 1) {
+    const list = candidates.map((c) => `  - ${c.name} ${styleText('grey', `(${c.key})`)}`).join('\n');
+    throw new Error(`Ambiguous name ${styleText('red', keyOrName)}, use the key instead:\n${list}`);
+  }
+
+  const { ownerId, key } = candidates[0];
+  const oauthConsumer = await getOauthConsumer({ id: ownerId, key }).then(sendToApi);
+  return { ownerId, ...oauthConsumer };
+}

--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -26,7 +26,7 @@ export function openBrowser(urlOrPath, message) {
   const url = urlOrPath.startsWith('/') ? `${config.CONSOLE_URL}${urlOrPath}` : urlOrPath;
 
   Logger.debug(`Opening URL "${url}" in browser`);
-  Logger.println(message);
+  Logger.println(`🌐 ${message}`);
 
   return openPage(url, { wait: false });
 }


### PR DESCRIPTION
## Context
Add CLI commands to manage OAuth consumers directly from `clever-tools`. This enables users to create, list, get, update, delete, and open OAuth consumers — both for personal accounts and organisations.

This is a rework of the original implementation by @davlgd with a focus on consistency with the rest of the codebase.

## Proposal
The PR is structured as preparatory refactorings followed by the feature itself:

### Refactoring (6 commits)
- Remove redundant properties (`options: {}`, `args: []`, `handler: null`) from parent namespace commands
- Normalize `openBrowser` messages across all commands (centralize 🌐 prefix, consistent wording)
- Rename `confirmAddonDeletionOption` → `skipConfirmationOption` for broader reuse
- Consolidate owner ID resolution into `getOwnerIdFromOrgIdOrName` (from `ids-resolver`)
- Extract `printItemsByOwner` utility (shared by config-provider list and operator list)
- Add `promptCheckbox`, `promptTextOption`, and `unwrapSchema` utilities

### Feature (1 commit)
- New `oauth-consumers` command group with 6 subcommands: `create`, `delete`, `get`, `list`, `open`, `update`
- Consumer resolution by key or name (with disambiguation prompt if name is ambiguous)
- Interactive rights selection via checkbox prompt for `create` and `update`
- Support for `--format json` output and `--org` targeting
- Model layer with full CRUD via Clever Cloud API (`/v2/oauth/consumers`)

## How to review
1. Start with the refactoring commits (oldest first) — each is self-contained
2. Then review the feature commit, starting with `src/models/oauth-consumer.js` (API layer) and `src/commands/oauth-consumers/` (command definitions)