### PR TITLE
feat: add service-tokens command

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -3049,6 +3049,103 @@ app-id|app-name                Application ID (or name, if unambiguous)
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 ```
 
+## service-tokens
+
+**Description:** Manage organisation service tokens for machine-to-machine authentication
+
+**Since:** 4.8.0
+
+**Usage**
+```
+clever service-tokens
+```
+
+### service-tokens create
+
+**Description:** Create a service token for an organisation
+
+**Since:** 4.8.0
+
+**Usage**
+```
+clever service-tokens create <token-name> [options]
+```
+
+**Arguments**
+```
+token-name                              Service token name
+```
+
+**Options**
+```
+-d, --description <description>         Service token description
+-e, --expiration <expiration>           Duration until token expiration (e.g.: 1h, 4d, 2w, 6M, 1y) (default: 90d)
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+    --resources <id1,id2,...>           Scope token to specific resources by app ID, add-on ID, or real ID (comma-separated)
+-r, --role <role>                       Role assigned to the service token (Admin, Manager, Developer, Accounting) (Admin, Manager, Developer, Accounting)
+```
+
+### service-tokens get
+
+**Description:** Get details about a service token
+
+**Since:** 4.8.0
+
+**Usage**
+```
+clever service-tokens get <token-id|token-name> [options]
+```
+
+**Arguments**
+```
+token-id|token-name                     Service token ID or name
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
+### service-tokens list
+
+**Description:** List service tokens for an organisation
+
+**Since:** 4.8.0
+
+**Usage**
+```
+clever service-tokens list [options]
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
+### service-tokens revoke
+
+**Description:** Revoke a service token
+
+**Since:** 4.8.0
+
+**Usage**
+```
+clever service-tokens revoke <token-id|token-name> [options]
+```
+
+**Arguments**
+```
+token-id|token-name                     Service token ID or name
+```
+
+**Options**
+```
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
 ## ssh
 
 **Description:** Connect to running instances through SSH

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -55,6 +55,7 @@ These options are available for all commands:
 |[`clever restart`](./restart/restart.docs.md)|Start or restart an application|
 |[`clever scale`](./scale/scale.docs.md)|Change scalability of an application|
 |[`clever service`](./service/service.docs.md)|Manage service dependencies|
+|[`clever service-tokens`](./service-tokens/service-tokens.docs.md)|Manage organisation service tokens for machine-to-machine authentication|
 |[`clever ssh`](./ssh/ssh.docs.md)|Connect to running instances through SSH|
 |[`clever ssh-keys`](./ssh-keys/ssh-keys.docs.md)|Manage SSH keys of the current user|
 |[`clever status`](./status/status.docs.md)|See the status of an application|

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -141,6 +141,11 @@ import { publishedConfigRmCommand } from './published-config/published-config.rm
 import { publishedConfigSetCommand } from './published-config/published-config.set.command.js';
 import { restartCommand } from './restart/restart.command.js';
 import { scaleCommand } from './scale/scale.command.js';
+import { serviceTokensCommand } from './service-tokens/service-tokens.command.js';
+import { serviceTokensCreateCommand } from './service-tokens/service-tokens.create.command.js';
+import { serviceTokensGetCommand } from './service-tokens/service-tokens.get.command.js';
+import { serviceTokensListCommand } from './service-tokens/service-tokens.list.command.js';
+import { serviceTokensRevokeCommand } from './service-tokens/service-tokens.revoke.command.js';
 import { serviceCommand } from './service/service.command.js';
 import { serviceLinkAddonCommand } from './service/service.link-addon.command.js';
 import { serviceLinkAppCommand } from './service/service.link-app.command.js';
@@ -442,6 +447,15 @@ export const globalCommands = {
       'link-app': serviceLinkAppCommand,
       'unlink-addon': serviceUnlinkAddonCommand,
       'unlink-app': serviceUnlinkAppCommand,
+    },
+  ],
+  'service-tokens': [
+    serviceTokensCommand,
+    {
+      create: serviceTokensCreateCommand,
+      get: serviceTokensGetCommand,
+      list: serviceTokensListCommand,
+      revoke: serviceTokensRevokeCommand,
     },
   ],
   ssh: sshCommand,

--- a/src/commands/service-tokens/service-tokens.command.js
+++ b/src/commands/service-tokens/service-tokens.command.js
@@ -1,0 +1,10 @@
+import { defineCommand } from '../../lib/define-command.js';
+
+export const serviceTokensCommand = defineCommand({
+  description: 'Manage organisation service tokens for machine-to-machine authentication',
+  since: '4.8.0',
+  options: {},
+  args: [],
+  // Parent command - no handler, only contains subcommands
+  handler: null,
+});

--- a/src/commands/service-tokens/service-tokens.create.command.js
+++ b/src/commands/service-tokens/service-tokens.create.command.js
@@ -1,0 +1,140 @@
+import dedent from 'dedent';
+import { z } from 'zod';
+import { formatDate } from '../../lib/date-utils.js';
+import { defineArgument } from '../../lib/define-argument.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { selectAnswer } from '../../lib/prompts.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import * as Organisation from '../../models/organisation.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { createServiceToken } from '../../models/service-token.js';
+import * as User from '../../models/user.js';
+import { futureDateOrDuration } from '../../parsers.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+
+const SERVICE_TOKEN_ROLES = ['Admin', 'Manager', 'Developer', 'Accounting'];
+
+export const serviceTokensCreateCommand = defineCommand({
+  description: 'Create a service token for an organisation',
+  since: '4.8.0',
+  options: {
+    org: orgaIdOrNameOption,
+    role: defineOption({
+      name: 'role',
+      schema: z.enum(SERVICE_TOKEN_ROLES).optional(),
+      description: 'Role assigned to the service token (Admin, Manager, Developer, Accounting)',
+      aliases: ['r'],
+      placeholder: 'role',
+    }),
+    resources: defineOption({
+      name: 'resources',
+      schema: z
+        .string()
+        .transform((v) => v.split(','))
+        .optional(),
+      description: 'Scope token to specific resources by app ID, add-on ID, or real ID (comma-separated)',
+      placeholder: 'id1,id2,...',
+    }),
+    description: defineOption({
+      name: 'description',
+      schema: z.string().optional(),
+      description: 'Service token description',
+      aliases: ['d'],
+      placeholder: 'description',
+    }),
+    expiration: defineOption({
+      name: 'expiration',
+      schema: z.string().default('90d').transform(futureDateOrDuration),
+      description: 'Duration until token expiration (e.g.: 1h, 4d, 2w, 6M, 1y)',
+      aliases: ['e'],
+      placeholder: 'expiration',
+    }),
+    format: humanJsonOutputFormatOption,
+  },
+  args: [
+    defineArgument({
+      schema: z.string(),
+      description: 'Service token name',
+      placeholder: 'token-name',
+    }),
+  ],
+  async handler(options, tokenName) {
+    const { org, description, resources, expiration, format } = options;
+    let { role } = options;
+
+    if (role == null) {
+      const roleChoices = SERVICE_TOKEN_ROLES.map((r) => ({
+        name: r,
+        value: r,
+      }));
+      role = await selectAnswer('Select a role for the service token:', roleChoices);
+    }
+
+    const orgaId = org != null ? await Organisation.getId(org) : await User.getCurrentId();
+    const ttlSeconds = Math.max(1, Math.floor((expiration.getTime() - Date.now()) / 1000));
+
+    const body = {
+      name: tokenName,
+      role: role.toUpperCase(),
+      // eslint-disable-next-line camelcase
+      ttl_seconds: ttlSeconds,
+      ...(description != null && { description }),
+      ...(resources != null && { resources }),
+    };
+
+    const response = await createServiceToken(orgaId, body)
+      .then(sendToApi)
+      .catch((error) => {
+        const fields = error?.responseBody?.fields;
+        if (fields != null) {
+          const details = Object.entries(fields)
+            .map(([key, msg]) => `${key.replace('serviceToken.', '')}: ${msg}`)
+            .join(', ');
+          throw new Error(details);
+        }
+        throw error;
+      });
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(response);
+        break;
+      case 'human':
+      default: {
+        const revokeCmd =
+          org != null
+            ? `clever service-tokens revoke ${response.metadata.id} --org ${orgaId}`
+            : `clever service-tokens revoke ${response.metadata.id}`;
+
+        const firstResource = resources?.[0];
+        let curlPath;
+        if (firstResource == null) {
+          curlPath = `/v2/organisations/${orgaId}/applications`;
+        } else if (firstResource.startsWith('app_')) {
+          curlPath = `/v2/organisations/${orgaId}/applications/${firstResource}`;
+        } else {
+          curlPath = `/v2/organisations/${orgaId}/addons/${firstResource}`;
+        }
+
+        Logger.println(dedent`
+            ${styleText('green', '✔')} Service token successfully created! Store it securely, you won't be able to print it again.
+
+              - Token ID    : ${styleText('grey', response.metadata.id)}
+              - Token       : ${styleText('grey', response.token)}
+              - Role        : ${styleText('grey', role)}
+              - Expiration  : ${styleText('grey', formatDate(response.metadata.expiredAt))}
+
+            Export this token and use it to make authenticated requests to the Clever Cloud API:
+
+            export CC_SERVICE_TOKEN=${response.token}
+            curl -H "Authorization: Bearer $CC_SERVICE_TOKEN" https://api.clever-cloud.com${curlPath}
+
+            Then, to revoke this token, run:
+            ${revokeCmd}
+          `);
+      }
+    }
+  },
+});

--- a/src/commands/service-tokens/service-tokens.docs.md
+++ b/src/commands/service-tokens/service-tokens.docs.md
@@ -1,0 +1,90 @@
+# 📖 `clever service-tokens` command reference
+
+## ➡️ `clever service-tokens` <kbd>Since 4.8.0</kbd>
+
+Manage organisation service tokens for machine-to-machine authentication
+
+```bash
+clever service-tokens
+```
+
+## ➡️ `clever service-tokens create` <kbd>Since 4.8.0</kbd>
+
+Create a service token for an organisation
+
+```bash
+clever service-tokens create <token-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`token-name`|Service token name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-d`, `--description` `<description>`|Service token description|
+|`-e`, `--expiration` `<expiration>`|Duration until token expiration (e.g.: 1h, 4d, 2w, 6M, 1y) (default: 90d)|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--resources` `<id1,id2,...>`|Scope token to specific resources by app ID, add-on ID, or real ID (comma-separated)|
+|`-r`, `--role` `<role>`|Role assigned to the service token (Admin, Manager, Developer, Accounting) (Admin, Manager, Developer, Accounting)|
+
+## ➡️ `clever service-tokens get` <kbd>Since 4.8.0</kbd>
+
+Get details about a service token
+
+```bash
+clever service-tokens get <token-id|token-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`token-id|token-name`|Service token ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever service-tokens list` <kbd>Since 4.8.0</kbd>
+
+List service tokens for an organisation
+
+```bash
+clever service-tokens list [options]
+```
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever service-tokens revoke` <kbd>Since 4.8.0</kbd>
+
+Revoke a service token
+
+```bash
+clever service-tokens revoke <token-id|token-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`token-id|token-name`|Service token ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|

--- a/src/commands/service-tokens/service-tokens.get.command.js
+++ b/src/commands/service-tokens/service-tokens.get.command.js
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { formatDate } from '../../lib/date-utils.js';
+import { defineArgument } from '../../lib/define-argument.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import * as Organisation from '../../models/organisation.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { getServiceTokenById, resolveServiceTokenId } from '../../models/service-token.js';
+import * as User from '../../models/user.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+
+export const serviceTokensGetCommand = defineCommand({
+  description: 'Get details about a service token',
+  since: '4.8.0',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [
+    defineArgument({
+      schema: z.string(),
+      description: 'Service token ID or name',
+      placeholder: 'token-id|token-name',
+    }),
+  ],
+  async handler(options, tokenIdOrName) {
+    const { org, format } = options;
+
+    const orgaId = org != null ? await Organisation.getId(org) : await User.getCurrentId();
+    const tokenId = await resolveServiceTokenId(orgaId, tokenIdOrName);
+    const token = await getServiceTokenById(orgaId, tokenId).then(sendToApi);
+
+    if (format === 'json') {
+      Logger.printJson(token);
+    } else {
+      console.table({
+        'Token ID': token.id,
+        Name: token.name,
+        Description: token.description ?? '',
+        Status: token.status,
+        Created: formatDate(token.createdAt),
+        Expires: formatDate(token.expiredAt),
+        ...(token.revokedAt != null && { Revoked: formatDate(token.revokedAt) }),
+      });
+    }
+  },
+});

--- a/src/commands/service-tokens/service-tokens.list.command.js
+++ b/src/commands/service-tokens/service-tokens.list.command.js
@@ -1,0 +1,47 @@
+import { formatDate } from '../../lib/date-utils.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import * as Organisation from '../../models/organisation.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { listServiceTokens } from '../../models/service-token.js';
+import * as User from '../../models/user.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+
+export const serviceTokensListCommand = defineCommand({
+  description: 'List service tokens for an organisation',
+  since: '4.8.0',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [],
+  async handler(options) {
+    const { org, format } = options;
+
+    const orgaId = org != null ? await Organisation.getId(org) : await User.getCurrentId();
+    const tokens = await listServiceTokens(orgaId).then(sendToApi);
+
+    if (format === 'json') {
+      Logger.printJson(tokens);
+    } else {
+      if (tokens.length === 0) {
+        Logger.println(
+          `No service token found, create one with ${styleText('blue', 'clever service-tokens create')} command`,
+        );
+      } else {
+        console.table(
+          tokens.map((token) => {
+            return {
+              'Token ID': token.id,
+              Name: token.name,
+              Status: token.status,
+              Created: formatDate(token.createdAt),
+              Expires: formatDate(token.expiredAt),
+            };
+          }),
+        );
+      }
+    }
+  },
+});

--- a/src/commands/service-tokens/service-tokens.revoke.command.js
+++ b/src/commands/service-tokens/service-tokens.revoke.command.js
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { defineArgument } from '../../lib/define-argument.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { Logger } from '../../logger.js';
+import * as Organisation from '../../models/organisation.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { deleteServiceToken, resolveServiceTokenId } from '../../models/service-token.js';
+import * as User from '../../models/user.js';
+import { orgaIdOrNameOption } from '../global.options.js';
+
+export const serviceTokensRevokeCommand = defineCommand({
+  description: 'Revoke a service token',
+  since: '4.8.0',
+  options: {
+    org: orgaIdOrNameOption,
+  },
+  args: [
+    defineArgument({
+      schema: z.string(),
+      description: 'Service token ID or name',
+      placeholder: 'token-id|token-name',
+    }),
+  ],
+  async handler(options, tokenIdOrName) {
+    const { org } = options;
+
+    const orgaId = org != null ? await Organisation.getId(org) : await User.getCurrentId();
+    const tokenId = await resolveServiceTokenId(orgaId, tokenIdOrName);
+    await deleteServiceToken(orgaId, tokenId).then(sendToApi);
+
+    Logger.printSuccess('Service token successfully revoked!');
+  },
+});

--- a/src/models/service-token.js
+++ b/src/models/service-token.js
@@ -1,0 +1,60 @@
+import dedent from 'dedent';
+import { styleText } from '../lib/style-text.js';
+import { sendToApi } from './send-to-api.js';
+
+const TOKEN_ID_REGEX = /^token_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function listServiceTokens(orgaId) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v2/organisations/${orgaId}/service-tokens`,
+    headers: { Accept: 'application/json' },
+  });
+}
+
+export function getServiceTokenById(orgaId, tokenId) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v2/organisations/${orgaId}/service-tokens/${tokenId}`,
+    headers: { Accept: 'application/json' },
+  });
+}
+
+export async function resolveServiceTokenId(orgaId, tokenIdOrName) {
+  if (TOKEN_ID_REGEX.test(tokenIdOrName)) {
+    return tokenIdOrName;
+  }
+
+  const tokens = await listServiceTokens(orgaId).then(sendToApi);
+  const matches = tokens.filter((t) => t.name === tokenIdOrName);
+
+  if (matches.length === 0) {
+    throw new Error(`Could not find service token ${styleText('red', tokenIdOrName)}`);
+  }
+  if (matches.length > 1) {
+    const list = matches.map((t) => `- ${t.name} (${t.id})`).join('\n');
+    throw new Error(dedent`
+      Ambiguous name ${styleText('red', tokenIdOrName)}, use the ID instead:
+      ${styleText('grey', list)}
+    `);
+  }
+
+  return matches[0].id;
+}
+
+export function createServiceToken(orgaId, body) {
+  return Promise.resolve({
+    method: 'post',
+    url: `/v2/organisations/${orgaId}/service-tokens`,
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body,
+  });
+}
+
+export function deleteServiceToken(orgaId, tokenId) {
+  return Promise.resolve({
+    method: 'delete',
+    url: `/v2/organisations/${orgaId}/service-tokens/${tokenId}`,
+    headers: { Accept: 'application/json' },
+  });
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing organisation service tokens, enabling machine-to-machine authentication in the Clever Cloud CLI. It adds a new top-level command, `clever service-tokens`, with subcommands to create, get, list, and revoke service tokens. The implementation includes comprehensive documentation, command definitions, and supporting model functions. I've build it according to existing (API) `tokens` command

You'll find draft Service Tokens documentation [here](https://github.com/CleverCloud/documentation/pull/911). 

The most important changes are:

**New Service Tokens Command Suite:**

* Added a new top-level command `service-tokens` with subcommands for creating, retrieving, listing, and revoking organisation service tokens, including all necessary options and argument parsing (`src/commands/service-tokens/service-tokens.command.js`, `src/commands/service-tokens/service-tokens.create.command.js`, `src/commands/service-tokens/service-tokens.get.command.js`, `src/commands/service-tokens/service-tokens.list.command.js`, `src/commands/service-tokens/service-tokens.revoke.command.js`, `src/commands/global.commands.js`) [[1]](diffhunk://#diff-bca25d3ce619058b322be0020913485db1f36edef699badce032e39e6f08f694R1-R10) [[2]](diffhunk://#diff-516adf096f5a08222953c5cffc689b99697279f9d36e5fa21ac704d416e9a624R1-R139) [[3]](diffhunk://#diff-aa9aa057e864189ea09da628a1e31069406ebaa47c45d4cb91e0a52b45aed3d1R1-R47) [[4]](diffhunk://#diff-43e31c70a606fa2c0d641268a14736c4f43729e284fe306c7a6da62ba56ae75dR1-R47) [[5]](diffhunk://#diff-1dce641ef42486213603d5ac3307fd7a06f650b3232e9a8ef19b46bb462a0d2aR1-R33) [[6]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR144-R148) [[7]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR452-R460).

* Implemented model functions for service token API interactions, including listing, retrieving, creating, deleting, and resolving tokens by name or ID (`src/models/service-token.js`).

**Documentation Updates:**

* Added detailed documentation for the new `service-tokens` command and its subcommands, including usage examples, arguments, and options (`src/commands/service-tokens/service-tokens.docs.md`, `skills/clever-tools/references/full-documentation.md`) [[1]](diffhunk://#diff-1ae56dbb04ae59bc5ebdd9cc822302062ef4c128e91ebb761fd4015664af16fbR1-R90) [[2]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR3052-R3148).

* Updated the main command reference to include the new `service-tokens` command (`src/commands/README.md`).