### PR TITLE
refactor(config): enhance config with @clevercloud/reglage

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,3 +44,5 @@ jobs:
         run: npm run typecheck
       - name: 'Check generated docs are up to date'
         run: npm run docs:check
+      - name: 'Run unit tests'
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/traverse": "7.28.5",
         "@clevercloud/client": "12.0.0",
+        "@clevercloud/reglage": "0.0.5",
         "@inquirer/prompts": "7.8.4",
         "char-regex": "2.0.2",
         "cliparse": "0.5.0",
@@ -1143,6 +1144,15 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0"
+      }
+    },
+    "node_modules/@clevercloud/reglage": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@clevercloud/reglage/-/reglage-0.0.5.tgz",
+      "integrity": "sha512-kWSRR4Xfn2qSFFxQOT4uqKGVUALwLXHK5a2Wv08B7VwSpJlQN+OWHOdivEBjmUeLACtuG4kgLhgHnHQ5uGkWEQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^4"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -9535,6 +9545,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@babel/traverse": "7.28.5",
     "@clevercloud/client": "12.0.0",
+    "@clevercloud/reglage": "0.0.5",
     "@inquirer/prompts": "7.8.4",
     "char-regex": "2.0.2",
     "cliparse": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "install-local:cliparse": "(cd ../cliparse-node && npm pack) && mv ../cliparse-node/cliparse-*.tgz . && npm i -f ./cliparse-*.tgz",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check",
+    "test": "node --experimental-test-module-mocks --test src/**/*.test.js",
+    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check && npm run test",
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -35,7 +35,7 @@ import { parseMarkdown } from './lib/markdown.js';
 
 const typedGlobalCommands = globalCommands;
 
-const apiClient = new CcApiClient({ baseUrl: baseConfig.API_HOST });
+const apiClient = new CcApiClient({ baseUrl: baseConfig.get('API_HOST') });
 
 runCommand(async () => {
   const checkMode = process.argv.includes('--check');

--- a/src/commands/addon/addon.create.command.js
+++ b/src/commands/addon/addon.create.command.js
@@ -20,7 +20,7 @@ const ADDON_PROVIDERS = {
   keycloak: {
     name: 'Keycloak',
     operatorProvider: 'keycloak',
-    postCreateInstructions: `Learn more about Keycloak on Clever Cloud: ${config.DOC_URL}/addons/keycloak/`,
+    postCreateInstructions: `Learn more about Keycloak on Clever Cloud: ${config.get('DOC_URL')}/addons/keycloak/`,
   },
   kv: {
     name: 'Materia KV',
@@ -29,27 +29,27 @@ const ADDON_PROVIDERS = {
       ${styleText('yellow', "You can easily use Materia KV with 'redis-cli', with such commands:")}
       ${styleText('blue', `source <(clever addon env ${addonId} -F shell)`)}
       ${styleText('blue', 'redis-cli -h $KV_HOST -p $KV_PORT --tls')}
-      Learn more about Materia KV on Clever Cloud: ${config.DOC_URL}/addons/materia-kv/
+      Learn more about Materia KV on Clever Cloud: ${config.get('DOC_URL')}/addons/materia-kv/
     `,
   },
   'addon-matomo': {
     name: 'Matomo',
     operatorProvider: 'matomo',
-    postCreateInstructions: `Learn more about Matomo on Clever Cloud: ${config.DOC_URL}/addons/matomo/`,
+    postCreateInstructions: `Learn more about Matomo on Clever Cloud: ${config.get('DOC_URL')}/addons/matomo/`,
   },
   metabase: {
     name: 'Metabase',
     operatorProvider: 'metabase',
-    postCreateInstructions: `Learn more about Metabase on Clever Cloud: ${config.DOC_URL}/addons/metabase/`,
+    postCreateInstructions: `Learn more about Metabase on Clever Cloud: ${config.get('DOC_URL')}/addons/metabase/`,
   },
   otoroshi: {
     name: 'Otoroshi with LLM',
     operatorProvider: 'otoroshi',
-    postCreateInstructions: `Learn more about Otoroshi with LLM on Clever Cloud: ${config.DOC_URL}/addons/otoroshi/`,
+    postCreateInstructions: `Learn more about Otoroshi with LLM on Clever Cloud: ${config.get('DOC_URL')}/addons/otoroshi/`,
   },
   'addon-pulsar': {
     name: 'Pulsar',
-    postCreateInstructions: `Learn more about Pulsar on Clever Cloud: ${config.DOC_URL}/addons/pulsar/`,
+    postCreateInstructions: `Learn more about Pulsar on Clever Cloud: ${config.get('DOC_URL')}/addons/pulsar/`,
   },
 };
 
@@ -198,7 +198,7 @@ export const addonCreateCommand = defineCommand({
         Logger.println();
         Logger.println(`Your ${ADDON_PROVIDERS[providerName].name} is starting:`);
         Logger.println(` - Access it: ${operator.accessUrl}`);
-        Logger.println(` - Manage it: ${config.GOTO_URL}/${newAddon.id}`);
+        Logger.println(` - Manage it: ${config.get('GOTO_URL')}/${newAddon.id}`);
       }
 
       if (operator.initialCredentials) {

--- a/src/commands/config-provider/config-provider.open.command.js
+++ b/src/commands/config-provider/config-provider.open.command.js
@@ -12,6 +12,6 @@ export const configProviderOpenCommand = defineCommand({
   args: [configProviderIdOrNameArg],
   async handler(_options, addonIdOrRealIdOrName) {
     const { addonId } = await resolveConfigProviderId(addonIdOrRealIdOrName);
-    await openBrowser(`${config.GOTO_URL}/${addonId}`, `Opening ${styleText('blue', addonId)} in the browser…`);
+    await openBrowser(`${config.get('GOTO_URL')}/${addonId}`, `Opening ${styleText('blue', addonId)} in the browser…`);
   },
 });

--- a/src/commands/create/create.command.js
+++ b/src/commands/create/create.command.js
@@ -75,7 +75,7 @@ async function displayAppCreation(app, alias, github, taskCommand) {
   }
 
   Logger.println(
-    `  ${styleText('blue', '→')} Manage your application at: ${styleText('underline', `${config.GOTO_URL}/${app.id}`)}`,
+    `  ${styleText('blue', '→')} Manage your application at: ${styleText('underline', `${config.get('GOTO_URL')}/${app.id}`)}`,
   );
   Logger.println('');
 }

--- a/src/commands/curl/curl.command.js
+++ b/src/commands/curl/curl.command.js
@@ -10,8 +10,8 @@ function getTokens() {
   return {
     OAUTH_CONSUMER_KEY: config.get('OAUTH_CONSUMER_KEY'),
     OAUTH_CONSUMER_SECRET: config.get('OAUTH_CONSUMER_SECRET'),
-    API_OAUTH_TOKEN: config.get('token'),
-    API_OAUTH_TOKEN_SECRET: config.get('secret'),
+    API_OAUTH_TOKEN: config.activeProfile?.token,
+    API_OAUTH_TOKEN_SECRET: config.activeProfile?.secret,
   };
 }
 

--- a/src/commands/curl/curl.command.js
+++ b/src/commands/curl/curl.command.js
@@ -8,10 +8,10 @@ import { Logger } from '../../logger.js';
 
 function getTokens() {
   return {
-    OAUTH_CONSUMER_KEY: config.OAUTH_CONSUMER_KEY,
-    OAUTH_CONSUMER_SECRET: config.OAUTH_CONSUMER_SECRET,
-    API_OAUTH_TOKEN: config.token,
-    API_OAUTH_TOKEN_SECRET: config.secret,
+    OAUTH_CONSUMER_KEY: config.get('OAUTH_CONSUMER_KEY'),
+    OAUTH_CONSUMER_SECRET: config.get('OAUTH_CONSUMER_SECRET'),
+    API_OAUTH_TOKEN: config.get('token'),
+    API_OAUTH_TOKEN_SECRET: config.get('secret'),
   };
 }
 
@@ -20,16 +20,16 @@ function printCleverCurlHelp() {
     Usage: clever curl
     Query Clever Cloud's API using Clever Tools credentials. For example:
     
-      clever curl ${config.API_HOST}/v2/self
-      clever curl ${config.API_HOST}/v2/summary
-      clever curl ${config.API_HOST}/v4/products/zones
-      clever curl ${config.API_HOST}/v2/organisations/<ORGANISATION_ID>/applications | jq '.[].id'
-      clever curl ${config.API_HOST}/v4/billing/organisations/<ORGANISATION_ID>/<INVOICE_NUMBER>.pdf > invoice.pdf
-    
+      clever curl ${config.get('API_HOST')}/v2/self
+      clever curl ${config.get('API_HOST')}/v2/summary
+      clever curl ${config.get('API_HOST')}/v4/products/zones
+      clever curl ${config.get('API_HOST')}/v2/organisations/<ORGANISATION_ID>/applications | jq '.[].id'
+      clever curl ${config.get('API_HOST')}/v4/billing/organisations/<ORGANISATION_ID>/<INVOICE_NUMBER>.pdf > invoice.pdf
+
     Our API documentation is available here :
-    
-      ${config.API_DOC_URL}/v2/
-      ${config.API_DOC_URL}/v4/
+
+      ${config.get('API_DOC_URL')}/v2/
+      ${config.get('API_DOC_URL')}/v4/
   `);
 }
 
@@ -45,11 +45,11 @@ export async function curl() {
     return;
   }
 
-  const curlUrl = curlArgs.find((part) => part.startsWith(config.API_HOST));
+  const curlUrl = curlArgs.find((part) => part.startsWith(config.get('API_HOST')));
 
   // We only allow request to the respective API_HOST
   if (curlUrl == null) {
-    Logger.error('"clever curl" command must be used with ' + styleText('blue', config.API_HOST));
+    Logger.error('"clever curl" command must be used with ' + styleText('blue', config.get('API_HOST')));
     process.exit(1);
   }
 

--- a/src/commands/diag/diag.command.js
+++ b/src/commands/diag/diag.command.js
@@ -55,7 +55,7 @@ export const diagCommand = defineCommand({
     format: humanJsonOutputFormatOption,
   },
   async handler(options) {
-    const activeProfile = config.profiles[0];
+    const activeProfile = config.get('profiles')[0];
     const user = await getUser({})
       .then(sendToApi)
       .catch(() => null);
@@ -71,15 +71,15 @@ export const diagCommand = defineCommand({
       terminal: getTerminal(),
       isPackaged: process.pkg != null,
       execPath: process.execPath,
-      configFile: config.CONFIGURATION_FILE,
+      configFile: config.get('CONFIGURATION_FILE'),
       profile: activeProfile?.alias ?? null,
       userId: activeProfile?.userId ?? user?.id ?? null,
       authSource: activeProfile?.alias === '$env' ? 'environment variables' : 'configuration file',
-      oAuthToken: config.token,
+      oAuthToken: config.get('token'),
       loggedIn: user != null,
       profileOverrides: activeProfile?.overrides ?? null,
       // No longer useful but kept for compatibility reasons
-      authState: getAuthState({ hasToken: config.token != null, apiUser: user }),
+      authState: getAuthState({ hasToken: config.get('token') != null, apiUser: user }),
     };
 
     const linuxInfos = await getLinuxInfos()

--- a/src/commands/diag/diag.command.js
+++ b/src/commands/diag/diag.command.js
@@ -55,7 +55,7 @@ export const diagCommand = defineCommand({
     format: humanJsonOutputFormatOption,
   },
   async handler(options) {
-    const activeProfile = config.get('profiles')[0];
+    const activeProfile = config.activeProfile;
     const user = await getUser({})
       .then(sendToApi)
       .catch(() => null);
@@ -75,11 +75,11 @@ export const diagCommand = defineCommand({
       profile: activeProfile?.alias ?? null,
       userId: activeProfile?.userId ?? user?.id ?? null,
       authSource: activeProfile?.alias === '$env' ? 'environment variables' : 'configuration file',
-      oAuthToken: config.get('token'),
+      oAuthToken: activeProfile?.token,
       loggedIn: user != null,
       profileOverrides: activeProfile?.overrides ?? null,
       // No longer useful but kept for compatibility reasons
-      authState: getAuthState({ hasToken: config.get('token') != null, apiUser: user }),
+      authState: getAuthState({ hasToken: activeProfile?.token != null, apiUser: user }),
     };
 
     const linuxInfos = await getLinuxInfos()

--- a/src/commands/login/login.command.js
+++ b/src/commands/login/login.command.js
@@ -67,7 +67,7 @@ async function loginViaConsole(apiHost, consoleTokenUrl) {
  * @returns {import('../../config/config.js').Profile | undefined}
  */
 function getExistingTargetProfile(alias) {
-  return config.profiles.find((profile) => profile.alias === alias);
+  return config.get('profiles').find((profile) => profile.alias === alias);
 }
 
 export const loginCommand = defineCommand({
@@ -145,8 +145,8 @@ export const loginCommand = defineCommand({
       throw new Error('Both `--token` and `--secret` must be defined');
     }
 
-    const apiHost = options.apiHost ?? baseConfig.API_HOST;
-    const consoleUrl = options.consoleUrl ? `${options.consoleUrl}/cli-oauth` : baseConfig.CONSOLE_TOKEN_URL;
+    const apiHost = options.apiHost ?? baseConfig.get('API_HOST');
+    const consoleUrl = options.consoleUrl ? `${options.consoleUrl}/cli-oauth` : baseConfig.get('CONSOLE_TOKEN_URL');
 
     if (!hasToken && existingTargetProfile != null) {
       // KO fallback wording (3 lines):
@@ -166,8 +166,8 @@ export const loginCommand = defineCommand({
         token: oauthData.token,
         secret: oauthData.secret,
         apiHost,
-        consumerKey: options.consumerKey ?? baseConfig.OAUTH_CONSUMER_KEY,
-        consumerSecret: options.consumerSecret ?? baseConfig.OAUTH_CONSUMER_SECRET,
+        consumerKey: options.consumerKey ?? baseConfig.get('OAUTH_CONSUMER_KEY'),
+        consumerSecret: options.consumerSecret ?? baseConfig.get('OAUTH_CONSUMER_SECRET'),
       }),
     );
 

--- a/src/commands/login/login.command.js
+++ b/src/commands/login/login.command.js
@@ -67,7 +67,7 @@ async function loginViaConsole(apiHost, consoleTokenUrl) {
  * @returns {import('../../config/config.js').Profile | undefined}
  */
 function getExistingTargetProfile(alias) {
-  return config.get('profiles').find((profile) => profile.alias === alias);
+  return config.profiles.find((profile) => profile.alias === alias);
 }
 
 export const loginCommand = defineCommand({

--- a/src/commands/logout/logout.command.js
+++ b/src/commands/logout/logout.command.js
@@ -19,11 +19,11 @@ export const logoutCommand = defineCommand({
     }),
   },
   async handler(options) {
-    if (config.profiles.length === 0) {
+    if (config.get('profiles').length === 0) {
       throw new Error(`No profile found, use ${styleText('red', 'clever login')} command`);
     }
 
-    const [activeProfile] = config.profiles;
+    const [activeProfile] = config.get('profiles');
     const aliasToRemove = options.alias ?? activeProfile.alias;
 
     if (aliasToRemove === '$env') {
@@ -32,7 +32,7 @@ export const logoutCommand = defineCommand({
       );
     }
 
-    const profileToRemove = config.profiles.find((p) => p.alias === aliasToRemove);
+    const profileToRemove = config.get('profiles').find((p) => p.alias === aliasToRemove);
     if (profileToRemove == null) {
       throw new Error(`Profile "${aliasToRemove}" not found.`);
     }

--- a/src/commands/logout/logout.command.js
+++ b/src/commands/logout/logout.command.js
@@ -19,11 +19,11 @@ export const logoutCommand = defineCommand({
     }),
   },
   async handler(options) {
-    if (config.get('profiles').length === 0) {
+    if (config.profiles.length === 0) {
       throw new Error(`No profile found, use ${styleText('red', 'clever login')} command`);
     }
 
-    const [activeProfile] = config.get('profiles');
+    const activeProfile = config.activeProfile;
     const aliasToRemove = options.alias ?? activeProfile.alias;
 
     if (aliasToRemove === '$env') {
@@ -32,7 +32,7 @@ export const logoutCommand = defineCommand({
       );
     }
 
-    const profileToRemove = config.get('profiles').find((p) => p.alias === aliasToRemove);
+    const profileToRemove = config.profiles.find((p) => p.alias === aliasToRemove);
     if (profileToRemove == null) {
       throw new Error(`Profile "${aliasToRemove}" not found.`);
     }

--- a/src/commands/profile/profile.command.js
+++ b/src/commands/profile/profile.command.js
@@ -12,7 +12,7 @@ export const profileCommand = defineCommand({
     format: humanJsonOutputFormatOption,
   },
   async handler(options) {
-    const [activeProfile] = config.profiles;
+    const [activeProfile] = config.get('profiles');
     if (activeProfile == null) {
       throw new Error(`No profile found, use ${styleText('red', 'clever login')} command`);
     }

--- a/src/commands/profile/profile.command.js
+++ b/src/commands/profile/profile.command.js
@@ -12,7 +12,7 @@ export const profileCommand = defineCommand({
     format: humanJsonOutputFormatOption,
   },
   async handler(options) {
-    const [activeProfile] = config.get('profiles');
+    const activeProfile = config.activeProfile;
     if (activeProfile == null) {
       throw new Error(`No profile found, use ${styleText('red', 'clever login')} command`);
     }

--- a/src/commands/profile/profile.list.command.js
+++ b/src/commands/profile/profile.list.command.js
@@ -11,12 +11,12 @@ export const profileListCommand = defineCommand({
     format: humanJsonOutputFormatOption,
   },
   async handler(options) {
-    if (config.get('profiles').length === 0) {
+    if (config.activeProfile == null) {
       throw new Error('No profile found. You are not logged in.');
     }
 
     const profilesDetails = await Promise.all(
-      config.get('profiles').map(async (profile, index) => {
+      config.profiles.map(async (profile, index) => {
         return getProfileDetails({
           profile,
           isActive: index === 0,

--- a/src/commands/profile/profile.list.command.js
+++ b/src/commands/profile/profile.list.command.js
@@ -11,12 +11,12 @@ export const profileListCommand = defineCommand({
     format: humanJsonOutputFormatOption,
   },
   async handler(options) {
-    if (config.profiles.length === 0) {
+    if (config.get('profiles').length === 0) {
       throw new Error('No profile found. You are not logged in.');
     }
 
     const profilesDetails = await Promise.all(
-      config.profiles.map(async (profile, index) => {
+      config.get('profiles').map(async (profile, index) => {
         return getProfileDetails({
           profile,
           isActive: index === 0,

--- a/src/commands/profile/profile.switch.command.js
+++ b/src/commands/profile/profile.switch.command.js
@@ -22,22 +22,22 @@ export const profileSwitchCommand = defineCommand({
     }),
   },
   async handler(options) {
-    if (config.get('profiles').length === 0) {
+    if (config.profiles.length === 0) {
       throw new Error('No profile found.');
     }
 
-    if (config.get('profiles').length === 1) {
+    if (config.profiles.length === 1) {
       throw new Error('Only one profile. Use clever login --alias <name> to add another.');
     }
 
-    const [activeProfile] = config.get('profiles');
+    const activeProfile = config.activeProfile;
     if (activeProfile.alias === '$env') {
       throw new Error(
         `Cannot switch profiles while using environment-based authentication, unset ${styleText('red', 'CLEVER_TOKEN')} and ${styleText('red', 'CLEVER_SECRET')} instead`,
       );
     }
 
-    const targetProfile = await resolveTargetProfile(config.get('profiles'), options.alias);
+    const targetProfile = await resolveTargetProfile(config.profiles, options.alias);
     if (targetProfile.alias === activeProfile.alias) {
       Logger.printInfo(`Already on profile ${styleText('blue', formatProfile(activeProfile))}`);
       return;

--- a/src/commands/profile/profile.switch.command.js
+++ b/src/commands/profile/profile.switch.command.js
@@ -22,22 +22,22 @@ export const profileSwitchCommand = defineCommand({
     }),
   },
   async handler(options) {
-    if (config.profiles.length === 0) {
+    if (config.get('profiles').length === 0) {
       throw new Error('No profile found.');
     }
 
-    if (config.profiles.length === 1) {
+    if (config.get('profiles').length === 1) {
       throw new Error('Only one profile. Use clever login --alias <name> to add another.');
     }
 
-    const [activeProfile] = config.profiles;
+    const [activeProfile] = config.get('profiles');
     if (activeProfile.alias === '$env') {
       throw new Error(
         `Cannot switch profiles while using environment-based authentication, unset ${styleText('red', 'CLEVER_TOKEN')} and ${styleText('red', 'CLEVER_SECRET')} instead`,
       );
     }
 
-    const targetProfile = await resolveTargetProfile(config.profiles, options.alias);
+    const targetProfile = await resolveTargetProfile(config.get('profiles'), options.alias);
     if (targetProfile.alias === activeProfile.alias) {
       Logger.printInfo(`Already on profile ${styleText('blue', formatProfile(activeProfile))}`);
       return;

--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -65,7 +65,7 @@ export const sshCommand = defineCommand({
     if (identityFile != null) {
       sshParams.push('-i', identityFile);
     }
-    sshParams.push(config.SSH_GATEWAY, sshTarget);
+    sshParams.push(config.get('SSH_GATEWAY'), sshTarget);
 
     // Interactive session mode (spawn SSH with inherited stdio)
     if (command == null) {

--- a/src/commands/tokens/tokens.command.js
+++ b/src/commands/tokens/tokens.command.js
@@ -8,7 +8,7 @@ import { sendToAuthBridge } from '../../models/send-to-api.js';
 import { humanJsonOutputFormatOption } from '../global.options.js';
 
 export const tokensCommand = defineCommand({
-  description: `Manage API tokens to query Clever Cloud API from ${config.AUTH_BRIDGE_HOST}`,
+  description: `Manage API tokens to query Clever Cloud API from ${config.get('AUTH_BRIDGE_HOST')}`,
   since: '3.12.0',
   options: {
     format: humanJsonOutputFormatOption,

--- a/src/commands/tokens/tokens.create.command.js
+++ b/src/commands/tokens/tokens.create.command.js
@@ -39,7 +39,7 @@ export const tokensCreateCommand = defineCommand({
     const user = await getCurrentUser();
 
     if (!user.hasPassword) {
-      const apiTokenListHref = new URL('/users/me/api-tokens', config.CONSOLE_URL).href;
+      const apiTokenListHref = new URL('/users/me/api-tokens', config.get('CONSOLE_URL')).href;
       throw new Error(dedent`
           ${styleText('yellow', '!')} Your Clever Cloud account is linked via GitHub and has no password. Setting one is required to create API tokens.
           ${styleText('blue', '→')} To do so, go to the following URL: ${styleText('blue', apiTokenListHref)}
@@ -98,7 +98,7 @@ export const tokensCreateCommand = defineCommand({
             Export this token and use it to make authenticated requests to the Clever Cloud API through the Auth Bridge:
     
             export CC_API_TOKEN=${createdToken.apiToken}
-            curl -H "Authorization: Bearer $CC_API_TOKEN" ${config.AUTH_BRIDGE_HOST}/v2/self
+            curl -H "Authorization: Bearer $CC_API_TOKEN" ${config.get('AUTH_BRIDGE_HOST')}/v2/self
     
             Then, to revoke this token, run:
             clever tokens revoke ${createdToken.apiTokenId}

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -62,11 +62,6 @@ const ConfigSchema = z
     // Default values are computed from `CONSOLE_URL` below
     CONSOLE_TOKEN_URL: z.url().optional(),
     GOTO_URL: z.url().optional(),
-
-    token: z.string().optional(),
-    secret: z.string().optional(),
-    expirationDate: z.string().optional(),
-    profiles: z.array(ProfileSchema).default([]),
   })
   .transform((config) => ({
     ...config,
@@ -76,7 +71,7 @@ const ConfigSchema = z
 
 /** @typedef {z.infer<typeof ConfigSchema>} ConfigData */
 
-export class Config {
+export class BaseConfig {
   /**
    * @param {ConfigData} config
    */
@@ -102,12 +97,46 @@ export class Config {
   }
 }
 
+export class Config extends BaseConfig {
+  /**
+   * @param {Object} param
+   * @param {ConfigData} param.data
+   * @param {Profile[]} param.profiles
+   */
+  constructor({ data, profiles }) {
+    super(data);
+    /** @type {Profile[]} */
+    this._profiles = profiles;
+  }
+
+  /**
+   * @param {Profile[]} profiles
+   */
+  reloadProfiles(profiles) {
+    this._profiles = profiles;
+  }
+
+  /**
+   * @returns {Profile[]}
+   */
+  get profiles() {
+    return this._profiles;
+  }
+
+  /**
+   * @returns {Profile | undefined}
+   */
+  get activeProfile() {
+    return this._profiles[0];
+  }
+}
+
 /**
  * Base configuration: environment variables + Zod schema defaults, without any profile overrides.
  * Use this as fallback when operating on a specific profile (login, profile list)
  * to avoid being affected by the active profile's overrides.
  */
-export const baseConfig = new Config(loadBaseConfig());
+export const baseConfig = new BaseConfig(loadBaseConfig());
 
 /**
  * @returns {ConfigData}
@@ -131,13 +160,14 @@ function loadBaseConfig() {
 export const config = new Config(loadConfig());
 
 /**
- * @returns {ConfigData}
+ * @returns {{data: ConfigData, profiles: Profile[]}}
  */
 function loadConfig() {
   Logger.debug(`Load configuration from ${baseConfig.get('CONFIGURATION_FILE')}`);
   const configFromFile = loadConfigFile();
 
   // If CLEVER_TOKEN and CLEVER_SECRET are set, inject a virtual "$env" profile as the active one
+  /** @type {Profile[]} */
   const profiles =
     process.env.CLEVER_TOKEN != null && process.env.CLEVER_SECRET != null
       ? [
@@ -150,10 +180,8 @@ function loadConfig() {
 
   /** @type {z.input<typeof ConfigSchema>} */
   const rawConfig = {
-    ...activeProfile,
     // Profile overrides (e.g. custom API_HOST) applied after profile auth data, before env vars
     ...activeProfile?.overrides,
-    profiles,
     ...process.env,
   };
 
@@ -165,7 +193,7 @@ function loadConfig() {
     process.exit(1);
   }
 
-  return result.data;
+  return { data: result.data, profiles };
 }
 
 /**
@@ -252,5 +280,7 @@ async function updateConfigFile(newConfig) {
  * This ensures all modules referencing the config object see the updated values.
  */
 export function reloadConfig() {
-  config.reload(loadConfig());
+  const { data, profiles } = loadConfig();
+  config.reload(data);
+  config.reloadProfiles(profiles);
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -74,15 +74,43 @@ const ConfigSchema = z
     GOTO_URL: config.GOTO_URL ?? `${config.CONSOLE_URL}/goto`,
   }));
 
+/** @typedef {z.infer<typeof ConfigSchema>} ConfigData */
+
+export class Config {
+  /**
+   * @param {ConfigData} config
+   */
+  constructor(config) {
+    /** @type {ConfigData} */
+    this._config = config;
+  }
+
+  /**
+   * @param {ConfigData} config
+   */
+  reload(config) {
+    this._config = config;
+  }
+
+  /**
+   * @template {keyof ConfigData} K
+   * @param {K} key
+   * @returns {ConfigData[K]}
+   */
+  get(key) {
+    return this._config[key];
+  }
+}
+
 /**
  * Base configuration: environment variables + Zod schema defaults, without any profile overrides.
  * Use this as fallback when operating on a specific profile (login, profile list)
  * to avoid being affected by the active profile's overrides.
  */
-export const baseConfig = loadBaseConfig();
+export const baseConfig = new Config(loadBaseConfig());
 
 /**
- * @returns {z.output<typeof ConfigSchema>}
+ * @returns {ConfigData}
  */
 function loadBaseConfig() {
   const result = ConfigSchema.safeParse(process.env);
@@ -100,13 +128,13 @@ function loadBaseConfig() {
  * The complete configuration object, loaded synchronously at startup.
  * Priority: environment variables > active profile overrides > Zod schema defaults.
  */
-export const config = loadConfig();
+export const config = new Config(loadConfig());
 
 /**
- * @returns {z.output<typeof ConfigSchema>}
+ * @returns {ConfigData}
  */
 function loadConfig() {
-  Logger.debug(`Load configuration from ${baseConfig.CONFIGURATION_FILE}`);
+  Logger.debug(`Load configuration from ${baseConfig.get('CONFIGURATION_FILE')}`);
   const configFromFile = loadConfigFile();
 
   // If CLEVER_TOKEN and CLEVER_SECRET are set, inject a virtual "$env" profile as the active one
@@ -145,7 +173,7 @@ function loadConfig() {
  * @returns {ConfigFile}
  */
 function loadConfigFile() {
-  const data = readJsonSync(baseConfig.CONFIGURATION_FILE);
+  const data = readJsonSync(baseConfig.get('CONFIGURATION_FILE'));
 
   // Try parsing as current format
   const result = ConfigFileSchema.safeParse(data);
@@ -212,10 +240,10 @@ export async function removeProfile(alias) {
 async function updateConfigFile(newConfig) {
   Logger.debug('Write the new config in the configuration file…');
   try {
-    await writeJson(baseConfig.CONFIGURATION_FILE, newConfig, { mode: 0o700 });
+    await writeJson(baseConfig.get('CONFIGURATION_FILE'), newConfig, { mode: 0o700 });
     reloadConfig();
   } catch (error) {
-    throw new Error(`Cannot write configuration to ${baseConfig.CONFIGURATION_FILE}\n${error.message}`);
+    throw new Error(`Cannot write configuration to ${baseConfig.get('CONFIGURATION_FILE')}\n${error.message}`);
   }
 }
 
@@ -224,10 +252,5 @@ async function updateConfigFile(newConfig) {
  * This ensures all modules referencing the config object see the updated values.
  */
 export function reloadConfig() {
-  const mutableConfig = /** @type {Record<string, unknown>} */ (config);
-  for (const key of Object.keys(mutableConfig)) {
-    delete mutableConfig[key];
-  }
-  const newConfig = loadConfig();
-  Object.assign(config, newConfig);
+  config.reload(loadConfig());
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,3 +1,4 @@
+import { createConfigBuilder, InvalidConfigError } from '@clevercloud/reglage';
 import path from 'node:path';
 import { z } from 'zod';
 import { readJsonSync, writeJson } from '../lib/fs.js';
@@ -40,36 +41,71 @@ const ConfigFileSchema = z.object({
 
 /** @typedef {z.infer<typeof ConfigFileSchema>} ConfigFile */
 
-const ConfigSchema = z
-  .object({
-    CONFIGURATION_FILE: z.string().default(getConfigPath('clever-tools.json')),
-    EXPERIMENTAL_FEATURES_FILE: z.string().default(getConfigPath('clever-tools-experimental-features.json')),
-    APP_CONFIGURATION_FILE: z.string().default(() => path.resolve('.', '.clever.json')),
+const CONFIG_SCHEMA = {
+  CONFIGURATION_FILE: {
+    schema: z.string().default(getConfigPath('clever-tools.json')),
+    documentation: 'Path to the main configuration file',
+  },
+  EXPERIMENTAL_FEATURES_FILE: {
+    schema: z.string().default(getConfigPath('clever-tools-experimental-features.json')),
+    documentation: 'Path to the experimental features configuration file',
+  },
+  APP_CONFIGURATION_FILE: {
+    schema: z.string().default(path.resolve('.', '.clever.json')),
+    documentation: 'Path to the per-project application configuration file',
+  },
 
-    API_HOST: z.url().default('https://api.clever-cloud.com'),
-    AUTH_BRIDGE_HOST: z.url().default('https://api-bridge.clever-cloud.com'),
-    SSH_GATEWAY: z.string().default('ssh@sshgateway-clevercloud-customers.services.clever-cloud.com'),
+  API_HOST: {
+    schema: z.url().default('https://api.clever-cloud.com'),
+    documentation: 'Clever Cloud API base URL',
+  },
+  AUTH_BRIDGE_HOST: {
+    schema: z.url().default('https://api-bridge.clever-cloud.com'),
+    documentation: 'Clever Cloud authentication bridge URL',
+  },
+  SSH_GATEWAY: {
+    schema: z.string().default('ssh@sshgateway-clevercloud-customers.services.clever-cloud.com'),
+    documentation: 'SSH gateway address',
+  },
 
-    // The disclosure of these tokens is not considered as a vulnerability.
-    // Do not report this to our security service.
-    OAUTH_CONSUMER_KEY: z.string().default('T5nFjKeHH4AIlEveuGhB5S3xg8T19e'),
-    OAUTH_CONSUMER_SECRET: z.string().default('MgVMqTr6fWlf2M0tkC2MXOnhfqBWDT'),
+  // The disclosure of these tokens is not considered as a vulnerability.
+  // Do not report this to our security service.
+  OAUTH_CONSUMER_KEY: {
+    schema: z.string().default('T5nFjKeHH4AIlEveuGhB5S3xg8T19e'),
+    secret: true,
+    documentation: 'OAuth consumer key',
+  },
+  OAUTH_CONSUMER_SECRET: {
+    schema: z.string().default('MgVMqTr6fWlf2M0tkC2MXOnhfqBWDT'),
+    secret: true,
+    documentation: 'OAuth consumer secret',
+  },
 
-    API_DOC_URL: z.url().default('https://www.clever.cloud/developers/api'),
-    DOC_URL: z.url().default('https://www.clever.cloud/developers/doc'),
-    CONSOLE_URL: z.url().default('https://console.clever-cloud.com'),
+  API_DOC_URL: {
+    schema: z.url().default('https://www.clever.cloud/developers/api'),
+    documentation: 'API documentation URL',
+  },
+  DOC_URL: {
+    schema: z.url().default('https://www.clever.cloud/developers/doc'),
+    documentation: 'Documentation URL',
+  },
+  CONSOLE_URL: {
+    schema: z.url().default('https://console.clever-cloud.com'),
+    documentation: 'Console URL',
+  },
 
-    // Default values are computed from `CONSOLE_URL` below
-    CONSOLE_TOKEN_URL: z.url().optional(),
-    GOTO_URL: z.url().optional(),
-  })
-  .transform((config) => ({
-    ...config,
-    CONSOLE_TOKEN_URL: config.CONSOLE_TOKEN_URL ?? `${config.CONSOLE_URL}/cli-oauth`,
-    GOTO_URL: config.GOTO_URL ?? `${config.CONSOLE_URL}/goto`,
-  }));
+  // Default values are computed from `CONSOLE_URL` via a derived source
+  CONSOLE_TOKEN_URL: {
+    schema: z.url().optional(),
+    documentation: 'Console token URL (derived from CONSOLE_URL)',
+  },
+  GOTO_URL: {
+    schema: z.url().optional(),
+    documentation: 'Goto URL (derived from CONSOLE_URL)',
+  },
+};
 
-/** @typedef {z.infer<typeof ConfigSchema>} ConfigData */
+/** @typedef {import('@clevercloud/reglage').Config<typeof CONFIG_SCHEMA>} ConfigData */
 
 export class BaseConfig {
   /**
@@ -88,12 +124,12 @@ export class BaseConfig {
   }
 
   /**
-   * @template {keyof ConfigData} K
+   * @template {keyof typeof CONFIG_SCHEMA} K
    * @param {K} key
-   * @returns {ConfigData[K]}
+   * @returns {import('@clevercloud/reglage').InferConfig<typeof CONFIG_SCHEMA>[K]}
    */
   get(key) {
-    return this._config[key];
+    return this._config.get(key);
   }
 }
 
@@ -142,15 +178,7 @@ export const baseConfig = new BaseConfig(loadBaseConfig());
  * @returns {ConfigData}
  */
 function loadBaseConfig() {
-  const result = ConfigSchema.safeParse(process.env);
-
-  if (!result.success) {
-    const errors = result.error.issues.map((issue) => `- ${issue.path.join('.')}: ${issue.message}`).join('\n');
-    Logger.error(`Invalid configuration:\n${errors}`);
-    process.exit(1);
-  }
-
-  return result.data;
+  return buildConfig([['env', process.env]]);
 }
 
 /**
@@ -178,22 +206,62 @@ function loadConfig() {
 
   const activeProfile = profiles[0];
 
-  /** @type {z.input<typeof ConfigSchema>} */
-  const rawConfig = {
-    // Profile overrides (e.g. custom API_HOST) applied after profile auth data, before env vars
-    ...activeProfile?.overrides,
-    ...process.env,
-  };
+  const config = buildConfig([
+    ['activeProfileOverride', activeProfile?.overrides],
+    ['env', process.env],
+  ]);
 
-  const result = ConfigSchema.safeParse(rawConfig);
+  Logger.debug('Configuration loaded:');
+  Logger.debug(config.toString('verbose'));
 
-  if (!result.success) {
-    const errors = result.error.issues.map((issue) => `- ${issue.path.join('.')}: ${issue.message}`).join('\n');
-    Logger.error(`Invalid configuration:\n${errors}`);
-    process.exit(1);
+  return { data: config, profiles };
+}
+
+/**
+ * Builds a Config from the given sources.
+ * Sources are applied in order (later sources override earlier ones).
+ * @param {Array<[string, Record<string, unknown> | undefined | null]>} sources
+ * @returns {ConfigData}
+ */
+function buildConfig(sources) {
+  const builder = createConfigBuilder(CONFIG_SCHEMA)
+    .refine('CONSOLE_TOKEN_URL', (schema, resolved) => {
+      if (resolved.CONSOLE_TOKEN_URL == null) {
+        return schema.default(`${resolved.CONSOLE_URL}/cli-oauth`);
+      }
+      return schema;
+    })
+    .refine('GOTO_URL', (schema, resolved) => {
+      if (resolved.GOTO_URL == null) {
+        return schema.default(`${resolved.CONSOLE_URL}/goto`);
+      }
+      return schema;
+    });
+
+  for (const [name, values] of sources) {
+    if (values != null) {
+      builder.addSource(name, values);
+    } else {
+      Logger.debug(`Skipping source "${name}": no values provided`);
+    }
   }
 
-  return { data: result.data, profiles };
+  try {
+    return builder.buildConfig();
+  } catch (error) {
+    if (error instanceof InvalidConfigError) {
+      const errors = error.issues
+        .map((issue) =>
+          issue.source != null
+            ? `- ${issue.key} (${issue.source}): ${issue.message}`
+            : `- ${issue.key}: ${issue.message}`,
+        )
+        .join('\n');
+      Logger.error(`Invalid configuration:\n${errors}`);
+      process.exit(1);
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -2,16 +2,21 @@ import assert from 'node:assert';
 import { after, beforeEach, describe, it, mock } from 'node:test';
 
 /**
+ * @typedef {import('./config.js').Config} Config
+ * @typedef {import('./config.js').ConfigData} ConfigData
+ */
+
+/**
  * Read a config value from either a plain object (original) or a reglage Config (.get()).
- * @param {Record<string, unknown>} cfg
- * @param {string} key
+ * @param {Config} cfg
+ * @param {keyof ConfigData} key
  */
 function get(cfg, key) {
-  return cfg[key];
+  return cfg.get(key);
 }
 
 /**
- * @param {Record<string, unknown> & { get?: (key: string) => unknown }} cfg
+ * @param {Config} cfg
  * @returns {Array<import('./config.js').Profile>}
  */
 function getProfiles(cfg) {

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -6,23 +6,6 @@ import { after, beforeEach, describe, it, mock } from 'node:test';
  * @typedef {import('./config.js').ConfigData} ConfigData
  */
 
-/**
- * Read a config value from either a plain object (original) or a reglage Config (.get()).
- * @param {Config} cfg
- * @param {keyof ConfigData} key
- */
-function get(cfg, key) {
-  return cfg.get(key);
-}
-
-/**
- * @param {Config} cfg
- * @returns {Array<import('./config.js').Profile>}
- */
-function getProfiles(cfg) {
-  return cfg.profiles;
-}
-
 /** @type {unknown} */
 let fakeConfigFileData;
 
@@ -97,62 +80,72 @@ describe('config', () => {
   describe('defaults (no config file, no env overrides)', () => {
     it('should have default API_HOST', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'API_HOST'), 'https://api.clever-cloud.com');
+      assert.strictEqual(config.get('API_HOST'), 'https://api.clever-cloud.com');
     });
 
     it('should have default AUTH_BRIDGE_HOST', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'AUTH_BRIDGE_HOST'), 'https://api-bridge.clever-cloud.com');
+      assert.strictEqual(config.get('AUTH_BRIDGE_HOST'), 'https://api-bridge.clever-cloud.com');
     });
 
     it('should have default CONSOLE_URL', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'CONSOLE_URL'), 'https://console.clever-cloud.com');
+      assert.strictEqual(config.get('CONSOLE_URL'), 'https://console.clever-cloud.com');
     });
 
     it('should have default DOC_URL', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'DOC_URL'), 'https://www.clever.cloud/developers/doc');
+      assert.strictEqual(config.get('DOC_URL'), 'https://www.clever.cloud/developers/doc');
     });
 
     it('should have default OAUTH_CONSUMER_KEY', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'OAUTH_CONSUMER_KEY'), 'T5nFjKeHH4AIlEveuGhB5S3xg8T19e');
+      assert.strictEqual(config.get('OAUTH_CONSUMER_KEY'), 'T5nFjKeHH4AIlEveuGhB5S3xg8T19e');
     });
 
     it('should have default SSH_GATEWAY', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'SSH_GATEWAY'), 'ssh@sshgateway-clevercloud-customers.services.clever-cloud.com');
+      assert.strictEqual(config.get('SSH_GATEWAY'), 'ssh@sshgateway-clevercloud-customers.services.clever-cloud.com');
     });
   });
 
   describe('derived keys from CONSOLE_URL', () => {
     it('should derive CONSOLE_TOKEN_URL from default CONSOLE_URL', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'CONSOLE_TOKEN_URL'), 'https://console.clever-cloud.com/cli-oauth');
+      assert.strictEqual(config.get('CONSOLE_TOKEN_URL'), 'https://console.clever-cloud.com/cli-oauth');
     });
 
     it('should derive GOTO_URL from default CONSOLE_URL', async () => {
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'GOTO_URL'), 'https://console.clever-cloud.com/goto');
+      assert.strictEqual(config.get('GOTO_URL'), 'https://console.clever-cloud.com/goto');
     });
 
     it('should derive from custom CONSOLE_URL env var', async () => {
       const { config } = await loadFreshConfig({ CONSOLE_URL: 'https://custom-console.example.com' });
-      assert.strictEqual(get(config, 'CONSOLE_TOKEN_URL'), 'https://custom-console.example.com/cli-oauth');
-      assert.strictEqual(get(config, 'GOTO_URL'), 'https://custom-console.example.com/goto');
+      assert.strictEqual(config.get('CONSOLE_TOKEN_URL'), 'https://custom-console.example.com/cli-oauth');
+      assert.strictEqual(config.get('GOTO_URL'), 'https://custom-console.example.com/goto');
+    });
+
+    it('should not derive CONSOLE_TOKEN_URL when not null', async () => {
+      const { config } = await loadFreshConfig({ CONSOLE_TOKEN_URL: 'https://token.example.com' });
+      assert.strictEqual(config.get('CONSOLE_TOKEN_URL'), 'https://token.example.com');
+    });
+
+    it('should not derive GOTO_URL when not null', async () => {
+      const { config } = await loadFreshConfig({ GOTO_URL: 'https://goto.example.com' });
+      assert.strictEqual(config.get('GOTO_URL'), 'https://goto.example.com');
     });
   });
 
   describe('env vars override defaults', () => {
     it('should override API_HOST from env', async () => {
       const { config } = await loadFreshConfig({ API_HOST: 'https://custom-api.example.com' });
-      assert.strictEqual(get(config, 'API_HOST'), 'https://custom-api.example.com');
+      assert.strictEqual(config.get('API_HOST'), 'https://custom-api.example.com');
     });
 
     it('should override SSH_GATEWAY from env', async () => {
       const { config } = await loadFreshConfig({ SSH_GATEWAY: 'custom-gateway' });
-      assert.strictEqual(get(config, 'SSH_GATEWAY'), 'custom-gateway');
+      assert.strictEqual(config.get('SSH_GATEWAY'), 'custom-gateway');
     });
   });
 
@@ -170,7 +163,7 @@ describe('config', () => {
         ],
       };
       const { baseConfig } = await loadFreshConfig();
-      assert.strictEqual(get(baseConfig, 'API_HOST'), 'https://api.clever-cloud.com');
+      assert.strictEqual(baseConfig.get('API_HOST'), 'https://api.clever-cloud.com');
     });
   });
 
@@ -184,7 +177,7 @@ describe('config', () => {
         ],
       };
       const { config } = await loadFreshConfig();
-      const profiles = getProfiles(config);
+      const profiles = config.profiles;
       assert.strictEqual(profiles.length, 2);
       assert.strictEqual(profiles[0].alias, 'prod');
       assert.strictEqual(profiles[1].alias, 'staging');
@@ -203,7 +196,7 @@ describe('config', () => {
         ],
       };
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'API_HOST'), 'https://custom-api.example.com');
+      assert.strictEqual(config.get('API_HOST'), 'https://custom-api.example.com');
     });
   });
 
@@ -215,7 +208,7 @@ describe('config', () => {
         expirationDate: '2030-01-01',
       };
       const { config } = await loadFreshConfig();
-      const profiles = getProfiles(config);
+      const profiles = config.profiles;
       assert.strictEqual(profiles.length, 1);
       assert.strictEqual(profiles[0].token, 'legacy-token');
       assert.strictEqual(profiles[0].secret, 'legacy-secret');
@@ -226,7 +219,7 @@ describe('config', () => {
   describe('CLEVER_TOKEN / CLEVER_SECRET env vars', () => {
     it('should inject a virtual $env profile as the active one', async () => {
       const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token', CLEVER_SECRET: 'env-secret' });
-      const profiles = getProfiles(config);
+      const profiles = config.profiles;
       assert.strictEqual(profiles[0].token, 'env-token');
       assert.strictEqual(profiles[0].secret, 'env-secret');
       assert.strictEqual(profiles[0].alias, '$env');
@@ -238,7 +231,7 @@ describe('config', () => {
         profiles: [{ alias: 'existing', token: 'tok', secret: 'sec' }],
       };
       const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token', CLEVER_SECRET: 'env-secret' });
-      const profiles = getProfiles(config);
+      const profiles = config.profiles;
       assert.strictEqual(profiles.length, 2);
       assert.strictEqual(profiles[0].alias, '$env');
       assert.strictEqual(profiles[1].alias, 'existing');
@@ -246,7 +239,7 @@ describe('config', () => {
 
     it('should not inject $env when only CLEVER_TOKEN is set', async () => {
       const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token' });
-      assert.deepStrictEqual(getProfiles(config), []);
+      assert.deepStrictEqual(config.profiles, []);
     });
   });
 
@@ -264,7 +257,7 @@ describe('config', () => {
         ],
       };
       const { config } = await loadFreshConfig({ API_HOST: 'https://env-api.example.com' });
-      assert.strictEqual(get(config, 'API_HOST'), 'https://env-api.example.com');
+      assert.strictEqual(config.get('API_HOST'), 'https://env-api.example.com');
     });
 
     it('profile overrides should override defaults', async () => {
@@ -280,7 +273,7 @@ describe('config', () => {
         ],
       };
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'API_HOST'), 'https://profile-api.example.com');
+      assert.strictEqual(config.get('API_HOST'), 'https://profile-api.example.com');
     });
   });
 
@@ -302,7 +295,7 @@ describe('config', () => {
       assert.strictEqual(mod.config.activeProfile.alias, 'initial');
       assert.strictEqual(mod.config.activeProfile.token, 'tok1');
       assert.strictEqual(mod.config.activeProfile.secret, 'sec1');
-      assert.strictEqual(get(mod.config, 'API_HOST'), 'https://initial-api.example.com');
+      assert.strictEqual(mod.config.get('API_HOST'), 'https://initial-api.example.com');
 
       // Simulate config file change
       fakeConfigFileData = {
@@ -322,7 +315,7 @@ describe('config', () => {
       assert.strictEqual(mod.config.activeProfile.alias, 'updated');
       assert.strictEqual(mod.config.activeProfile.token, 'tok2');
       assert.strictEqual(mod.config.activeProfile.secret, 'sec2');
-      assert.strictEqual(get(mod.config, 'API_HOST'), 'https://updated-api.example.com');
+      assert.strictEqual(mod.config.get('API_HOST'), 'https://updated-api.example.com');
     });
   });
 });

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -20,7 +20,7 @@ function get(cfg, key) {
  * @returns {Array<import('./config.js').Profile>}
  */
 function getProfiles(cfg) {
-  return /** @type {any} */ (get(cfg, 'profiles'));
+  return cfg.profiles;
 }
 
 /** @type {unknown} */
@@ -43,9 +43,6 @@ const CONFIG_KEYS = [
   'CONSOLE_URL',
   'CONSOLE_TOKEN_URL',
   'GOTO_URL',
-  'token',
-  'secret',
-  'expirationDate',
   'CLEVER_TOKEN',
   'CLEVER_SECRET',
 ];
@@ -127,17 +124,6 @@ describe('config', () => {
       const { config } = await loadFreshConfig();
       assert.strictEqual(get(config, 'SSH_GATEWAY'), 'ssh@sshgateway-clevercloud-customers.services.clever-cloud.com');
     });
-
-    it('should have empty profiles', async () => {
-      const { config } = await loadFreshConfig();
-      assert.deepStrictEqual(get(config, 'profiles'), []);
-    });
-
-    it('should have undefined token and secret', async () => {
-      const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'token'), undefined);
-      assert.strictEqual(get(config, 'secret'), undefined);
-    });
   });
 
   describe('derived keys from CONSOLE_URL', () => {
@@ -171,16 +157,6 @@ describe('config', () => {
   });
 
   describe('baseConfig ignores profiles', () => {
-    it('should not have profile token/secret even when config file has profiles', async () => {
-      fakeConfigFileData = {
-        version: 1,
-        profiles: [{ alias: 'default', token: 'file-token', secret: 'file-secret' }],
-      };
-      const { baseConfig } = await loadFreshConfig();
-      assert.strictEqual(get(baseConfig, 'token'), undefined);
-      assert.strictEqual(get(baseConfig, 'secret'), undefined);
-    });
-
     it('should use default API_HOST even when profile has override', async () => {
       fakeConfigFileData = {
         version: 1,
@@ -199,16 +175,6 @@ describe('config', () => {
   });
 
   describe('config file with current format', () => {
-    it('should load token and secret from the active profile', async () => {
-      fakeConfigFileData = {
-        version: 1,
-        profiles: [{ alias: 'default', token: 'my-token', secret: 'my-secret' }],
-      };
-      const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'token'), 'my-token');
-      assert.strictEqual(get(config, 'secret'), 'my-secret');
-    });
-
     it('should load all profiles', async () => {
       fakeConfigFileData = {
         version: 1,
@@ -249,10 +215,10 @@ describe('config', () => {
         expirationDate: '2030-01-01',
       };
       const { config } = await loadFreshConfig();
-      assert.strictEqual(get(config, 'token'), 'legacy-token');
-      assert.strictEqual(get(config, 'secret'), 'legacy-secret');
       const profiles = getProfiles(config);
       assert.strictEqual(profiles.length, 1);
+      assert.strictEqual(profiles[0].token, 'legacy-token');
+      assert.strictEqual(profiles[0].secret, 'legacy-secret');
       assert.strictEqual(profiles[0].alias, 'default');
     });
   });
@@ -260,9 +226,9 @@ describe('config', () => {
   describe('CLEVER_TOKEN / CLEVER_SECRET env vars', () => {
     it('should inject a virtual $env profile as the active one', async () => {
       const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token', CLEVER_SECRET: 'env-secret' });
-      assert.strictEqual(get(config, 'token'), 'env-token');
-      assert.strictEqual(get(config, 'secret'), 'env-secret');
       const profiles = getProfiles(config);
+      assert.strictEqual(profiles[0].token, 'env-token');
+      assert.strictEqual(profiles[0].secret, 'env-secret');
       assert.strictEqual(profiles[0].alias, '$env');
     });
 
@@ -280,7 +246,7 @@ describe('config', () => {
 
     it('should not inject $env when only CLEVER_TOKEN is set', async () => {
       const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token' });
-      assert.deepStrictEqual(get(config, 'profiles'), []);
+      assert.deepStrictEqual(getProfiles(config), []);
     });
   });
 
@@ -322,23 +288,41 @@ describe('config', () => {
     it('should reflect config file changes after reload', async () => {
       fakeConfigFileData = {
         version: 1,
-        profiles: [{ alias: 'initial', token: 'tok1', secret: 'sec1' }],
+        profiles: [
+          {
+            alias: 'initial',
+            token: 'tok1',
+            secret: 'sec1',
+            overrides: { API_HOST: 'https://initial-api.example.com' },
+          },
+        ],
       };
       const mod = await loadFreshConfig();
 
-      assert.strictEqual(get(mod.config, 'token'), 'tok1');
+      assert.strictEqual(mod.config.activeProfile.alias, 'initial');
+      assert.strictEqual(mod.config.activeProfile.token, 'tok1');
+      assert.strictEqual(mod.config.activeProfile.secret, 'sec1');
+      assert.strictEqual(get(mod.config, 'API_HOST'), 'https://initial-api.example.com');
 
       // Simulate config file change
       fakeConfigFileData = {
         version: 1,
-        profiles: [{ alias: 'updated', token: 'tok2', secret: 'sec2' }],
+        profiles: [
+          {
+            alias: 'updated',
+            token: 'tok2',
+            secret: 'sec2',
+            overrides: { API_HOST: 'https://updated-api.example.com' },
+          },
+        ],
       };
 
       mod.reloadConfig();
 
-      assert.strictEqual(get(mod.config, 'token'), 'tok2');
-      const profiles = getProfiles(mod.config);
-      assert.strictEqual(profiles[0].alias, 'updated');
+      assert.strictEqual(mod.config.activeProfile.alias, 'updated');
+      assert.strictEqual(mod.config.activeProfile.token, 'tok2');
+      assert.strictEqual(mod.config.activeProfile.secret, 'sec2');
+      assert.strictEqual(get(mod.config, 'API_HOST'), 'https://updated-api.example.com');
     });
   });
 });

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,0 +1,339 @@
+import assert from 'node:assert';
+import { after, beforeEach, describe, it, mock } from 'node:test';
+
+/**
+ * Read a config value from either a plain object (original) or a reglage Config (.get()).
+ * @param {Record<string, unknown>} cfg
+ * @param {string} key
+ */
+function get(cfg, key) {
+  return cfg[key];
+}
+
+/**
+ * @param {Record<string, unknown> & { get?: (key: string) => unknown }} cfg
+ * @returns {Array<import('./config.js').Profile>}
+ */
+function getProfiles(cfg) {
+  return /** @type {any} */ (get(cfg, 'profiles'));
+}
+
+/** @type {unknown} */
+let fakeConfigFileData;
+
+// Save original env
+const originalEnv = { ...process.env };
+
+const CONFIG_KEYS = [
+  'CONFIGURATION_FILE',
+  'EXPERIMENTAL_FEATURES_FILE',
+  'APP_CONFIGURATION_FILE',
+  'API_HOST',
+  'AUTH_BRIDGE_HOST',
+  'SSH_GATEWAY',
+  'OAUTH_CONSUMER_KEY',
+  'OAUTH_CONSUMER_SECRET',
+  'API_DOC_URL',
+  'DOC_URL',
+  'CONSOLE_URL',
+  'CONSOLE_TOKEN_URL',
+  'GOTO_URL',
+  'token',
+  'secret',
+  'expirationDate',
+  'CLEVER_TOKEN',
+  'CLEVER_SECRET',
+];
+
+function cleanEnv() {
+  for (const key of CONFIG_KEYS) {
+    delete process.env[key];
+  }
+}
+
+/** Counter to bust ESM module cache */
+let importCounter = 0;
+
+/**
+ * Set up mocks for fs, then import a fresh config module.
+ * Uses a query string to bust the ESM cache so each test gets a fresh evaluation.
+ * @param {Record<string, string>} [envOverrides]
+ */
+async function loadFreshConfig(envOverrides = {}) {
+  cleanEnv();
+  Object.assign(process.env, envOverrides);
+
+  mock.module('../lib/fs.js', {
+    namedExports: {
+      readJsonSync: () => fakeConfigFileData,
+      readJson: async () => fakeConfigFileData,
+      writeJson: async () => {},
+    },
+  });
+
+  importCounter++;
+  return import(`./config.js?v=${importCounter}`);
+}
+
+describe('config', () => {
+  beforeEach(() => {
+    fakeConfigFileData = null;
+    mock.restoreAll();
+  });
+
+  after(() => {
+    cleanEnv();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+    mock.restoreAll();
+  });
+
+  describe('defaults (no config file, no env overrides)', () => {
+    it('should have default API_HOST', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'API_HOST'), 'https://api.clever-cloud.com');
+    });
+
+    it('should have default AUTH_BRIDGE_HOST', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'AUTH_BRIDGE_HOST'), 'https://api-bridge.clever-cloud.com');
+    });
+
+    it('should have default CONSOLE_URL', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'CONSOLE_URL'), 'https://console.clever-cloud.com');
+    });
+
+    it('should have default DOC_URL', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'DOC_URL'), 'https://www.clever.cloud/developers/doc');
+    });
+
+    it('should have default OAUTH_CONSUMER_KEY', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'OAUTH_CONSUMER_KEY'), 'T5nFjKeHH4AIlEveuGhB5S3xg8T19e');
+    });
+
+    it('should have default SSH_GATEWAY', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'SSH_GATEWAY'), 'ssh@sshgateway-clevercloud-customers.services.clever-cloud.com');
+    });
+
+    it('should have empty profiles', async () => {
+      const { config } = await loadFreshConfig();
+      assert.deepStrictEqual(get(config, 'profiles'), []);
+    });
+
+    it('should have undefined token and secret', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'token'), undefined);
+      assert.strictEqual(get(config, 'secret'), undefined);
+    });
+  });
+
+  describe('derived keys from CONSOLE_URL', () => {
+    it('should derive CONSOLE_TOKEN_URL from default CONSOLE_URL', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'CONSOLE_TOKEN_URL'), 'https://console.clever-cloud.com/cli-oauth');
+    });
+
+    it('should derive GOTO_URL from default CONSOLE_URL', async () => {
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'GOTO_URL'), 'https://console.clever-cloud.com/goto');
+    });
+
+    it('should derive from custom CONSOLE_URL env var', async () => {
+      const { config } = await loadFreshConfig({ CONSOLE_URL: 'https://custom-console.example.com' });
+      assert.strictEqual(get(config, 'CONSOLE_TOKEN_URL'), 'https://custom-console.example.com/cli-oauth');
+      assert.strictEqual(get(config, 'GOTO_URL'), 'https://custom-console.example.com/goto');
+    });
+  });
+
+  describe('env vars override defaults', () => {
+    it('should override API_HOST from env', async () => {
+      const { config } = await loadFreshConfig({ API_HOST: 'https://custom-api.example.com' });
+      assert.strictEqual(get(config, 'API_HOST'), 'https://custom-api.example.com');
+    });
+
+    it('should override SSH_GATEWAY from env', async () => {
+      const { config } = await loadFreshConfig({ SSH_GATEWAY: 'custom-gateway' });
+      assert.strictEqual(get(config, 'SSH_GATEWAY'), 'custom-gateway');
+    });
+  });
+
+  describe('baseConfig ignores profiles', () => {
+    it('should not have profile token/secret even when config file has profiles', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [{ alias: 'default', token: 'file-token', secret: 'file-secret' }],
+      };
+      const { baseConfig } = await loadFreshConfig();
+      assert.strictEqual(get(baseConfig, 'token'), undefined);
+      assert.strictEqual(get(baseConfig, 'secret'), undefined);
+    });
+
+    it('should use default API_HOST even when profile has override', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [
+          {
+            alias: 'default',
+            token: 'tok',
+            secret: 'sec',
+            overrides: { API_HOST: 'https://profile-api.example.com' },
+          },
+        ],
+      };
+      const { baseConfig } = await loadFreshConfig();
+      assert.strictEqual(get(baseConfig, 'API_HOST'), 'https://api.clever-cloud.com');
+    });
+  });
+
+  describe('config file with current format', () => {
+    it('should load token and secret from the active profile', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [{ alias: 'default', token: 'my-token', secret: 'my-secret' }],
+      };
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'token'), 'my-token');
+      assert.strictEqual(get(config, 'secret'), 'my-secret');
+    });
+
+    it('should load all profiles', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [
+          { alias: 'prod', token: 'tok1', secret: 'sec1' },
+          { alias: 'staging', token: 'tok2', secret: 'sec2' },
+        ],
+      };
+      const { config } = await loadFreshConfig();
+      const profiles = getProfiles(config);
+      assert.strictEqual(profiles.length, 2);
+      assert.strictEqual(profiles[0].alias, 'prod');
+      assert.strictEqual(profiles[1].alias, 'staging');
+    });
+
+    it('should apply active profile overrides', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [
+          {
+            alias: 'custom',
+            token: 'tok',
+            secret: 'sec',
+            overrides: { API_HOST: 'https://custom-api.example.com' },
+          },
+        ],
+      };
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'API_HOST'), 'https://custom-api.example.com');
+    });
+  });
+
+  describe('legacy config file format', () => {
+    it('should auto-convert legacy format to profile', async () => {
+      fakeConfigFileData = {
+        token: 'legacy-token',
+        secret: 'legacy-secret',
+        expirationDate: '2030-01-01',
+      };
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'token'), 'legacy-token');
+      assert.strictEqual(get(config, 'secret'), 'legacy-secret');
+      const profiles = getProfiles(config);
+      assert.strictEqual(profiles.length, 1);
+      assert.strictEqual(profiles[0].alias, 'default');
+    });
+  });
+
+  describe('CLEVER_TOKEN / CLEVER_SECRET env vars', () => {
+    it('should inject a virtual $env profile as the active one', async () => {
+      const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token', CLEVER_SECRET: 'env-secret' });
+      assert.strictEqual(get(config, 'token'), 'env-token');
+      assert.strictEqual(get(config, 'secret'), 'env-secret');
+      const profiles = getProfiles(config);
+      assert.strictEqual(profiles[0].alias, '$env');
+    });
+
+    it('should prepend $env profile before file profiles', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [{ alias: 'existing', token: 'tok', secret: 'sec' }],
+      };
+      const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token', CLEVER_SECRET: 'env-secret' });
+      const profiles = getProfiles(config);
+      assert.strictEqual(profiles.length, 2);
+      assert.strictEqual(profiles[0].alias, '$env');
+      assert.strictEqual(profiles[1].alias, 'existing');
+    });
+
+    it('should not inject $env when only CLEVER_TOKEN is set', async () => {
+      const { config } = await loadFreshConfig({ CLEVER_TOKEN: 'env-token' });
+      assert.deepStrictEqual(get(config, 'profiles'), []);
+    });
+  });
+
+  describe('source priority: env > profile overrides > profile > defaults', () => {
+    it('env vars should override profile overrides', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [
+          {
+            alias: 'default',
+            token: 'tok',
+            secret: 'sec',
+            overrides: { API_HOST: 'https://profile-api.example.com' },
+          },
+        ],
+      };
+      const { config } = await loadFreshConfig({ API_HOST: 'https://env-api.example.com' });
+      assert.strictEqual(get(config, 'API_HOST'), 'https://env-api.example.com');
+    });
+
+    it('profile overrides should override defaults', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [
+          {
+            alias: 'default',
+            token: 'tok',
+            secret: 'sec',
+            overrides: { API_HOST: 'https://profile-api.example.com' },
+          },
+        ],
+      };
+      const { config } = await loadFreshConfig();
+      assert.strictEqual(get(config, 'API_HOST'), 'https://profile-api.example.com');
+    });
+  });
+
+  describe('reloadConfig', () => {
+    it('should reflect config file changes after reload', async () => {
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [{ alias: 'initial', token: 'tok1', secret: 'sec1' }],
+      };
+      const mod = await loadFreshConfig();
+
+      assert.strictEqual(get(mod.config, 'token'), 'tok1');
+
+      // Simulate config file change
+      fakeConfigFileData = {
+        version: 1,
+        profiles: [{ alias: 'updated', token: 'tok2', secret: 'sec2' }],
+      };
+
+      mod.reloadConfig();
+
+      assert.strictEqual(get(mod.config, 'token'), 'tok2');
+      const profiles = getProfiles(mod.config);
+      assert.strictEqual(profiles[0].alias, 'updated');
+    });
+  });
+});

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -43,7 +43,7 @@ export const EXPERIMENTAL_FEATURES = {
       - Delete a Kubernetes cluster:
           clever k8s delete my-cluster
 
-      Learn more about Clever Kubernetes: ${config.DOC_URL}/kubernetes/
+      Learn more about Clever Kubernetes: ${config.get('DOC_URL')}/kubernetes/
     `,
   },
   kv: {
@@ -59,7 +59,7 @@ export const EXPERIMENTAL_FEATURES = {
           clever kv myMateriaKV -o myOrg TTL myTempKey
           clever kv redis_xxxxx --org org_xxxxx PING
 
-      Learn more about Materia KV: ${config.DOC_URL}/addons/materia-kv/
+      Learn more about Materia KV: ${config.get('DOC_URL')}/addons/materia-kv/
     `,
   },
   ng: {
@@ -87,7 +87,7 @@ export const EXPERIMENTAL_FEATURES = {
       - Search Network Groups, members or peers:
           clever ng search myQuery
 
-      Learn more about Network Groups: ${config.DOC_URL}/develop/network-groups/
+      Learn more about Network Groups: ${config.get('DOC_URL')}/develop/network-groups/
     `,
   },
   operators: {

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -168,7 +168,7 @@ export async function operatorList(provider, format) {
 export async function operatorOpen(provider, addonIdOrName) {
   const operator = await Operator.getDetails(provider, addonIdOrName);
   await openBrowser(
-    `${config.GOTO_URL}/${operator.addonId}`,
+    `${config.get('GOTO_URL')}/${operator.addonId}`,
     `Opening ${styleText('blue', operator.addonId)} in the browser…`,
   );
 }

--- a/src/lib/profile.js
+++ b/src/lib/profile.js
@@ -51,9 +51,9 @@ export async function getProfileDetails({ profile, isActive }) {
   const sendWithCredentials = sendToApiWithConfig({
     token: profile.token,
     secret: profile.secret,
-    apiHost: profile.overrides?.API_HOST ?? baseConfig.API_HOST,
-    consumerKey: profile.overrides?.OAUTH_CONSUMER_KEY ?? baseConfig.OAUTH_CONSUMER_KEY,
-    consumerSecret: profile.overrides?.OAUTH_CONSUMER_SECRET ?? baseConfig.OAUTH_CONSUMER_SECRET,
+    apiHost: profile.overrides?.API_HOST ?? baseConfig.get('API_HOST'),
+    consumerKey: profile.overrides?.OAUTH_CONSUMER_KEY ?? baseConfig.get('OAUTH_CONSUMER_KEY'),
+    consumerSecret: profile.overrides?.OAUTH_CONSUMER_SECRET ?? baseConfig.get('OAUTH_CONSUMER_SECRET'),
   });
 
   const [user, token] = await Promise.all([

--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -10,15 +10,15 @@ import * as User from './user.js';
 // TODO: Maybe use fs-utils findPath()
 export async function loadApplicationConf(ignoreParentConfig = false, pathToFolder) {
   if (pathToFolder == null) {
-    pathToFolder = path.dirname(config.APP_CONFIGURATION_FILE);
+    pathToFolder = path.dirname(config.get('APP_CONFIGURATION_FILE'));
   }
-  const fileName = path.basename(config.APP_CONFIGURATION_FILE);
+  const fileName = path.basename(config.get('APP_CONFIGURATION_FILE'));
   const fullPath = path.join(pathToFolder, fileName);
   Logger.debug('Loading app configuration from ' + fullPath);
   try {
     return await readJson(fullPath);
   } catch (error) {
-    Logger.info('Cannot load app configuration from ' + config.APP_CONFIGURATION_FILE + ' (' + error + ')');
+    Logger.info('Cannot load app configuration from ' + config.get('APP_CONFIGURATION_FILE') + ' (' + error + ')');
     if (ignoreParentConfig || path.parse(pathToFolder).root === pathToFolder) {
       return { apps: [] };
     }
@@ -56,7 +56,7 @@ export async function addLinkedApplication(appData, alias, ignoreParentConfig) {
 
   currentConfig.apps.push(appEntry);
 
-  return writeJson(config.APP_CONFIGURATION_FILE, currentConfig).then(() => {
+  return writeJson(config.get('APP_CONFIGURATION_FILE'), currentConfig).then(() => {
     return appEntry;
   });
 }
@@ -77,7 +77,7 @@ export async function removeLinkedApplication({ appId, alias }) {
     delete newConfig.default;
   }
 
-  await writeJson(config.APP_CONFIGURATION_FILE, newConfig);
+  await writeJson(config.get('APP_CONFIGURATION_FILE'), newConfig);
   return true;
 }
 
@@ -156,5 +156,5 @@ export async function setDefault(alias) {
   const appConfig = await loadApplicationConf();
   const app = findApp(appConfig, alias);
   const newConfig = { ...appConfig, default: app.app_id };
-  return writeJson(config.APP_CONFIGURATION_FILE, newConfig);
+  return writeJson(config.get('APP_CONFIGURATION_FILE'), newConfig);
 }

--- a/src/models/git-isomorphic.js
+++ b/src/models/git-isomorphic.js
@@ -18,8 +18,8 @@ export class GitIsomorphic extends Git {
 
   #onAuth() {
     return {
-      username: config.get('token'),
-      password: config.get('secret'),
+      username: config.activeProfile?.token,
+      password: config.activeProfile?.secret,
     };
   }
 

--- a/src/models/git-isomorphic.js
+++ b/src/models/git-isomorphic.js
@@ -18,8 +18,8 @@ export class GitIsomorphic extends Git {
 
   #onAuth() {
     return {
-      username: config.token,
-      password: config.secret,
+      username: config.get('token'),
+      password: config.get('secret'),
     };
   }
 

--- a/src/models/git-system.js
+++ b/src/models/git-system.js
@@ -78,8 +78,8 @@ export class GitSystem extends Git {
 
   #buildAuthenticatedUrl(url) {
     const urlObj = new URL(url);
-    urlObj.username = config.get('token');
-    urlObj.password = config.get('secret');
+    urlObj.username = config.activeProfile?.token;
+    urlObj.password = config.activeProfile?.secret;
     return urlObj;
   }
 

--- a/src/models/git-system.js
+++ b/src/models/git-system.js
@@ -78,8 +78,8 @@ export class GitSystem extends Git {
 
   #buildAuthenticatedUrl(url) {
     const urlObj = new URL(url);
-    urlObj.username = config.token;
-    urlObj.password = config.secret;
+    urlObj.username = config.get('token');
+    urlObj.password = config.get('secret');
     return urlObj;
   }
 

--- a/src/models/log.js
+++ b/src/models/log.js
@@ -161,7 +161,7 @@ export async function watchDeploymentAndDisplayLogs(options) {
     }
 
     Logger.println(
-      `${styleText(['bold', 'blue'], '→ Manage your application:')} ${styleText(['underline', 'bold'], `${config.GOTO_URL}/${appId}`)}`,
+      `${styleText(['bold', 'blue'], '→ Manage your application:')} ${styleText(['underline', 'bold'], `${config.get('GOTO_URL')}/${appId}`)}`,
     );
   } else if (deploymentEnded.state === 'CANCELLED') {
     throw new Error('Deployment was cancelled. Please check the activity');

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -58,8 +58,8 @@ async function executeRequest(requestParams, customConfig = {}) {
   const tokens = {
     OAUTH_CONSUMER_KEY: customConfig.OAUTH_CONSUMER_KEY ?? config.get('OAUTH_CONSUMER_KEY'),
     OAUTH_CONSUMER_SECRET: customConfig.OAUTH_CONSUMER_SECRET ?? config.get('OAUTH_CONSUMER_SECRET'),
-    API_OAUTH_TOKEN: customConfig.API_OAUTH_TOKEN ?? config.get('token'),
-    API_OAUTH_TOKEN_SECRET: customConfig.API_OAUTH_TOKEN_SECRET ?? config.get('secret'),
+    API_OAUTH_TOKEN: customConfig.API_OAUTH_TOKEN ?? config.activeProfile?.token,
+    API_OAUTH_TOKEN_SECRET: customConfig.API_OAUTH_TOKEN_SECRET ?? config.activeProfile?.secret,
   };
 
   return Promise.resolve(requestParams)
@@ -98,8 +98,8 @@ export function getHostAndTokens() {
     tokens: {
       OAUTH_CONSUMER_KEY: config.get('OAUTH_CONSUMER_KEY'),
       OAUTH_CONSUMER_SECRET: config.get('OAUTH_CONSUMER_SECRET'),
-      API_OAUTH_TOKEN: config.get('token'),
-      API_OAUTH_TOKEN_SECRET: config.get('secret'),
+      API_OAUTH_TOKEN: config.activeProfile?.token,
+      API_OAUTH_TOKEN_SECRET: config.activeProfile?.secret,
     },
   };
 }

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -18,7 +18,7 @@ export async function sendToApi(requestParams) {
 }
 
 export async function sendToAuthBridge(requestParams) {
-  return executeRequest(requestParams, { API_HOST: config.AUTH_BRIDGE_HOST });
+  return executeRequest(requestParams, { API_HOST: config.get('AUTH_BRIDGE_HOST') });
 }
 
 /**
@@ -54,12 +54,12 @@ export function sendToApiWithConfig(customConfig) {
  * @returns {Promise<unknown>}
  */
 async function executeRequest(requestParams, customConfig = {}) {
-  const host = customConfig.API_HOST ?? config.API_HOST;
+  const host = customConfig.API_HOST ?? config.get('API_HOST');
   const tokens = {
-    OAUTH_CONSUMER_KEY: customConfig.OAUTH_CONSUMER_KEY ?? config.OAUTH_CONSUMER_KEY,
-    OAUTH_CONSUMER_SECRET: customConfig.OAUTH_CONSUMER_SECRET ?? config.OAUTH_CONSUMER_SECRET,
-    API_OAUTH_TOKEN: customConfig.API_OAUTH_TOKEN ?? config.token,
-    API_OAUTH_TOKEN_SECRET: customConfig.API_OAUTH_TOKEN_SECRET ?? config.secret,
+    OAUTH_CONSUMER_KEY: customConfig.OAUTH_CONSUMER_KEY ?? config.get('OAUTH_CONSUMER_KEY'),
+    OAUTH_CONSUMER_SECRET: customConfig.OAUTH_CONSUMER_SECRET ?? config.get('OAUTH_CONSUMER_SECRET'),
+    API_OAUTH_TOKEN: customConfig.API_OAUTH_TOKEN ?? config.get('token'),
+    API_OAUTH_TOKEN_SECRET: customConfig.API_OAUTH_TOKEN_SECRET ?? config.get('secret'),
   };
 
   return Promise.resolve(requestParams)
@@ -94,12 +94,12 @@ export function processError(error) {
 
 export function getHostAndTokens() {
   return {
-    apiHost: config.API_HOST,
+    apiHost: config.get('API_HOST'),
     tokens: {
-      OAUTH_CONSUMER_KEY: config.OAUTH_CONSUMER_KEY,
-      OAUTH_CONSUMER_SECRET: config.OAUTH_CONSUMER_SECRET,
-      API_OAUTH_TOKEN: config.token,
-      API_OAUTH_TOKEN_SECRET: config.secret,
+      OAUTH_CONSUMER_KEY: config.get('OAUTH_CONSUMER_KEY'),
+      OAUTH_CONSUMER_SECRET: config.get('OAUTH_CONSUMER_SECRET'),
+      API_OAUTH_TOKEN: config.get('token'),
+      API_OAUTH_TOKEN_SECRET: config.get('secret'),
     },
   };
 }

--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -23,7 +23,7 @@ export class Deferred {
  * @returns {Promise<void>} A promise that resolves when the URL is opened
  */
 export function openBrowser(urlOrPath, message) {
-  const url = urlOrPath.startsWith('/') ? `${config.CONSOLE_URL}${urlOrPath}` : urlOrPath;
+  const url = urlOrPath.startsWith('/') ? `${config.get('CONSOLE_URL')}${urlOrPath}` : urlOrPath;
 
   Logger.debug(`Opening URL "${url}" in browser`);
   Logger.println(`🌐 ${message}`);


### PR DESCRIPTION
## Context

The config module was hand-rolled around a Zod schema plus `safeParse`, with a few sharp edges that
made it awkward to extend:

- Reload mutated the singleton in place (`delete` every key, then `Object.assign`) so consumers that
  imported `config` saw fresh values. Fragile, and incompatible with any immutable config object.
- Profiles flowed through the same Zod schema as configuration values, even though they are
  auth-related runtime state, not user-facing config.
- We had no first-class notion of named sources, derived keys, or secret marking — features we kept
  reaching for ad hoc.

`@clevercloud/reglage` is a purpose-built config builder that gives us all of the above out of the
box. Adopting it lets us delete the bespoke validation/merge code and gain better diagnostics
(per-source error attribution, structured `toString`, secret redaction) for free.

## Changes

- Wrap config in a `Config` class exposing a typed `get(key)` accessor. `reload()` now swaps the
  inner config reference instead of mutating fields in place.
- Migrate every call site from `config.API_HOST` / `config.TOKEN` / etc. to `config.get('API_HOST')`,
  `config.activeProfile?.token`, and so on.
- Split `BaseConfig` (validated config values) from `Config` (adds `profiles` and `activeProfile` as
  dedicated properties). The `$env` virtual profile derived from `CLEVER_TOKEN` / `CLEVER_SECRET`
  lives here too.
- Replace the Zod `safeParse` pipeline with `createConfigBuilder` from `@clevercloud/reglage`.
  `CONSOLE_TOKEN_URL` and `GOTO_URL` become `refine`-based derived keys off `CONSOLE_URL`; OAuth
  consumer key/secret are marked `secret: true`.
- Add 23 unit tests covering defaults, env overrides, derived keys, profile overrides, source
  priority, and reload semantics. Wire `npm test` into the `validate` script and the
  `code-quality` CI workflow.

### Implementation notes

The `Config` wrapper is the linchpin: reglage produces immutable config instances, so we cannot
keep mutating a shared object on reload. The wrapper lets every consumer hold a stable reference
to `config` while the inner immutable object gets swapped on `reloadConfig()`. That is also why
the call-site migration to `get()` is mandatory rather than cosmetic — direct property access on
the inner instance would skip the swap.

## How to review

1. Start with `src/config/config.js` — the `BaseConfig` / `Config` split, `loadConfig()`, and
   `buildConfig()` are the load-bearing pieces.
2. Skim `src/config/config.test.js` to see the contract that's now pinned down (defaults, env
   overrides, derived keys, profile overrides, priority, reload).
3. Run `npm test` locally to exercise the suite; CI now runs it via the new step in
   `.github/workflows/code-quality.yml`.
4. Spot-check a few migrated call sites (e.g. `src/models/send-to-api.js`,
   `src/commands/curl/curl.command.js`, `src/commands/login/login.command.js`) to confirm the
   `config.get(...)` / `config.activeProfile` pattern reads cleanly.