### PR TITLE
test: add commands tests infrastructure

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,8 @@
+{
+  "all": true,
+  "include": ["src/**/*.js"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.types.d.ts"],
+  "reporter": ["text", "text-summary", "html", "lcovonly", "json-summary"],
+  "reports-dir": "coverage",
+  "check-coverage": false
+}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,9 +5,16 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/setup-node@v4
+      id: setup-node
       with:
         node-version-file: 'package.json'
-        cache: 'npm'
+    - name: 'Cache node_modules'
+      id: cache-node-modules
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-node-modules-${{ hashFiles('package-lock.json') }}
     - name: 'Install Node.js dependencies'
-      run: npm ci
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci --prefer-offline --no-audit --no-fund
       shell: bash

--- a/.github/workflows/code-coverage-cleanup.yml
+++ b/.github/workflows/code-coverage-cleanup.yml
@@ -1,0 +1,31 @@
+name: Cleanup Code coverage
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches-ignore:
+      - 'release-please--**'
+
+env:
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET: ${{ vars.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET }}
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID: ${{ secrets.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID }}
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY: ${{ secrets.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY }}
+
+jobs:
+  cleanup:
+    name: 'Cleanup code coverage'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-node
+      - name: 'Delete code coverage report'
+        run: ./scripts/code-coverage.js delete ${{ github.event.pull_request.head.ref }}
+      - name: 'Update PR comment'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: 'Code coverage'
+          message: '📊 The code coverage report has been automatically deleted.'

--- a/.github/workflows/code-coverage-master.yml
+++ b/.github/workflows/code-coverage-master.yml
@@ -1,0 +1,31 @@
+name: Publish master code coverage
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+
+concurrency:
+  group: code-coverage-master
+  cancel-in-progress: true
+
+env:
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET: ${{ vars.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET }}
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID: ${{ secrets.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID }}
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY: ${{ secrets.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY }}
+
+jobs:
+  code-coverage:
+    name: 'Publish master code coverage'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-node
+      - name: 'Run tests with coverage'
+        run: npm run test:coverage
+      - name: 'Publish master code coverage report'
+        run: ./scripts/code-coverage.js publish master

--- a/.github/workflows/code-coverage-pr.yml
+++ b/.github/workflows/code-coverage-pr.yml
@@ -1,0 +1,47 @@
+name: Publish code coverage
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths-ignore:
+      - '**/*.md'
+    branches-ignore:
+      - 'release-please--**'
+
+concurrency:
+  group: code-coverage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET: ${{ vars.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET }}
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID: ${{ secrets.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID }}
+  CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY: ${{ secrets.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY }}
+
+jobs:
+  code-coverage:
+    name: 'Publish code coverage'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-node
+      - name: 'Run tests with coverage'
+        run: npm run test:coverage
+      - name: 'Publish code coverage report'
+        run: ./scripts/code-coverage.js publish ${{ github.event.pull_request.head.ref }}
+      - name: 'Prepare PR comment'
+        id: coverage-comment
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          ./scripts/code-coverage.js pr-comment ${{ github.event.pull_request.head.ref }} >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: 'Add code coverage comment to PR'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: 'Code coverage'
+          message: ${{ steps.coverage-comment.outputs.body }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,71 @@
+name: Tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths-ignore:
+      - '**/*.md'
+    branches-ignore:
+      - 'release-please--**'
+
+concurrency:
+  group: tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ github.event.pull_request.head.ref }}
+      isPreview: true
+
+  tests:
+    needs: build
+    name: 'Tests (${{ matrix.os }})'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-latest
+            artifact: build-linux-archive
+          - os: macos
+            runner: macos-14
+            artifact: build-macos-archive
+          - os: win
+            runner: windows-2025
+            artifact: build-win-archive
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/download-artifacts
+        with:
+          pattern: ${{ matrix.artifact }}
+      - name: 'Extract built CLI and set CLEVER_BIN'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p cli-under-test
+          archive=$(find build -type f \( -name "clever-tools-*_${{ matrix.os }}.tar.gz" -o -name "clever-tools-*_${{ matrix.os }}.zip" \) | head -n1)
+          if [ -z "$archive" ]; then
+            echo "No archive found for ${{ matrix.os }} under build/"; exit 1
+          fi
+          case "$archive" in
+            *.zip)    powershell -NoProfile -Command "Expand-Archive -Path '$archive' -DestinationPath cli-under-test" ;;
+            *.tar.gz) tar -xzf "$archive" -C cli-under-test ;;
+          esac
+          binary=$(find cli-under-test -type f \( -name clever -o -name clever.exe \) | head -n1)
+          if [ -z "$binary" ]; then
+            echo "Could not locate clever binary after extraction"; find cli-under-test; exit 1
+          fi
+          abs_binary=$(node -e "process.stdout.write(require('path').resolve(process.argv[1]))" "$binary")
+          echo "CLEVER_BIN=$abs_binary" >> "$GITHUB_ENV"
+          echo "Using CLI binary: $abs_binary"
+          "$abs_binary" version
+      - name: 'Run tests against built CLI'
+        shell: bash
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .clever.json
 build/
+coverage/
 .idea/
 .s3cfg*
 *.gpg.key

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "3.940.0",
+        "@clevercloud/doublure": "0.0.4",
         "@clevercloud/eslint-config": "1.1.0",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
@@ -51,11 +52,13 @@
         "eslint": "9.39.1",
         "globals": "16.5.0",
         "mime-types": "3.0.2",
+        "node-pty": "1.2.0-beta.13",
         "prettier": "3.7.3",
         "prettier-plugin-organize-imports": "4.3.0",
         "remark-parse": "11.0.0",
         "remark-stringify": "11.0.0",
         "rollup": "4.53.3",
+        "strip-ansi": "7.2.0",
         "tinyglobby": "0.2.15",
         "typescript": "5.9.3",
         "unified": "11.0.5"
@@ -1130,6 +1133,25 @@
         "eventsource": "^4.0.0"
       }
     },
+    "node_modules/@clevercloud/doublure": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@clevercloud/doublure/-/doublure-0.0.4.tgz",
+      "integrity": "sha512-23qEY6r+rqTgl4MSf9LPUtQugJEOKJwCUP4jJBIoarypPy+Tw8IncKklUpCJUYL46RsE5v5lDLkSXJGq6FSJcw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fastify": ">=5",
+        "find-my-way": "^9.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@clevercloud/eslint-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@clevercloud/eslint-config/-/eslint-config-1.1.0.tgz",
@@ -1763,6 +1785,123 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2258,6 +2397,13 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -3988,6 +4134,13 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4040,6 +4193,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-align": {
@@ -4113,6 +4284,16 @@
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/atomically": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
@@ -4135,6 +4316,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
       }
     },
     "node_modules/b4a": {
@@ -4849,6 +5051,20 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/core-util-is": {
@@ -5737,6 +5953,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5758,12 +5981,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -5801,6 +6059,50 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastify": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5836,6 +6138,21 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -6371,6 +6688,16 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6760,6 +7087,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -6864,6 +7211,45 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -7759,6 +8145,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -7786,6 +8179,27 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.2.0-beta.13",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.13.tgz",
+      "integrity": "sha512-ZbbJ7aJdmvRA53bw30D6YSJJKqo1IXTojD0kJeHZ/xZIxr7p1DCmvOmrOnjUo/rn1z4MDwKQGpx0C7K+cRKETw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -7987,6 +8401,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8095,6 +8549,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8147,6 +8618,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -8190,6 +8668,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -8334,6 +8822,34 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
@@ -8409,11 +8925,61 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -8426,6 +8992,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -8566,6 +9139,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/split2": {
@@ -8864,6 +9447,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -8925,6 +9528,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+      "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/mime-types": "3.0.1",
         "@types/picomatch": "4.0.2",
         "@yao-pkg/pkg": "6.10.1",
+        "c8": "11.0.0",
         "eslint": "9.39.1",
         "globals": "16.5.0",
         "mime-types": "3.0.2",
@@ -1115,6 +1116,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@clevercloud/client": {
@@ -2333,6 +2344,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3671,6 +3692,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3708,7 +3736,6 @@
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -4147,7 +4174,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4664,6 +4690,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/c8": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5053,6 +5113,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -5080,7 +5147,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5550,7 +5616,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5919,7 +5984,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
       "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -6208,6 +6272,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -6402,6 +6483,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6413,6 +6512,45 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-directory": {
@@ -6528,6 +6666,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -7032,6 +7177,45 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
@@ -7375,6 +7559,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.18",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
@@ -7383,6 +7577,22 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8373,6 +8583,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8505,7 +8732,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8856,7 +9082,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9424,6 +9649,60 @@
         "node": ">=6"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -9646,7 +9925,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9771,7 +10049,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -9866,6 +10143,21 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "isomorphic-git": "1.35.1",
         "linux-release-info": "3.0.0",
         "lodash": "4.17.21",
-        "open": "10.2.0",
+        "open": "11.0.0",
         "semver": "7.7.3",
         "simple-git": "3.30.0",
         "slugify": "1.6.6",
@@ -4067,12 +4067,15 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -4332,18 +4335,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boxen/node_modules/ansi-regex": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/boxen/node_modules/ansi-styles": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
@@ -4389,21 +4380,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/boxen/node_modules/type-fest": {
@@ -4655,6 +4631,29 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
@@ -5032,9 +5031,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -5048,9 +5047,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6469,6 +6468,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -6596,9 +6607,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -7620,11 +7631,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -7786,18 +7797,20 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7981,6 +7994,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prebuild-install": {
@@ -8353,9 +8378,9 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8654,7 +8679,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -8664,6 +8698,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-json-comments": {
@@ -9311,18 +9360,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/widest-line/node_modules/ansi-regex": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/widest-line/node_modules/emoji-regex": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
@@ -9344,21 +9381,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/word-wrap": {
@@ -9385,6 +9407,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9392,15 +9435,16 @@
       "license": "ISC"
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "license": "MIT",
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9472,6 +9516,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yargs/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -9485,6 +9539,19 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yargs/node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "install-local:cliparse": "(cd ../cliparse-node && npm pack) && mv ../cliparse-node/cliparse-*.tgz . && npm i -f ./cliparse-*.tgz",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check"
   },
   "dependencies": {
     "@babel/traverse": "7.28.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "isomorphic-git": "1.35.1",
     "linux-release-info": "3.0.0",
     "lodash": "4.17.21",
-    "open": "10.2.0",
+    "open": "11.0.0",
     "semver": "7.7.3",
     "simple-git": "3.30.0",
     "slugify": "1.6.6",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "install-local:cliparse": "(cd ../cliparse-node && npm pack) && mv ../cliparse-node/cliparse-*.tgz . && npm i -f ./cliparse-*.tgz",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
+    "test": "node --experimental-strip-types --disable-warning=ExperimentalWarning --test --test-force-exit --test-reporter=./test/reporter/reporter.ts 'src/**/*.test.ts'",
     "typecheck": "tsc -p tsconfig.json",
     "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check"
   },
@@ -72,6 +73,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "3.940.0",
+    "@clevercloud/doublure": "0.0.4",
     "@clevercloud/eslint-config": "1.1.0",
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
@@ -85,11 +87,13 @@
     "eslint": "9.39.1",
     "globals": "16.5.0",
     "mime-types": "3.0.2",
+    "node-pty": "1.2.0-beta.13",
     "prettier": "3.7.3",
     "prettier-plugin-organize-imports": "4.3.0",
     "remark-parse": "11.0.0",
     "remark-stringify": "11.0.0",
     "rollup": "4.53.3",
+    "strip-ansi": "7.2.0",
     "tinyglobby": "0.2.15",
     "typescript": "5.9.3",
     "unified": "11.0.5"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "node --experimental-strip-types --disable-warning=ExperimentalWarning --test --test-force-exit --test-reporter=./test/reporter/reporter.ts 'src/**/*.test.ts'",
+    "test:coverage": "c8 node --experimental-strip-types --disable-warning=ExperimentalWarning --test --test-force-exit --test-reporter=./test/reporter/reporter.ts 'src/**/*.test.ts'",
     "typecheck": "tsc -p tsconfig.json",
     "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check"
   },
@@ -84,6 +85,7 @@
     "@types/mime-types": "3.0.1",
     "@types/picomatch": "4.0.2",
     "@yao-pkg/pkg": "6.10.1",
+    "c8": "11.0.0",
     "eslint": "9.39.1",
     "globals": "16.5.0",
     "mime-types": "3.0.2",

--- a/scripts/code-coverage.js
+++ b/scripts/code-coverage.js
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+//
+// Manage code coverage reports published to Cellar storage.
+//
+// This script handles the coverage report workflow for clever-tools PRs:
+// - Publishing the local `coverage/` directory to Cellar under the per-preview prefix
+// - Deleting a previously-published coverage report (e.g. when a PR is closed)
+// - Generating a GitHub PR comment with a summary table and a link to the report
+//
+// USAGE:
+//   coverage.js publish [branch-name]
+//   coverage.js delete [branch-name]
+//   coverage.js pr-comment [branch-name]
+//
+// ARGUMENTS:
+//   command         Command to execute (publish|delete|pr-comment)
+//   [branch-name]   Branch name (e.g., "my-feature"), defaults to current git branch
+//
+// ENVIRONMENT VARIABLES:
+//   CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET      Preview storage bucket (required for publish/delete/pr-comment)
+//   CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID      Cellar access key (required for publish/delete)
+//   CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY  Cellar secret key (required for publish/delete)
+//
+// EXAMPLES:
+//   coverage.js publish
+//   coverage.js publish feature-branch
+//   coverage.js delete feature-branch
+//   coverage.js pr-comment feature-branch
+
+import dedent from 'dedent';
+import fs from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import { CellarClientPublic } from './lib/cellar-client-public.js';
+import { CellarClient } from './lib/cellar-client.js';
+import { ArgumentError, readEnvVars, runCommand, UnknownCommandError } from './lib/command.js';
+import { readJson } from './lib/fs.js';
+import { getCurrentBranch } from './lib/git.js';
+import { CODE_COVERAGE_DIR } from './lib/paths.js';
+import { highlight } from './lib/terminal.js';
+import { getVersion } from './lib/utils.js';
+
+/**
+ * @typedef {{ pct: number, covered: number, total: number, skipped: number }} CoverageMetric
+ * @typedef {{ statements: CoverageMetric, branches: CoverageMetric, functions: CoverageMetric, lines: CoverageMetric }} CoverageMetrics
+ * @typedef {{ total: CoverageMetrics }} CoverageSummary
+ */
+
+const DEFAULT_PREVIEW_CELLAR_BUCKET = 'clever-tools-preview.clever-cloud.com';
+const LOCAL_REPORT_DIR = 'coverage';
+const LOCAL_SUMMARY_PATH = `${LOCAL_REPORT_DIR}/coverage-summary.json`;
+const REMOTE_SUMMARY_FILE = 'coverage-summary.json';
+const SKIP_DIRS = ['tmp', 'lcov-report'];
+const MASTER_BRANCH_NAME = 'master';
+/** @type {Array<keyof CoverageMetrics>} */
+const METRIC_KEYS = ['statements', 'branches', 'functions', 'lines'];
+/** @type {Record<keyof CoverageMetrics, string>} */
+const METRIC_LABELS = {
+  statements: 'Statements',
+  branches: 'Branches',
+  functions: 'Functions',
+  lines: 'Lines',
+};
+
+/**
+ * Remote path for the coverage report of a given preview, relative to the bucket root.
+ * @param {string} previewName
+ * @returns {string}
+ */
+function getRemoteReportDir(previewName) {
+  return `${CODE_COVERAGE_DIR}/${previewName}`;
+}
+
+runCommand(async () => {
+  const [command, rawPreviewName] = process.argv.slice(2);
+
+  if (command == null || command.length === 0) {
+    throw new ArgumentError('command');
+  }
+
+  const branchDirectory = getVersion(rawPreviewName ?? (await getCurrentBranch()));
+
+  switch (command) {
+    case 'publish':
+      return publishCoverage(branchDirectory);
+    case 'delete':
+      return deleteCoverage(branchDirectory);
+    case 'pr-comment':
+      return printPrComment(branchDirectory);
+  }
+
+  throw new UnknownCommandError(command);
+});
+
+/**
+ * Uploads every file in the local `coverage/` directory to Cellar under the per-preview prefix.
+ * @param {string} branchDirectory
+ * @returns {Promise<void>}
+ */
+async function publishCoverage(branchDirectory) {
+  const cellarClient = createCellarClient();
+  const remoteDir = getRemoteReportDir(branchDirectory);
+
+  const files = await listFilesRecursive(LOCAL_REPORT_DIR);
+  const items = files.map((file) => ({
+    filepath: file,
+    remoteFilepath: `${remoteDir}/${relative(LOCAL_REPORT_DIR, file).split(sep).join('/')}`,
+  }));
+  await cellarClient.uploadFiles(items, {
+    onUpload: ({ filepath, remoteFilepath }) => {
+      console.log(highlight`=> Upload ${filepath} to ${remoteFilepath}`);
+    },
+  });
+
+  const reportUrl = cellarClient.getPublicUrl(`${remoteDir}/index.html`);
+  console.log(highlight`=> Coverage report available at ${reportUrl}`);
+}
+
+/**
+ * Deletes the published coverage report for a given preview.
+ * @param {string} branchDirectory
+ * @returns {Promise<void>}
+ */
+async function deleteCoverage(branchDirectory) {
+  const cellarClient = createCellarClient();
+  const remoteDir = getRemoteReportDir(branchDirectory);
+  console.log(highlight`=> Delete ${remoteDir + '/**'}`);
+  await cellarClient.delete(remoteDir);
+}
+
+/**
+ * Emits a markdown comment with the coverage totals and a link to the report.
+ * When a master coverage summary is available on Cellar, renders a Master / PR / Δ comparison
+ * table; otherwise falls back to the PR-only table.
+ * @param {string} branchDirectory
+ * @returns {Promise<void>}
+ */
+async function printPrComment(branchDirectory) {
+  const cellarClient = createCellarClientPublic();
+  const reportUrl = cellarClient.getPublicUrl(`${getRemoteReportDir(branchDirectory)}/index.html`);
+  const masterReportUrl = cellarClient.getPublicUrl(`${getRemoteReportDir(MASTER_BRANCH_NAME)}/index.html`);
+
+  const prSummary = /** @type {CoverageSummary} */ (await readJson(LOCAL_SUMMARY_PATH));
+  const masterSummary = await tryFetchMasterSummary(cellarClient);
+
+  const table = masterSummary
+    ? renderComparisonTable(masterSummary.total, prSummary.total)
+    : renderSingleTable(prSummary.total);
+
+  const reportLinks = masterSummary
+    ? `[Browse the PR HTML report](${reportUrl}) · [Browse the master HTML report](${masterReportUrl})`
+    : `[Browse the full HTML report](${reportUrl})`;
+
+  console.log(dedent`
+    📊 A code coverage report has been automatically published!
+
+    ${table}
+
+    ${reportLinks}
+
+    _This report will be deleted once this PR is closed._
+  `);
+}
+
+/**
+ * Fetches the master coverage summary from Cellar. Returns null on any failure
+ * (404, network error, malformed JSON, unexpected shape) so the caller can
+ * fall back to the PR-only table.
+ * @param {CellarClientPublic} cellarClient
+ * @returns {Promise<CoverageSummary | null>}
+ */
+async function tryFetchMasterSummary(cellarClient) {
+  try {
+    const raw = await cellarClient.getObject(`${getRemoteReportDir(MASTER_BRANCH_NAME)}/${REMOTE_SUMMARY_FILE}`);
+    const parsed = JSON.parse(raw);
+    if (parsed?.total?.statements?.pct == null) {
+      return null;
+    }
+    return /** @type {CoverageSummary} */ (parsed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {CoverageMetrics} pr
+ * @returns {string}
+ */
+function renderSingleTable(pr) {
+  const rows = METRIC_KEYS.map((key) => {
+    const m = pr[key];
+    return `| ${METRIC_LABELS[key]} | ${formatPct(m)} | ${formatCount(m)} |`;
+  }).join('\n');
+  return (
+    dedent`
+    | Metric | Coverage | Covered / Total |
+    | --- | ---: | ---: |
+  ` +
+    '\n' +
+    rows
+  );
+}
+
+/**
+ * @param {CoverageMetrics} master
+ * @param {CoverageMetrics} pr
+ * @returns {string}
+ */
+function renderComparisonTable(master, pr) {
+  const rows = METRIC_KEYS.map((key) => {
+    const masterMetric = master[key];
+    const prMetric = pr[key];
+    const masterCell = masterMetric != null ? formatPct(masterMetric) : 'n/a';
+    const deltaCell = masterMetric != null ? formatDelta(masterMetric.pct, prMetric.pct) : '—';
+    return `| ${METRIC_LABELS[key]} | ${masterCell} | ${formatPct(prMetric)} | ${deltaCell} | ${formatCount(prMetric)} |`;
+  }).join('\n');
+  return (
+    dedent`
+    | Metric | Master | PR | Δ | Covered / Total |
+    | --- | ---: | ---: | ---: | ---: |
+  ` +
+    '\n' +
+    rows
+  );
+}
+
+/**
+ * @param {CoverageMetric} m
+ * @returns {string}
+ */
+function formatPct(m) {
+  return `${m.pct.toFixed(2)}%`;
+}
+
+/**
+ * @param {CoverageMetric} m
+ * @returns {string}
+ */
+function formatCount(m) {
+  return `${m.covered} / ${m.total}`;
+}
+
+/**
+ * Formats the PR-vs-master coverage delta as a colored MathJax expression that GitHub
+ * markdown renders inline. `%` is escaped because it's a comment marker in LaTeX math mode.
+ * @param {number} masterPct
+ * @param {number} prPct
+ * @returns {string}
+ */
+function formatDelta(masterPct, prPct) {
+  const delta = prPct - masterPct;
+  const rounded = delta.toFixed(2);
+  if (rounded === '0.00' || rounded === '-0.00') {
+    return '—';
+  }
+  if (delta > 0) {
+    return `$\\color{green}{\\uparrow +${rounded}\\%}$`;
+  }
+  return `$\\color{red}{\\downarrow ${rounded}\\%}$`;
+}
+
+/**
+ * Recursively lists every regular file inside a directory, skipping `SKIP_DIRS` subdirectories.
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+async function listFilesRecursive(dir) {
+  const entries = await fs.readdir(dir, { recursive: true, withFileTypes: true });
+  const skipPrefixes = SKIP_DIRS.map((sub) => join(dir, sub) + sep);
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .filter((path) => !skipPrefixes.some((prefix) => path.startsWith(prefix)));
+}
+
+/**
+ * @returns {CellarClient}
+ */
+function createCellarClient() {
+  const bucket = process.env.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET ?? DEFAULT_PREVIEW_CELLAR_BUCKET;
+  const [accessKeyId, secretAccessKey] = readEnvVars([
+    'CC_CLEVER_TOOLS_PREVIEWS_CELLAR_KEY_ID',
+    'CC_CLEVER_TOOLS_PREVIEWS_CELLAR_SECRET_KEY',
+  ]);
+  return new CellarClient({ bucket, accessKeyId, secretAccessKey });
+}
+
+/**
+ * @returns {CellarClientPublic}
+ */
+function createCellarClientPublic() {
+  const bucket = process.env.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET ?? DEFAULT_PREVIEW_CELLAR_BUCKET;
+  return new CellarClientPublic({ bucket });
+}

--- a/scripts/lib/cellar-client.js
+++ b/scripts/lib/cellar-client.js
@@ -82,6 +82,21 @@ export class CellarClient {
   }
 
   /**
+   * Uploads multiple local files to the bucket with bounded parallelism.
+   * @param {Array<{ filepath: string, remoteFilepath: string }>} items - Files to upload
+   * @param {Object} [options]
+   * @param {number} [options.concurrency=8] - Max uploads in flight at once
+   * @param {(item: { filepath: string, remoteFilepath: string }) => void} [options.onUpload] - Called before each upload starts
+   * @throws {Error} When any upload fails
+   */
+  async uploadFiles(items, { concurrency = 8, onUpload } = {}) {
+    await this.#runInPool(items, concurrency, async (item) => {
+      onUpload?.(item);
+      await this.upload(item.filepath, item.remoteFilepath);
+    });
+  }
+
+  /**
    * Uploads raw data to the bucket with automatic content type detection.
    * @param {Buffer|string} body - The data to upload
    * @param {string} remoteFilepath - The destination path in the bucket
@@ -101,22 +116,23 @@ export class CellarClient {
   }
 
   /**
-   * Deletes all objects that match the given prefix.
+   * Deletes all objects that match the given prefix, with bounded parallelism.
    *
    * @param {string} remoteFilepath - The path prefix to delete (can be a file or directory)
+   * @param {Object} [options]
+   * @param {number} [options.concurrency=8] - Max deletes in flight at once
    * @throws {Error} When the deletion fails
    */
-  async delete(remoteFilepath) {
+  async delete(remoteFilepath, { concurrency = 8 } = {}) {
     const keys = await this.listObjects(remoteFilepath);
-    const promises = keys.map((key) => {
-      return this.#client.send(
+    await this.#runInPool(keys, concurrency, async (key) => {
+      await this.#client.send(
         new DeleteObjectCommand({
           Bucket: this.#bucket,
           Key: key,
         }),
       );
     });
-    await Promise.all(promises);
   }
 
   /**
@@ -138,5 +154,26 @@ export class CellarClient {
     }
 
     return [];
+  }
+
+  /**
+   * Runs `fn` over `items` with at most `concurrency` tasks in flight at once.
+   * Workers share the queue via `shift()` — safe under JS's single-threaded model.
+   * @template T
+   * @param {T[]} items
+   * @param {number} concurrency
+   * @param {(item: T) => Promise<void>} fn
+   * @returns {Promise<void>}
+   */
+  async #runInPool(items, concurrency, fn) {
+    const queue = items.slice();
+    const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (queue.length > 0) {
+        const item = queue.shift();
+        if (item === undefined) break;
+        await fn(item);
+      }
+    });
+    await Promise.all(workers);
   }
 }

--- a/scripts/lib/paths.js
+++ b/scripts/lib/paths.js
@@ -1,5 +1,6 @@
 export const BUILD_DIR = 'build';
 export const PREVIEW_DIR = 'previews';
+export const CODE_COVERAGE_DIR = 'code-coverage';
 export const RELEASES_DIR = 'releases';
 export const LOCAL_PREVIEW_DIR = '.preview-binaries';
 

--- a/src/commands/curl/curl.command.test.ts
+++ b/src/commands/curl/curl.command.test.ts
@@ -1,0 +1,140 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { profileConfig } from '../../../test/fixtures/profile.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const TOKEN = 'curl-token';
+const SECRET = 'curl-secret';
+const PROFILE = profileConfig({ token: TOKEN, secret: SECRET });
+
+function buildHelpOutput(apiHost: string) {
+  return dedent`
+    Usage: clever curl
+    Query Clever Cloud's API using Clever Tools credentials. For example:
+
+      clever curl ${apiHost}/v2/self
+      clever curl ${apiHost}/v2/summary
+      clever curl ${apiHost}/v4/products/zones
+      clever curl ${apiHost}/v2/organisations/<ORGANISATION_ID>/applications | jq '.[].id'
+      clever curl ${apiHost}/v4/billing/organisations/<ORGANISATION_ID>/<INVOICE_NUMBER>.pdf > invoice.pdf
+
+    Our API documentation is available here :
+
+      https://www.clever.cloud/developers/api/v2/
+      https://www.clever.cloud/developers/api/v4/
+  `;
+}
+
+describe('curl command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+  let apiHost: string;
+
+  before(async () => {
+    newScenario = await hooks.before();
+    apiHost = newScenario.mockClient.baseUrl;
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('calls the API with an OAuth authorization header when given a valid URL', async () => {
+      // `-s` silences curl's progress output (which would otherwise pollute stderr)
+      await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['curl', '-s', `${apiHost}/v2/self`])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/self');
+          const authorization = calls.first.headers.authorization as string;
+          assert.match(authorization, /^OAuth /);
+          assert.match(authorization, new RegExp(`oauth_token="${TOKEN}"`));
+          assert.match(authorization, new RegExp(`oauth_signature="[^"]*%26${SECRET}"`));
+        });
+    });
+  });
+
+  describe('help variants', () => {
+    it('prints help when called with no arguments', async () => {
+      const result = await newScenario()
+        .thenRunCli(['curl'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, buildHelpOutput(apiHost));
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints help when called with --help as the first argument', async () => {
+      const result = await newScenario()
+        .thenRunCli(['curl', '--help'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, buildHelpOutput(apiHost));
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints help when called with -h as the first argument', async () => {
+      const result = await newScenario()
+        .thenRunCli(['curl', '-h'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, buildHelpOutput(apiHost));
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('does not call when the last argument is --help', async () => {
+      await newScenario()
+        .withConfigFile(PROFILE)
+        .thenRunCli(['curl', `${apiHost}/v2/self`, '--help'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when no argument matches the configured API host', async () => {
+      const result = await newScenario()
+        .thenRunCli(['curl', 'https://other-host.example.com/foo'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, `[ERROR] "clever curl" command must be used with ${apiHost}`);
+    });
+  });
+
+  describe('no auth', () => {
+    // `clever curl` shells out to the system `curl` binary, which surfaces 401 directly
+    // (HTTP error body, not the friendly NOT_LOGGED_IN_ERROR message). With `-s -f` we get
+    // a non-zero exit code; without `-f` curl prints the body to stdout and exits 0. We
+    // assert the body-on-stdout path since that's the default behavior.
+    it('passes the missing-auth response from the API through to stdout', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['curl', '-s', `${apiHost}/v2/self`])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '{"error":"unauthorized"}');
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+});

--- a/src/commands/database/database.backups.download.command.test.ts
+++ b/src/commands/database/database.backups.download.command.test.ts
@@ -1,0 +1,404 @@
+/* eslint-disable camelcase */
+// API fields below (backup_id, creation_date, download_url) are snake_case on purpose:
+// they mirror the Clever Cloud API response shape and the eslint rule is disabled per
+// the test-checklist's §4 guidance for mock object literals.
+
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { ADDON_ID, ORGA_ID, UUID } from '../../../test/fixtures/id.ts';
+import { idsCache } from '../../../test/fixtures/ids-cache.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const REAL_ADDON_ID = `postgresql_${UUID}`;
+const BACKUP_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_BACKUP_ID = '22222222-2222-2222-2222-222222222222';
+const BACKUP_CONTENT = 'mock-backup-content';
+
+const SUMMARY = {
+  user: { ...SELF, applications: [], addons: [], consumers: [] },
+  organisations: [
+    {
+      id: ORGA_ID,
+      name: 'test-org',
+      applications: [],
+      addons: [{ id: ADDON_ID, realId: REAL_ADDON_ID, name: 'my-db', providerId: 'postgresql-addon' }],
+      consumers: [],
+    },
+  ],
+};
+
+const ADDON_IDS_CACHE = idsCache({
+  owners: {
+    [ADDON_ID]: ORGA_ID,
+    [REAL_ADDON_ID]: ORGA_ID,
+  },
+  addons: {
+    [ADDON_ID]: { addonId: ADDON_ID, realId: REAL_ADDON_ID },
+    [REAL_ADDON_ID]: { addonId: ADDON_ID, realId: REAL_ADDON_ID },
+  },
+});
+
+const BACKUPS_ENDPOINT = '/v2/backups/:ownerId/:realAddonId';
+
+/**
+ * Build a single API-shaped backup entry. Use it as a fixture for /v2/backups response bodies.
+ */
+function backupEntry({
+  id = BACKUP_ID,
+  date = '2026-02-01T00:00:00Z',
+  downloadUrl,
+}: {
+  id?: string;
+  date?: string;
+  downloadUrl: string;
+}) {
+  return {
+    backup_id: id,
+    creation_date: date,
+    status: 'COMPLETED',
+    download_url: downloadUrl,
+  };
+}
+
+describe('database backups download command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+  let apiHost: string;
+
+  before(async () => {
+    newScenario = await hooks.before();
+    apiHost = newScenario.mockClient.baseUrl;
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('writes backup content to stdout when --output is omitted', async () => {
+      const downloadPath = `/downloads/${BACKUP_ID}`;
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({
+          status: 200,
+          body: [
+            backupEntry({
+              id: OTHER_BACKUP_ID,
+              date: '2026-01-01T00:00:00Z',
+              downloadUrl: `${apiHost}/downloads/${OTHER_BACKUP_ID}`,
+            }),
+            backupEntry({ downloadUrl: `${apiHost}${downloadPath}` }),
+          ],
+        })
+        .when({ method: 'GET', path: downloadPath })
+        .respond({ status: 200, body: BACKUP_CONTENT })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.realAddonId, REAL_ADDON_ID);
+          assert.strictEqual(calls.last.path, downloadPath);
+        });
+
+      assert.strictEqual(result.stdout, BACKUP_CONTENT);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('writes backup content to a file when --output is provided', async () => {
+      const downloadPath = `/downloads/${BACKUP_ID}`;
+      const result = await newScenario()
+        .withAppFile('placeholder', '')
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 200, body: [backupEntry({ downloadUrl: `${apiHost}${downloadPath}` })] })
+        .when({ method: 'GET', path: downloadPath })
+        .respond({ status: 200, body: BACKUP_CONTENT })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID, '--output', 'backup.dump'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.last.path, downloadPath);
+        })
+        .verifyFiles((fsRead) => {
+          assert.strictEqual(fsRead.readAppFile('backup.dump'), BACKUP_CONTENT);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('accepts --out as an alias for --output', async () => {
+      const downloadPath = `/downloads/${BACKUP_ID}`;
+      const result = await newScenario()
+        .withAppFile('placeholder', '')
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 200, body: [backupEntry({ downloadUrl: `${apiHost}${downloadPath}` })] })
+        .when({ method: 'GET', path: downloadPath })
+        .respond({ status: 200, body: BACKUP_CONTENT })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID, '--out', 'backup.dump'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.last.path, downloadPath);
+        })
+        .verifyFiles((fsRead) => {
+          assert.strictEqual(fsRead.readAppFile('backup.dump'), BACKUP_CONTENT);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when no arguments are given', async () => {
+      const result = await newScenario()
+        .thenRunCli(['database', 'backups', 'download'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /missing value/);
+    });
+
+    it('errors when only the addon argument is given', async () => {
+      const result = await newScenario()
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /backup-id: missing value/);
+    });
+  });
+
+  describe('backup selection', () => {
+    it('errors when no backup matches the given ID', async () => {
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({
+          status: 200,
+          body: [backupEntry({ id: OTHER_BACKUP_ID, downloadUrl: `${apiHost}/downloads/${OTHER_BACKUP_ID}` })],
+        })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] no backup with this ID');
+    });
+
+    it('errors when the backup list is empty', async () => {
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 200, body: [] })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] no backup with this ID');
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when the backups list endpoint returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+
+    it('errors when the download URL returns a non-OK status', async () => {
+      const downloadPath = `/downloads/${BACKUP_ID}`;
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 200, body: [backupEntry({ downloadUrl: `${apiHost}${downloadPath}` })] })
+        .when({ method: 'GET', path: downloadPath })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Failed to download backup');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when the backups endpoint returns 401', async () => {
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+
+  describe('addon ID resolution', () => {
+    const ADDON_NAME = 'my-db';
+    const downloadPath = `/downloads/${BACKUP_ID}`;
+
+    function withSuccessfulBackup(scenario: ReturnType<NewCliScenario>) {
+      return scenario
+        .when({ method: 'GET', path: BACKUPS_ENDPOINT })
+        .respond({ status: 200, body: [backupEntry({ downloadUrl: `${apiHost}${downloadPath}` })] })
+        .when({ method: 'GET', path: downloadPath })
+        .respond({ status: 200, body: BACKUP_CONTENT });
+    }
+
+    // === addon ID (addon_<UUID>) ===
+
+    it('resolves an addon ID from cache without calling /v2/summary', async () => {
+      const result = await withSuccessfulBackup(newScenario().withIdsCacheFile(ADDON_IDS_CACHE))
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.pathParams?.realAddonId, REAL_ADDON_ID);
+          assert.strictEqual(calls.last.path, downloadPath);
+        });
+
+      assert.strictEqual(result.stdout, BACKUP_CONTENT);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('resolves an addon ID via /v2/summary when cache is empty', async () => {
+      const result = await withSuccessfulBackup(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 3);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, BACKUP_CONTENT);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('errors when an addon ID is not in cache and not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['database', 'backups', 'download', 'addon_unknown', BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Add-on addon_unknown does not exist');
+    });
+
+    it('errors when an addon ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['database', 'backups', 'download', ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === real ID (postgresql_<UUID>) ===
+
+    it('resolves a real ID from cache without calling /v2/summary', async () => {
+      const result = await withSuccessfulBackup(newScenario().withIdsCacheFile(ADDON_IDS_CACHE))
+        .thenRunCli(['database', 'backups', 'download', REAL_ADDON_ID, BACKUP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.pathParams?.realAddonId, REAL_ADDON_ID);
+          assert.strictEqual(calls.last.path, downloadPath);
+        });
+
+      assert.strictEqual(result.stdout, BACKUP_CONTENT);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('resolves a real ID via /v2/summary when cache is empty', async () => {
+      const result = await withSuccessfulBackup(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['database', 'backups', 'download', REAL_ADDON_ID, BACKUP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 3);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, BACKUP_CONTENT);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('errors when a real ID is not in cache and not in /v2/summary', async () => {
+      const unknownRealId = 'postgresql_99999999-9999-9999-9999-999999999999';
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['database', 'backups', 'download', unknownRealId, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, `[ERROR] Add-on ${unknownRealId} does not exist`);
+    });
+
+    it('errors when a real ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['database', 'backups', 'download', REAL_ADDON_ID, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === addon name — not supported by resolveAddon, always errors ===
+
+    it('errors when an addon name is passed (cache hit by name is not supported)', async () => {
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['database', 'backups', 'download', ADDON_NAME, BACKUP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, `[ERROR] Add-on ${ADDON_NAME} does not exist`);
+    });
+  });
+});

--- a/src/commands/deploy/deploy.command.test.ts
+++ b/src/commands/deploy/deploy.command.test.ts
@@ -1,0 +1,302 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { multiAppConfig, singleAppConfig } from '../../../test/fixtures/app-config.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { APP_ID, ORGA_ID } from '../../../test/fixtures/id.ts';
+import { profileConfig } from '../../../test/fixtures/profile.ts';
+
+const PROFILE = profileConfig();
+
+const APP_ENDPOINT = `/v2/organisations/${ORGA_ID}/applications/${APP_ID}`;
+const DEPLOYMENTS_ENDPOINT = `${APP_ENDPOINT}/deployments`;
+
+/**
+ * Minimum app body that survives `addInstanceLifetime` (which dereferences `instance.lifetime`).
+ */
+function appBody({ commitId = null }: { commitId?: string | null } = {}) {
+  return {
+    id: APP_ID,
+    ownerId: ORGA_ID,
+    name: 'test-app',
+    commitId,
+    instance: { lifetime: 'REGULAR' },
+  };
+}
+
+describe('deploy command', () => {
+  const hooks = cliHooks({ enableGit: true });
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(async () => {
+    await hooks.beforeEach();
+  });
+
+  after(async () => {
+    await hooks.after();
+  });
+
+  /**
+   * App config tied to the running mock git server, since `deploy_url` must
+   * resolve to a repo we control.
+   */
+  function appConfig() {
+    return singleAppConfig({ app_id: APP_ID, deploy_url: newScenario.gitClient.getRepoUrl(APP_ID) });
+  }
+
+  describe('happy path', () => {
+    it('pushes a new commit and exits at deploy-start', async () => {
+      let headCommit;
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppFile('README.md', 'Hello, world!')
+        .withAppGit(APP_ID, (repo) => {
+          headCommit = repo.commitAll();
+        })
+        .when({ method: 'GET', path: APP_ENDPOINT })
+        .respond({ status: 200, body: appBody() })
+        .when({ method: 'GET', path: DEPLOYMENTS_ENDPOINT })
+        .respond([
+          { status: 200, body: [] },
+          { status: 200, body: [{ uuid: 'deploy_new', commit: headCommit, state: 'WIP' }] },
+        ])
+        .thenRunCli(['deploy', '--exit-on', 'deploy-start'])
+        .verify((calls) => {
+          assert.strictEqual(calls.filter({ method: 'GET', path: APP_ENDPOINT }).count, 1);
+          assert.ok(calls.filter({ method: 'GET', path: DEPLOYMENTS_ENDPOINT }).count >= 2);
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(
+        result.stdout.replace(/\(\d+\.\d+s\)/, '(<duration>)'),
+        dedent`
+          🚀 Deploying test-app
+             Application ID  ${APP_ID}
+             Organisation ID ${ORGA_ID}
+
+          🔀 Git information
+             ! App is brand new, no commits on remote yet
+             Local commit    ${headCommit} [will be deployed]
+
+          🔄 Deployment progress
+             → Pushing source code to Clever Cloud…
+             ✓ Code pushed to Clever Cloud (<duration>)
+             → Waiting for deployment to start…
+             ✓ Deployment started (deploy_new)
+        `,
+      );
+    });
+
+    it('reports brand-new app and pushes when remote has no commits', async () => {
+      let headCommit = '';
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppFile('README.md', 'Hello, world!')
+        .withAppGit(APP_ID, (client) => {
+          headCommit = client.commitAll();
+        })
+        .when({ method: 'GET', path: APP_ENDPOINT })
+        .respond({ status: 200, body: appBody() })
+        .when({ method: 'GET', path: DEPLOYMENTS_ENDPOINT })
+        .respond([
+          { status: 200, body: [] },
+          { status: 200, body: [{ uuid: 'deploy_new', commit: headCommit, state: 'WIP' }] },
+        ])
+        .thenRunCli(['deploy', '--exit-on', 'deploy-start']);
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(
+        result.stdout.replace(/\(\d+\.\d+s\)/, '(<duration>)'),
+        dedent`
+          🚀 Deploying test-app
+             Application ID  ${APP_ID}
+             Organisation ID ${ORGA_ID}
+
+          🔀 Git information
+             ! App is brand new, no commits on remote yet
+             Local commit    ${headCommit} [will be deployed]
+
+          🔄 Deployment progress
+             → Pushing source code to Clever Cloud…
+             ✓ Code pushed to Clever Cloud (<duration>)
+             → Waiting for deployment to start…
+             ✓ Deployment started (deploy_new)
+        `,
+      );
+    });
+  });
+
+  describe('linked application resolution', () => {
+    it('errors when not in an app directory', async () => {
+      const result = await newScenario()
+        .thenRunCli(['deploy'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] There is no linked or targeted application. Use `--app` option or `clever link` command.',
+      );
+    });
+
+    it('errors when app config has multiple aliases and no --alias is given', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['deploy'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Several applications are linked. You can specify one with the "--alias" option. Run "clever applications" to list linked applications. Available aliases: prod, staging',
+      );
+    });
+
+    it('errors when --alias does not match any linked application', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['deploy', '--alias', 'unknown'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] There are no applications matching alias unknown');
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when --tag points to a tag that does not exist locally', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppGit(APP_ID)
+        .thenRunCli(['deploy', '--tag', 'v-missing'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stderr, "[ERROR] Tag v-missing doesn't exist locally");
+    });
+
+    // --same-commit-policy schema is `z.enum(['error', 'ignore', 'restart', 'rebuild'])`.
+    it('errors when --same-commit-policy is not in the allowed enum', async () => {
+      const result = await newScenario()
+        .thenRunCli(['deploy', '--same-commit-policy', 'invalid'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(
+        result.stdout,
+        /^same-commit-policy: Invalid option: expected one of "error"\|"ignore"\|"restart"\|"rebuild"/,
+      );
+    });
+
+    // --exit-on schema is `z.enum(['deploy-start', 'deploy-end', 'never'])`.
+    it('errors when --exit-on is not in the allowed enum', async () => {
+      const result = await newScenario()
+        .thenRunCli(['deploy', '--exit-on', 'invalid'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^exit-on: Invalid option: expected one of "deploy-start"\|"deploy-end"\|"never"/);
+    });
+  });
+
+  describe('same-commit policy', () => {
+    it('prints up-to-date and skips the push when --same-commit-policy ignore is given', async () => {
+      let headCommit = '';
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppFile('README.md', 'Hello, world!\n')
+        .withAppGit(APP_ID, (repo) => {
+          headCommit = repo.commitAll();
+          repo.push();
+        })
+        .when({ method: 'GET', path: APP_ENDPOINT })
+        .respond({ status: 200, body: appBody({ commitId: headCommit }) })
+        .thenRunCli(['deploy', '--same-commit-policy', 'ignore'])
+        .verify((calls) => {
+          assert.strictEqual(calls.filter({ method: 'GET', path: DEPLOYMENTS_ENDPOINT }).count, 0);
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(result.stdout, `✓ The application is up-to-date (${headCommit})`);
+    });
+
+    it('errors by default when local commit equals the remote head', async () => {
+      let headCommit = '';
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppFile('README.md', 'Hello, world!\n')
+        .withAppGit(APP_ID, (repo) => {
+          headCommit = repo.commitAll();
+          repo.push();
+        })
+        .when({ method: 'GET', path: APP_ENDPOINT })
+        .respond({ status: 200, body: appBody({ commitId: headCommit }) })
+        .thenRunCli(['deploy'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.filter({ method: 'GET', path: DEPLOYMENTS_ENDPOINT }).count, 0);
+        });
+
+      assert.match(result.stderr, /Remote HEAD has the same commit as the one to push/);
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when GET /v2/organisations/:ownerId/applications/:appId returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppGit(APP_ID, (repo) => {
+          repo.commitAll();
+          repo.push();
+        })
+        .when({ method: 'GET', path: APP_ENDPOINT })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['deploy'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.filter({ method: 'GET', path: APP_ENDPOINT }).count, 1);
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when /v2/organisations/:ownerId/applications/:appId returns 401', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withAppConfigFile(appConfig())
+        .withAppGit(APP_ID, (repo) => {
+          repo.commitAll();
+          repo.push();
+        })
+        .when({ method: 'GET', path: APP_ENDPOINT })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['deploy'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.filter({ method: 'GET', path: APP_ENDPOINT }).count, 1);
+        });
+
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/emails/emails.add.command.test.ts
+++ b/src/commands/emails/emails.add.command.test.ts
@@ -1,0 +1,119 @@
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+
+describe('emails add command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('adds a secondary email address', async () => {
+      const result = await newScenario()
+        .when({ method: 'PUT', path: '/v2/self/emails/:address' })
+        .respond({ status: 200, body: {} })
+        .thenRunCli(['emails', 'add', 'test.user+secondary@example.com'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.method, 'PUT');
+          assert.strictEqual(calls.first.pathParams?.address, 'test.user+secondary@example.com');
+        });
+
+      assert.strictEqual(
+        result.stdout,
+        '✓ The server sent a confirmation email to test.user+secondary@example.com to validate your secondary address',
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when the email argument is missing', async () => {
+      const result = await newScenario()
+        .thenRunCli(['emails', 'add'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^email: missing value/);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    // emailArg.schema is `z.string().email()` — exercises zod's email validator.
+    it('errors when the email argument fails the z.string().email() schema', async () => {
+      const result = await newScenario()
+        .thenRunCli(['emails', 'add', 'not-an-email'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^email: Invalid email address/);
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('API errors on PUT /v2/self/emails/:address', () => {
+    it('reports a clear error for id=101 (address already on account)', async () => {
+      const result = await newScenario()
+        .when({ method: 'PUT', path: '/v2/self/emails/:address' })
+        .respond({ status: 400, body: { id: 101 } })
+        .thenRunCli(['emails', 'add', 'test.user@example.com'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] This address already belongs to your account');
+    });
+
+    it('reports a clear error for id=550 (invalid format)', async () => {
+      const result = await newScenario()
+        .when({ method: 'PUT', path: '/v2/self/emails/:address' })
+        .respond({ status: 400, body: { id: 550 } })
+        .thenRunCli(['emails', 'add', 'test.user@example.com'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] The format of this address is invalid');
+    });
+
+    it('reports a clear error for id=1004 (belongs to another account)', async () => {
+      const result = await newScenario()
+        .when({ method: 'PUT', path: '/v2/self/emails/:address' })
+        .respond({ status: 400, body: { id: 1004 } })
+        .thenRunCli(['emails', 'add', 'test.user@example.com'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] This address belongs to another account');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when the API returns 401', async () => {
+      const result = await newScenario()
+        .when({ method: 'PUT', path: '/v2/self/emails/:address' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['emails', 'add', 'test.user@example.com'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/emails/emails.command.test.ts
+++ b/src/commands/emails/emails.command.test.ts
@@ -1,0 +1,161 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+describe('emails command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('prints the primary email when there are no secondary addresses', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/emails' })
+        .respond({ status: 200, body: [] })
+        .thenRunCli(['emails'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(
+        result.stdout,
+        dedent`
+              ✉️  Primary email address:
+               • test.user@example.com
+            `,
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints the primary and secondary email addresses', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/emails' })
+        .respond({ status: 200, body: ['test.user+secondary@example.com'] })
+        .thenRunCli(['emails'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(
+        result.stdout,
+        dedent`
+              ✉️  Primary email address:
+               • test.user@example.com
+
+              ✉️  1 secondary email address(es):
+               • test.user+secondary@example.com
+            `,
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('accepts -F as an alias for --format', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/emails' })
+        .respond({ status: 200, body: ['b@example.com', 'a@example.com'] })
+        .thenRunCli(['emails', '-F', 'json'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.deepStrictEqual(JSON.parse(result.stdout), {
+        primary: SELF.email,
+        secondary: ['a@example.com', 'b@example.com'],
+      });
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints the result as sorted JSON when --format json is given', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/emails' })
+        .respond({ status: 200, body: ['b@example.com', 'a@example.com'] })
+        .thenRunCli(['emails', '--format', 'json'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.deepStrictEqual(JSON.parse(result.stdout), {
+        primary: SELF.email,
+        secondary: ['a@example.com', 'b@example.com'],
+      });
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('rejects an invalid --format value', async () => {
+      const result = await newScenario()
+        .thenRunCli(['emails', '--format', 'xml'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^format: Invalid option: expected one of "human"\|"json"/);
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when /v2/self returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['emails'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/self');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+
+    it('reports the error body when /v2/self/emails returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/emails' })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['emails'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when /v2/self returns 401', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['emails'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/env/env.import.command.test.ts
+++ b/src/commands/env/env.import.command.test.ts
@@ -1,0 +1,331 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { multiAppConfig, singleAppConfig } from '../../../test/fixtures/app-config.ts';
+import { APP_ALIAS_MUTEX_ERROR, NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { APP_ID, ORGA_ID } from '../../../test/fixtures/id.ts';
+import { idsCache } from '../../../test/fixtures/ids-cache.ts';
+
+const SUMMARY = {
+  user: { id: APP_ID, applications: [], addons: [], consumers: [] },
+  organisations: [
+    {
+      id: ORGA_ID,
+      name: 'test-org',
+      applications: [{ id: APP_ID, name: 'test-app', variantSlug: 'node' }],
+      addons: [],
+      consumers: [],
+    },
+  ],
+};
+
+const APP_IDS_CACHE = idsCache({ owners: { [APP_ID]: ORGA_ID } });
+
+const ENV_ENDPOINT = '/v2/organisations/:ownerId/applications/:appId/env';
+
+const APP_NAME = 'test-app';
+const UNKNOWN_APP_ID = 'app_99999999-9999-4999-8999-999999999999';
+
+describe('env import command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('replaces all env vars from name=value lines on stdin', async () => {
+      const stdin = dedent`
+        FOO=bar
+        BAZ="qux quux"
+      `;
+
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'PUT', path: ENV_ENDPOINT })
+        .respond({ status: 200, body: {} })
+        .thenRunCli(['env', 'import'], { stdin })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.method, 'PUT');
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.appId, APP_ID);
+          assert.deepStrictEqual(calls.first.body, { FOO: 'bar', BAZ: 'qux quux' });
+        });
+
+      assert.strictEqual(result.stdout, 'Environment variables have been set');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('replaces all env vars from JSON on stdin when --json is given', async () => {
+      const stdin = JSON.stringify([
+        { name: 'FOO', value: 'bar' },
+        { name: 'BAZ', value: 'qux quux' },
+      ]);
+
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'PUT', path: ENV_ENDPOINT })
+        .respond({ status: 200, body: {} })
+        .thenRunCli(['env', 'import', '--json'], { stdin })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.deepStrictEqual(calls.first.body, { FOO: 'bar', BAZ: 'qux quux' });
+        });
+
+      assert.strictEqual(result.stdout, 'Environment variables have been set');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('accepts -a as an alias for --alias', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .when({ method: 'PUT', path: ENV_ENDPOINT })
+        .respond({ status: 200, body: {} })
+        .thenRunCli(['env', 'import', '-a', 'prod'], { stdin: 'FOO=bar' })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, 'Environment variables have been set');
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('stdin parsing errors', () => {
+    it('errors when name=value input has a duplicate name', async () => {
+      const stdin = dedent`
+        FOO=1
+        FOO=2
+      `;
+
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .thenRunCli(['env', 'import'], { stdin, expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] line 2: be careful, the name FOO is already defined');
+    });
+
+    it('errors when --json input is not valid JSON', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .thenRunCli(['env', 'import', '--json'], { stdin: 'not json', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        `[ERROR] Error when parsing JSON input: Unexpected token 'o', "not json" is not valid JSON`,
+      );
+    });
+  });
+
+  describe('linked application resolution', () => {
+    it('errors when not in an app directory and --app is missing', async () => {
+      const result = await newScenario()
+        .thenRunCli(['env', 'import'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] There is no linked or targeted application. Use `--app` option or `clever link` command.',
+      );
+    });
+
+    it('errors when app config has multiple aliases and no --alias is given', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['env', 'import'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Several applications are linked. You can specify one with the "--alias" option. Run "clever applications" to list linked applications. Available aliases: prod, staging',
+      );
+    });
+
+    it('errors when --alias does not match any linked application', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['env', 'import', '--alias', 'unknown'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] There are no applications matching alias unknown');
+    });
+
+    it('errors when both --app and --alias are provided', async () => {
+      const result = await newScenario()
+        .thenRunCli(['env', 'import', '--app', APP_ID, '--alias', 'test-app'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, APP_ALIAS_MUTEX_ERROR);
+    });
+  });
+
+  describe('app ID resolution', () => {
+    function withSuccessfulPut(scenario: ReturnType<NewCliScenario>) {
+      return scenario.when({ method: 'PUT', path: ENV_ENDPOINT }).respond({ status: 200, body: {} });
+    }
+
+    // === app ID (app_<UUID>) ===
+
+    it('resolves an app ID from cache without calling /v2/summary', async () => {
+      const result = await withSuccessfulPut(newScenario().withIdsCacheFile(APP_IDS_CACHE))
+        .thenRunCli(['env', 'import', '--app', APP_ID], { stdin: 'FOO=bar' })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, 'Environment variables have been set');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('resolves an app ID via /v2/summary when cache is empty', async () => {
+      const result = await withSuccessfulPut(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['env', 'import', '--app', APP_ID], { stdin: 'FOO=bar' })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.last.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, 'Environment variables have been set');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('errors when an app ID is not in cache and not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['env', 'import', '--app', UNKNOWN_APP_ID], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Application not found');
+    });
+
+    it('errors when an app ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['env', 'import', '--app', APP_ID], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === app name — goes directly to /v2/summary (no cache lookup) ===
+
+    it('resolves an app name via /v2/summary', async () => {
+      const result = await withSuccessfulPut(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['env', 'import', '--app', APP_NAME], { stdin: 'FOO=bar' })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, 'Environment variables have been set');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('errors when an app name is not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['env', 'import', '--app', 'unknown-app'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Application not found');
+    });
+
+    it('errors when /v2/summary returns 404 for an app name', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['env', 'import', '--app', APP_NAME], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when PUT /v2/organisations/:ownerId/applications/:appId/env returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'PUT', path: ENV_ENDPOINT })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['env', 'import'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when the API returns 401', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'PUT', path: ENV_ENDPOINT })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['env', 'import'], { stdin: 'FOO=bar', expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/kv/kv.command.test.ts
+++ b/src/commands/kv/kv.command.test.ts
@@ -1,0 +1,291 @@
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { ORGA_ID, UUID } from '../../../test/fixtures/id.ts';
+import { profileConfig } from '../../../test/fixtures/profile.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+import type { MockRedisServer } from '../../../test/mocks/redis-server-mock.ts';
+import { startMockRedisServer } from '../../../test/mocks/redis-server-mock.ts';
+
+const PROFILE = profileConfig();
+
+const KV_NAME = 'myKv';
+const KV_ADDON_ID = `addon_${UUID}`;
+const KV_REAL_ID = `kv_${UUID}`;
+
+const SUMMARY = {
+  user: { ...SELF, applications: [], addons: [], consumers: [] },
+  organisations: [
+    {
+      id: ORGA_ID,
+      name: 'test-org',
+      applications: [],
+      addons: [{ id: KV_ADDON_ID, realId: KV_REAL_ID, name: KV_NAME, providerId: 'kv' }],
+      consumers: [],
+    },
+  ],
+};
+
+const ENABLED_FEATURES = { kv: true };
+
+describe('kv command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+  let redis: MockRedisServer;
+
+  before(async () => {
+    newScenario = await hooks.before();
+    redis = await startMockRedisServer();
+  });
+
+  beforeEach(async () => {
+    await hooks.beforeEach();
+    redis.reset();
+  });
+
+  after(async () => {
+    await redis.close();
+    await hooks.after();
+  });
+
+  function withResolvedKvAddon(scenario: ReturnType<NewCliScenario>) {
+    return scenario
+      .withConfigFile(PROFILE)
+      .withExperimentalFeaturesFile(ENABLED_FEATURES)
+      .when({ method: 'GET', path: '/v2/summary' })
+      .respond({ status: 200, body: SUMMARY })
+      .when({ method: 'GET', path: '/v2/organisations/:ownerId/addons/:addonId/env' })
+      .respond({ status: 200, body: [{ name: 'REDIS_URL', value: redis.url }] });
+  }
+
+  describe('happy path', () => {
+    it('sends the command to Redis and prints the reply (human format)', async () => {
+      redis.setReply('PING', '+PONG\r\n');
+
+      const result = await withResolvedKvAddon(newScenario())
+        .thenRunCli(['kv', KV_NAME, 'PING'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.last.pathParams?.addonId, KV_ADDON_ID);
+        });
+
+      assert.strictEqual(result.stdout, 'PONG');
+      assert.strictEqual(result.stderr, '');
+      assert.deepStrictEqual(redis.received, [['PING']]);
+    });
+
+    it('forwards every positional argument as part of the Redis command', async () => {
+      redis.setReply('SET', '+OK\r\n');
+
+      const result = await withResolvedKvAddon(newScenario())
+        .thenRunCli(['kv', KV_NAME, 'SET', 'k', 'v', 'EX', '120'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, 'OK');
+      assert.strictEqual(result.stderr, '');
+      assert.deepStrictEqual(redis.received, [['SET', 'k', 'v', 'EX', '120']]);
+    });
+
+    it('accepts -F as an alias for --format json', async () => {
+      redis.setReply('GET foo', '$3\r\nbar\r\n');
+
+      const result = await withResolvedKvAddon(newScenario())
+        .thenRunCli(['kv', KV_NAME, 'GET', 'foo', '-F', 'json'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '"bar"');
+      assert.strictEqual(result.stderr, '');
+      assert.deepStrictEqual(redis.received, [['GET', 'foo']]);
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when the add-on argument is missing', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .thenRunCli(['kv'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /missing value/);
+    });
+
+    // --format schema is `z.enum(['human', 'json'])`.
+    it('errors when --format is not in the allowed enum', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .thenRunCli(['kv', KV_NAME, 'PING', '--format', 'xml'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^format: Invalid option: expected one of "human"\|"json"/);
+    });
+  });
+
+  describe('experimental feature gate', () => {
+    it('does not expose the kv subcommand when the kv feature is not enabled', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .thenRunCli(['kv', KV_NAME, 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      // With kv hidden, the CLI prints global help on stdout (no [ERROR]).
+      assert.strictEqual(result.stderr, '');
+      assert.doesNotMatch(result.stdout, /clever kv/);
+    });
+  });
+
+  describe('add-on resolution', () => {
+    it('errors when the add-on does not exist', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['kv', 'unknown-addon', 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Add-on unknown-addon not found');
+    });
+
+    it('errors when several add-ons match the given name (across orgs)', async () => {
+      const ambiguousSummary = {
+        user: { ...SELF, applications: [], addons: [], consumers: [] },
+        organisations: [
+          {
+            id: ORGA_ID,
+            name: 'orga-1',
+            applications: [],
+            addons: [{ id: KV_ADDON_ID, realId: KV_REAL_ID, name: KV_NAME, providerId: 'kv' }],
+            consumers: [],
+          },
+          {
+            id: 'orga_other',
+            name: 'orga-2',
+            applications: [],
+            addons: [{ id: 'addon_other', realId: 'kv_other', name: KV_NAME, providerId: 'kv' }],
+            consumers: [],
+          },
+        ],
+      };
+
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: ambiguousSummary })
+        .thenRunCli(['kv', KV_NAME, 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.match(result.stderr, /^\[ERROR\] Several add-ons found for/);
+    });
+  });
+
+  describe('redis URL discovery', () => {
+    it('errors when the add-on env vars do not include REDIS_URL', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .when({ method: 'GET', path: '/v2/organisations/:ownerId/addons/:addonId/env' })
+        .respond({ status: 200, body: [{ name: 'OTHER', value: 'x' }] })
+        .thenRunCli(['kv', KV_NAME, 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Environment variable REDIS_URL not found, is it a Materia KV or Redis® add-on?',
+      );
+    });
+  });
+
+  describe('Redis errors', () => {
+    it('exits with an error when Redis returns an error reply', async () => {
+      redis.setReply('GET', '-WRONGTYPE Operation against a key holding the wrong kind of value\r\n');
+
+      const result = await withResolvedKvAddon(newScenario())
+        .thenRunCli(['kv', KV_NAME, 'GET', 'aList'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] WRONGTYPE Operation against a key holding the wrong kind of value');
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when /v2/summary returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['kv', KV_NAME, 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+
+    it('reports the error body when the addon env endpoint returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .when({ method: 'GET', path: '/v2/organisations/:ownerId/addons/:addonId/env' })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['kv', KV_NAME, 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when /v2/summary returns 401', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .withExperimentalFeaturesFile(ENABLED_FEATURES)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['kv', KV_NAME, 'PING'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/link/link.command.test.ts
+++ b/src/commands/link/link.command.test.ts
@@ -1,0 +1,157 @@
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { APP_ID, ORGA_ID } from '../../../test/fixtures/id.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const APP = {
+  id: APP_ID,
+  ownerId: SELF.id,
+  name: 'test-app',
+  deployment: {
+    httpUrl: `https://push-n2-par-clevercloud-customers.services.clever-cloud.com/${APP_ID}.git`,
+  },
+};
+
+describe('link command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('links the repository by app ID and writes .clever.json', async () => {
+      const result = await newScenario()
+        .withAppFile('my-app.js', '')
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/applications/:app' })
+        .respond({ status: 200, body: APP })
+        .thenRunCli(['link', APP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.last.pathParams?.app, APP_ID);
+        })
+        .verifyFiles((fsRead) => {
+          assert.deepStrictEqual(fsRead.readAppConfigFile(), {
+            apps: [
+              {
+                app_id: APP_ID,
+                org_id: SELF.id,
+                deploy_url: APP.deployment.httpUrl,
+                name: APP.name,
+                alias: APP.name,
+              },
+            ],
+          });
+        });
+
+      assert.strictEqual(
+        result.stdout,
+        `✓ Application ${APP_ID} has been successfully linked to local alias ${APP.name}!`,
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('links with a custom --alias', async () => {
+      const result = await newScenario()
+        .withAppFile('my-app.js', '')
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/applications/:app' })
+        .respond({ status: 200, body: APP })
+        .thenRunCli(['link', APP_ID, '--alias', 'prod'])
+        .verifyFiles((fsRead) => {
+          assert.strictEqual(fsRead.readAppConfigFile().apps[0].alias, 'prod');
+        });
+
+      assert.strictEqual(result.stdout, `✓ Application ${APP_ID} has been successfully linked to local alias prod!`);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('warns and ignores --org when an app ID is given', async () => {
+      const result = await newScenario()
+        .withAppFile('my-app.js', '')
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/applications/:app' })
+        .respond({ status: 200, body: APP })
+        .thenRunCli(['link', APP_ID, '--org', ORGA_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.last.path, `/v2/self/applications/${APP_ID}`);
+        });
+
+      assert.match(result.stdout, /unique application ID, organisation option will be ignored/);
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when no application argument is given', async () => {
+      const result = await newScenario()
+        .thenRunCli(['link'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^app-id\|app-name: missing value/);
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when GET /v2/self/applications/:app returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withAppFile('my-app.js', '')
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'GET', path: '/v2/self/applications/:app' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['link', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    it('reports the error body when GET /v2/self returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withAppFile('my-app.js', '')
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['link', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when /v2/self returns 401', async () => {
+      const result = await newScenario()
+        .withAppFile('my-app.js', '')
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['link', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/login/login.command.js
+++ b/src/commands/login/login.command.js
@@ -2,7 +2,6 @@ import { get as getUser } from '@clevercloud/client/esm/api/v2/organisation.js';
 import dedent from 'dedent';
 import crypto from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
-import open from 'open';
 import { z } from 'zod';
 import pkg from '../../../package.json' with { type: 'json' };
 import { baseConfig, config, saveProfile } from '../../config/config.js';
@@ -12,6 +11,7 @@ import { formatProfile } from '../../lib/profile.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import { sendToApiWithConfig } from '../../models/send-to-api.js';
+import { openBrowser } from '../../models/utils.js';
 
 function randomToken() {
   return crypto.randomBytes(20).toString('base64').replace(/\//g, '-').replace(/\+/g, '_').replace(/=/g, '');
@@ -55,8 +55,10 @@ async function loginViaConsole(apiHost, consoleTokenUrl) {
   cliPollUrl.searchParams.set('cli_token', cliToken);
 
   Logger.debug('Try to login to Clever Cloud…');
-  Logger.println(`Opening ${styleText('blue', consoleUrl.toString())} in your browser to log you in…`);
-  await open(consoleUrl.toString(), { wait: false });
+  await openBrowser(
+    consoleUrl.toString(),
+    `Opening ${styleText('blue', consoleUrl.toString())} in your browser to log you in…`,
+  );
 
   return pollOauthData(cliPollUrl.toString());
 }

--- a/src/commands/login/login.command.test.ts
+++ b/src/commands/login/login.command.test.ts
@@ -1,0 +1,340 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const OAUTH_RESPONSE = {
+  token: 'oauth-token',
+  secret: 'oauth-secret',
+  expirationDate: '2099-01-01T00:00:00.000Z',
+};
+
+describe('login command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+  let cliVersion: string;
+
+  before(async () => {
+    newScenario = await hooks.before();
+    // CI runs tests against the packaged binary, whose version is `preview-<branch>` rather
+    // than the dev version in package.json. Ask the binary itself so assertions match both.
+    cliVersion = (await newScenario().thenRunCli(['version'])).stdout;
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('skips the browser and saves the profile when --token and --secret are provided', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['login', '--token', 'provided-token', '--secret', 'provided-secret'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/self');
+        })
+        .verifyFiles((fsRead) => {
+          const configFile = fsRead.readConfigFile();
+          assert.strictEqual(configFile.version, 1);
+          assert.strictEqual(configFile.profiles.length, 1);
+          assert.deepStrictEqual(configFile.profiles[0], {
+            alias: 'default',
+            token: 'provided-token',
+            secret: 'provided-secret',
+            userId: SELF.id,
+            email: SELF.email,
+          });
+        });
+
+      assert.strictEqual(result.stdout, `✓ Login successful as default (test.user@example.com)`);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('opens the browser at the Console OAuth URL and saves the profile on successful poll', async () => {
+      let cliToken: string | undefined;
+
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self/cli_tokens' })
+        .respond({ status: 200, body: OAUTH_RESPONSE })
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['login'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/self/cli_tokens');
+          assert.strictEqual(calls.last.path, '/v2/self');
+          cliToken = calls.first.queryParams?.cli_token as string | undefined;
+        })
+        .verifyFiles((fsRead) => {
+          const configFile = fsRead.readConfigFile();
+          assert.deepStrictEqual(configFile.profiles[0], {
+            alias: 'default',
+            token: OAUTH_RESPONSE.token,
+            secret: OAUTH_RESPONSE.secret,
+            expirationDate: OAUTH_RESPONSE.expirationDate,
+            userId: SELF.id,
+            email: SELF.email,
+          });
+        });
+
+      const expectedUrl = `https://console.clever-cloud.com/cli-oauth?cli_version=${cliVersion}&cli_token=${cliToken}`;
+
+      assert.strictEqual(
+        result.stdout,
+        dedent`
+          🌐 Opening ${expectedUrl} in your browser to log you in…
+          ✓ Login successful as default (${SELF.email})
+        `,
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('opens the browser at the overridden Console OAuth URL when --console-url is given', async () => {
+      const consoleUrlOverride = 'https://console.test.example.com';
+
+      let expectedUrl: string | undefined;
+
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self/cli_tokens' })
+        .respond({ status: 200, body: OAUTH_RESPONSE })
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['login', '--console-url', consoleUrlOverride])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          expectedUrl = `${consoleUrlOverride}/cli-oauth?cli_version=${cliVersion}&cli_token=${calls.first.queryParams?.cli_token}`;
+        })
+        .verifyFiles((fsRead) => {
+          assert.deepStrictEqual(fsRead.readConfigFile().profiles[0].overrides, {
+            CONSOLE_URL: consoleUrlOverride,
+          });
+        });
+
+      assert.strictEqual(
+        result.stdout,
+        dedent`
+          🌐 Opening ${expectedUrl} in your browser to log you in…
+          ✓ Login successful as default (${SELF.email})
+        `,
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('saves the profile under the given --alias', async () => {
+      await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['login', '--token', 't', '--secret', 's', '--alias', 'staging'])
+        .verifyFiles((fsRead) => {
+          assert.strictEqual(fsRead.readConfigFile().profiles[0].alias, 'staging');
+        });
+    });
+
+    it('persists every override flag in profile.overrides', async () => {
+      // Skipping --api-host here so /v2/self still hits the mock host injected via env;
+      // the remaining overrides exercise the persistence path on their own.
+      await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli([
+          'login',
+          '--token',
+          't',
+          '--secret',
+          's',
+          '--auth-bridge-host',
+          'https://bridge.example.com',
+          '--ssh-gateway',
+          'gateway.example.com',
+          '--oauth-consumer-key',
+          'k',
+          '--oauth-consumer-secret',
+          'cs',
+        ])
+        .verifyFiles((fsRead) => {
+          assert.deepStrictEqual(fsRead.readConfigFile().profiles[0].overrides, {
+            AUTH_BRIDGE_HOST: 'https://bridge.example.com',
+            SSH_GATEWAY: 'gateway.example.com',
+            OAUTH_CONSUMER_KEY: 'k',
+            OAUTH_CONSUMER_SECRET: 'cs',
+          });
+        });
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when --token is given without --secret', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--token', 'a-token'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Both `--token` and `--secret` must be defined');
+    });
+
+    it('errors when --secret is given without --token', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--secret', 'a-secret'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Both `--token` and `--secret` must be defined');
+    });
+
+    it('rejects "$env" as an --alias (reserved for env-based auth)', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--token', 't', '--secret', 's', '--alias', '$env'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^alias: .+reserved/);
+    });
+
+    it('rejects an --alias with disallowed characters', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--token', 's', '--secret', 's', '--alias', 'has space'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^alias: .+letters, numbers, hyphens and underscores/);
+    });
+
+    // --api-host schema is `z.string().url()`.
+    it('rejects an --api-host that is not a valid URL', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--api-host', 'not-a-url'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^api-host: Invalid URL/);
+    });
+
+    // --console-url schema is `z.string().url()`.
+    it('rejects a --console-url that is not a valid URL', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--console-url', 'not-a-url'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^console-url: Invalid URL/);
+    });
+
+    // --auth-bridge-host schema is `z.string().url()`.
+    it('rejects an --auth-bridge-host that is not a valid URL', async () => {
+      const result = await newScenario()
+        .thenRunCli(['login', '--auth-bridge-host', 'not-a-url'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^auth-bridge-host: Invalid URL/);
+    });
+  });
+
+  describe('existing profile warning', () => {
+    it('warns when a profile with the same alias already exists (old profile config)', async () => {
+      const existingProfile = {
+        alias: 'default',
+        token: 'old-token',
+        secret: 'old-secret',
+        userId: 'user_old',
+        email: 'old.user@example.com',
+      };
+
+      let expectedUrl: string | undefined;
+
+      const result = await newScenario()
+        .withConfigFile(existingProfile)
+        .when({ method: 'GET', path: '/v2/self/cli_tokens' })
+        .respond({ status: 200, body: { token: 'new-token', secret: 'new-secret' } })
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['login'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          expectedUrl = `https://console.clever-cloud.com/cli-oauth?cli_version=${cliVersion}&cli_token=${calls.first.queryParams?.cli_token}`;
+        });
+
+      const expectedStdout = dedent`
+        You are already logged in with profile default; this login may overwrite it.
+        Press Ctrl+C to cancel, then run clever login --alias <another-alias>.
+
+        🌐 Opening ${expectedUrl} in your browser to log you in…
+        ✓ Login successful as default (${SELF.email})
+      `;
+      assert.strictEqual(result.stdout, expectedStdout);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('warns when a profile with the same alias already exists (profile config v1)', async () => {
+      const existingProfile = {
+        version: 1,
+        profiles: [
+          {
+            alias: 'default',
+            token: 'old-token',
+            secret: 'old-secret',
+            userId: 'user_old',
+            email: 'old.user@example.com',
+          },
+        ],
+      };
+
+      let expectedUrl: string | undefined;
+
+      const result = await newScenario()
+        .withConfigFile(existingProfile)
+        .when({ method: 'GET', path: '/v2/self/cli_tokens' })
+        .respond({ status: 200, body: { token: 'new-token', secret: 'new-secret' } })
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['login'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          expectedUrl = `https://console.clever-cloud.com/cli-oauth?cli_version=${cliVersion}&cli_token=${calls.first.queryParams?.cli_token}`;
+        });
+
+      const expectedStdout = dedent`
+        You are already logged in with profile default (old.user@example.com); this login may overwrite it.
+        Press Ctrl+C to cancel, then run clever login --alias <another-alias>.
+
+        🌐 Opening ${expectedUrl} in your browser to log you in…
+        ✓ Login successful as default (${SELF.email})
+      `;
+      assert.strictEqual(result.stdout, expectedStdout);
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('API errors', () => {
+    // `login` is the entry point for authentication, so the unauthenticated case is rendered as
+    // "[ERROR] You're not logged in" here — same as any other command. There is no dedicated
+    // "no auth" describe for this command.
+    it('reports the not-logged-in error when /v2/self returns 401', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['login', '--token', 'bad-token', '--secret', 'bad-secret'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.match(
+        result.stderr,
+        /^\[ERROR\] You're not logged in, use clever login command to connect to your Clever Cloud account/,
+      );
+    });
+  });
+});

--- a/src/commands/logs/logs.command.test.ts
+++ b/src/commands/logs/logs.command.test.ts
@@ -1,0 +1,479 @@
+import type { MockSseEventClose, MockSseEventMessage } from '@clevercloud/doublure';
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { multiAppConfig, singleAppConfig } from '../../../test/fixtures/app-config.ts';
+import { APP_ALIAS_MUTEX_ERROR } from '../../../test/fixtures/errors.ts';
+import { ADDON_ID, APP_ID, ORGA_ID, UUID } from '../../../test/fixtures/id.ts';
+import { idsCache } from '../../../test/fixtures/ids-cache.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const REAL_ADDON_ID = `postgresql_${UUID}`;
+const APP_NAME = 'test-app';
+const ADDON_NAME = 'my-db';
+const UNKNOWN_APP_ID = 'app_99999999-9999-4999-8999-999999999999';
+
+const SUMMARY = {
+  user: { ...SELF, applications: [], addons: [], consumers: [] },
+  organisations: [
+    {
+      id: ORGA_ID,
+      name: 'test-org',
+      applications: [{ id: APP_ID, name: APP_NAME, variantSlug: 'node' }],
+      addons: [{ id: ADDON_ID, realId: REAL_ADDON_ID, name: ADDON_NAME, providerId: 'postgresql-addon' }],
+      consumers: [],
+    },
+  ],
+};
+
+const APP_IDS_CACHE = idsCache({ owners: { [APP_ID]: ORGA_ID } });
+
+const ADDON_IDS_CACHE = idsCache({
+  owners: {
+    [ADDON_ID]: ORGA_ID,
+    [REAL_ADDON_ID]: ORGA_ID,
+  },
+  addons: {
+    [ADDON_ID]: { addonId: ADDON_ID, realId: REAL_ADDON_ID },
+    [REAL_ADDON_ID]: { addonId: ADDON_ID, realId: REAL_ADDON_ID },
+  },
+});
+
+const LOGS_APP_ENDPOINT = '/v4/logs/organisations/:ownerId/applications/:appId/logs';
+const LOGS_ADDON_ENDPOINT = '/v4/logs/organisations/:ownerId/resources/:realAddonId/logs';
+
+const ENDED_BY_LIMIT_EVENT: MockSseEventMessage = {
+  type: 'message',
+  event: 'END_OF_STREAM',
+  data: JSON.stringify({ endedBy: 'limit' }),
+};
+const CLOSE_EVENT: MockSseEventClose = { type: 'close' };
+
+const WAITING_FOR_APP_LOGS = 'Waiting for application logs…';
+const WAITING_FOR_ADDON_LOGS = 'Waiting for addon logs…';
+
+describe('logs command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('streams app log events from the SSE endpoint', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: LOGS_APP_ENDPOINT })
+        .respond({
+          status: 200,
+          events: [
+            {
+              type: 'message',
+              event: 'APPLICATION_LOG',
+              data: JSON.stringify({ id: '1', message: 'log message 1', date: '2026-04-24T10:00:00Z' }),
+            },
+            {
+              type: 'message',
+              event: 'APPLICATION_LOG',
+              data: JSON.stringify({ id: '2', message: 'log message 2', date: '2026-04-24T10:00:01Z' }),
+            },
+            ENDED_BY_LIMIT_EVENT,
+            CLOSE_EVENT,
+          ],
+          delayBetween: 10,
+        })
+        .thenRunCli(['logs'], { stripAnsi: false })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.appId, APP_ID);
+        });
+
+      const reset = '\x1B[0m';
+      assert.strictEqual(
+        result.stdout,
+        dedent`Waiting for application logs…
+        2026-04-24T10:00:00.000Z: log message 1${reset}
+        2026-04-24T10:00:01.000Z: log message 2${reset}`,
+      );
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints only the header when the stream closes with no log events', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: LOGS_APP_ENDPOINT })
+        .respond({ status: 200, events: [ENDED_BY_LIMIT_EVENT, CLOSE_EVENT], delayBetween: 10 })
+        .thenRunCli(['logs'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, 'Waiting for application logs…');
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('linked application resolution', () => {
+    it('errors when not in an app directory and --app is missing', async () => {
+      const result = await newScenario()
+        .thenRunCli(['logs'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] There is no linked or targeted application. Use `--app` option or `clever link` command.',
+      );
+    });
+
+    it('errors when app config has multiple aliases and no --alias is given', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['logs'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Several applications are linked. You can specify one with the "--alias" option. Run "clever applications" to list linked applications. Available aliases: prod, staging',
+      );
+    });
+
+    it('errors when --alias does not match any linked application', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['logs', '--alias', 'unknown'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] There are no applications matching alias unknown');
+    });
+
+    it('errors when both --app and --alias are provided', async () => {
+      const result = await newScenario()
+        .thenRunCli(['logs', '--app', APP_ID, '--alias', 'prod'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, APP_ALIAS_MUTEX_ERROR);
+    });
+  });
+
+  describe('app ID resolution', () => {
+    function withAppLogStream(scenario: ReturnType<NewCliScenario>) {
+      return scenario
+        .when({ method: 'GET', path: LOGS_APP_ENDPOINT })
+        .respond({ status: 200, events: [ENDED_BY_LIMIT_EVENT, CLOSE_EVENT], delayBetween: 10 });
+    }
+
+    // === app ID (app_<UUID>) ===
+
+    it('resolves an app ID from cache without calling /v2/summary', async () => {
+      const result = await withAppLogStream(newScenario().withIdsCacheFile(APP_IDS_CACHE))
+        .thenRunCli(['logs', '--app', APP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_APP_LOGS);
+    });
+
+    it('resolves an app ID via /v2/summary when cache is empty', async () => {
+      const result = await withAppLogStream(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['logs', '--app', APP_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.last.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_APP_LOGS);
+    });
+
+    it('errors when an app ID is not in cache and not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['logs', '--app', UNKNOWN_APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Application not found');
+    });
+
+    it('errors when an app ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['logs', '--app', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === app name — goes directly to /v2/summary (no cache lookup) ===
+
+    it('resolves an app name via /v2/summary', async () => {
+      const result = await withAppLogStream(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['logs', '--app', APP_NAME])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_APP_LOGS);
+    });
+
+    it('errors when an app name is not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['logs', '--app', 'unknown-app'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Application not found');
+    });
+
+    it('errors when /v2/summary returns 404 for an app name', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['logs', '--app', APP_NAME], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+  });
+
+  describe('addon ID resolution', () => {
+    function withAddonLogStream(scenario: ReturnType<NewCliScenario>) {
+      return scenario
+        .when({ method: 'GET', path: LOGS_ADDON_ENDPOINT })
+        .respond({ status: 200, events: [ENDED_BY_LIMIT_EVENT, CLOSE_EVENT], delayBetween: 10 });
+    }
+
+    // === addon ID (addon_<UUID>) ===
+
+    it('resolves an addon ID from cache without calling /v2/summary', async () => {
+      const result = await withAddonLogStream(newScenario().withIdsCacheFile(ADDON_IDS_CACHE))
+        .thenRunCli(['logs', '--addon', ADDON_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.realAddonId, REAL_ADDON_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_ADDON_LOGS);
+    });
+
+    it('resolves an addon ID via /v2/summary when cache is empty', async () => {
+      const result = await withAddonLogStream(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['logs', '--addon', ADDON_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.realAddonId, REAL_ADDON_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_ADDON_LOGS);
+    });
+
+    it('errors when an addon ID is not in cache and not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['logs', '--addon', 'addon_unknown'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Add-on addon_unknown does not exist');
+    });
+
+    it('errors when an addon ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['logs', '--addon', ADDON_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === real ID (postgresql_<UUID>) ===
+
+    it('resolves a real ID from cache without calling /v2/summary', async () => {
+      const result = await withAddonLogStream(newScenario().withIdsCacheFile(ADDON_IDS_CACHE))
+        .thenRunCli(['logs', '--addon', REAL_ADDON_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.realAddonId, REAL_ADDON_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_ADDON_LOGS);
+    });
+
+    it('resolves a real ID via /v2/summary when cache is empty', async () => {
+      const result = await withAddonLogStream(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['logs', '--addon', REAL_ADDON_ID])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.realAddonId, REAL_ADDON_ID);
+        });
+
+      assert.strictEqual(result.stdout, WAITING_FOR_ADDON_LOGS);
+    });
+
+    it('errors when a real ID is not in cache and not in /v2/summary', async () => {
+      const unknownRealId = 'postgresql_99999999-9999-9999-9999-999999999999';
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['logs', '--addon', unknownRealId], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, `[ERROR] Add-on ${unknownRealId} does not exist`);
+    });
+
+    it('errors when a real ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['logs', '--addon', REAL_ADDON_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === addon name — not supported by resolveAddon, always errors ===
+
+    it('errors when an addon name is passed (cache hit by name is not supported)', async () => {
+      const result = await newScenario()
+        .withIdsCacheFile(ADDON_IDS_CACHE)
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['logs', '--addon', ADDON_NAME], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, `[ERROR] Add-on ${ADDON_NAME} does not exist`);
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when --format json is given without a limiting parameter (--until)', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .thenRunCli(['logs', '--format', 'json'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] "json" format is only applicable with a limiting parameter such as `--until`',
+      );
+    });
+
+    // --format schema is `z.enum(['human', 'json', 'json-stream'])`.
+    it('errors when --format is not in the allowed enum', async () => {
+      const result = await newScenario()
+        .thenRunCli(['logs', '--format', 'xml'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^format: Invalid option: expected one of "human"\|"json"\|"json-stream"/);
+    });
+
+    // --before schema is `z.string().transform(date)`; the transform throws on unparseable ISO durations.
+    it('errors when --before is not a valid date or duration', async () => {
+      const result = await newScenario()
+        .thenRunCli(['logs', '--before', 'P_NOT_VALID'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^before: Invalid duration: "P_NOT_VALID"/);
+    });
+
+    // --after schema is `z.string().transform(date)`; same transform as --before.
+    it('errors when --after is not a valid date or duration', async () => {
+      const result = await newScenario()
+        .thenRunCli(['logs', '--after', 'P_NOT_VALID'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^after: Invalid duration: "P_NOT_VALID"/);
+    });
+  });
+
+  describe('no auth', () => {
+    // The SSE path uses its own error renderer and surfaces raw `HTTP error 401: <body>`
+    // rather than the friendly NOT_LOGGED_IN_ERROR message from send-to-api's processError.
+    it('reports an HTTP 401 when the log stream endpoint rejects the request', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: LOGS_APP_ENDPOINT })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['logs'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] HTTP error 401: {"error":"unauthorized"}');
+    });
+  });
+});

--- a/src/commands/notify-email/notify-email.command.test.ts
+++ b/src/commands/notify-email/notify-email.command.test.ts
@@ -1,0 +1,296 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { multiAppConfig, singleAppConfig } from '../../../test/fixtures/app-config.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { APP_ID, ORGA_ID } from '../../../test/fixtures/id.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const EMPTY_EMAIL_HOOKS: Array<any> = [];
+
+// Note: the linked-app fixture sets `org_id` to ORGA_ID and `app_id` to APP_ID; mock hooks below
+// are keyed against ORGA_ID/APP_ID so the scoping logic in the handler matches them.
+const EMAIL_HOOKS = [
+  {
+    id: 'notif_1',
+    name: 'App hook',
+    ownerId: ORGA_ID,
+    scope: [APP_ID],
+    events: ['DEPLOYMENT_SUCCESS', 'DEPLOYMENT_FAIL'],
+    notified: [{ target: 'alice@example.com' }, { target: null }],
+  },
+  {
+    id: 'notif_2',
+    ownerId: ORGA_ID,
+  },
+  {
+    id: 'notif_3',
+    name: 'Other app',
+    ownerId: ORGA_ID,
+    scope: ['app_other'],
+    events: ['DEPLOYMENT_SUCCESS'],
+    notified: [{ target: 'dave@example.com' }],
+  },
+];
+
+const FORMATTED_SCOPED_HOOKS = [
+  {
+    id: 'notif_1',
+    name: 'App hook',
+    ownerId: ORGA_ID,
+    services: [APP_ID],
+    events: ['DEPLOYMENT_SUCCESS', 'DEPLOYMENT_FAIL'],
+    notified: ['alice@example.com', 'whole team'],
+  },
+  {
+    id: 'notif_2',
+    ownerId: ORGA_ID,
+    services: [ORGA_ID],
+    events: ['ALL'],
+    notified: ['whole team'],
+  },
+];
+
+const FORMATTED_ALL_HOOKS = [
+  ...FORMATTED_SCOPED_HOOKS,
+  {
+    id: 'notif_3',
+    name: 'Other app',
+    ownerId: ORGA_ID,
+    services: ['app_other'],
+    events: ['DEPLOYMENT_SUCCESS'],
+    notified: ['dave@example.com'],
+  },
+];
+
+const HUMAN_SCOPED_OUTPUT = dedent`
+  App hook
+    id: notif_1
+    services: ${APP_ID}
+    events: DEPLOYMENT_SUCCESS, DEPLOYMENT_FAIL
+    to:
+      alice@example.com
+      whole team
+  notif_2
+    id: notif_2
+    services: ${ORGA_ID}
+    events: ALL
+    to: whole team
+`;
+
+const HUMAN_ALL_OUTPUT =
+  HUMAN_SCOPED_OUTPUT +
+  '\n' +
+  dedent`
+    Other app
+      id: notif_3
+      services: app_other
+      events: DEPLOYMENT_SUCCESS
+      to: dave@example.com
+  `;
+
+const SUMMARY_FOR_ORG_NAME = {
+  user: { id: SELF.id },
+  organisations: [{ id: ORGA_ID, name: 'my-org' }],
+};
+
+const EMAILHOOKS_ENDPOINT = '/v2/notifications/emailhooks/:ownerId';
+
+describe('notify-email command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('prints scoped hooks for the linked app (default)', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 200, body: EMAIL_HOOKS })
+        .thenRunCli(['notify-email'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+        });
+
+      assert.strictEqual(result.stdout, HUMAN_SCOPED_OUTPUT.trim());
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints an empty string when there are no email hooks', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 200, body: EMPTY_EMAIL_HOOKS })
+        .thenRunCli(['notify-email'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('shows all hooks (across apps) when --list-all is set (uses current user, not linked app)', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: { ...SELF, id: ORGA_ID } })
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 200, body: EMAIL_HOOKS })
+        .thenRunCli(['notify-email', '--list-all'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.last.pathParams?.ownerId, ORGA_ID);
+        });
+
+      assert.strictEqual(result.stdout, HUMAN_ALL_OUTPUT.trim());
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('prints JSON when --format json is given', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 200, body: EMAIL_HOOKS })
+        .thenRunCli(['notify-email', '--format', 'json'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.deepStrictEqual(JSON.parse(result.stdout), FORMATTED_SCOPED_HOOKS);
+    });
+
+    it('prints all hooks as JSON when --list-all --format json are combined', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: { ...SELF, id: ORGA_ID } })
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 200, body: EMAIL_HOOKS })
+        .thenRunCli(['notify-email', '--list-all', '--format', 'json'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.deepStrictEqual(JSON.parse(result.stdout), FORMATTED_ALL_HOOKS);
+    });
+
+    it('resolves owner from --org name via /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY_FOR_ORG_NAME })
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 200, body: EMPTY_EMAIL_HOOKS })
+        .thenRunCli(['notify-email', '--org', 'my-org'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.ownerId, ORGA_ID);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('arguments and options', () => {
+    // --format schema is `z.enum(['human', 'json'])`.
+    it('errors when --format is not in the allowed enum', async () => {
+      const result = await newScenario()
+        .thenRunCli(['notify-email', '--format', 'xml'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^format: Invalid option: expected one of "human"\|"json"/);
+    });
+  });
+
+  describe('linked application resolution', () => {
+    it('errors when not in an app directory and --org/--list-all are not set', async () => {
+      const result = await newScenario()
+        .thenRunCli(['notify-email'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] There is no linked or targeted application. Use `--app` option or `clever link` command.',
+      );
+    });
+
+    it('errors when app config has multiple aliases and no --alias is given', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['notify-email'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Several applications are linked. You can specify one with the "--alias" option. Run "clever applications" to list linked applications. Available aliases: prod, staging',
+      );
+    });
+
+    it('errors when --org does not match any known organisation', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY_FOR_ORG_NAME })
+        .thenRunCli(['notify-email', '--org', 'unknown-org'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] Organisation not found');
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when /v2/notifications/emailhooks/:ownerId returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['notify-email'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when the API returns 401', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: EMAILHOOKS_ENDPOINT })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['notify-email'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/profile/profile.switch.command.test.ts
+++ b/src/commands/profile/profile.switch.command.test.ts
@@ -1,0 +1,173 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { USER_ID } from '../../../test/fixtures/id.ts';
+import { keys } from '../../../test/keys.ts';
+
+const THREE_PROFILES = {
+  version: 1,
+  profiles: [
+    { alias: 'first', token: 't1', secret: 's1', userId: USER_ID, email: 'first@example.com' },
+    { alias: 'second', token: 't2', secret: 's2', userId: USER_ID, email: 'second@example.com' },
+    { alias: 'third', token: 't3', secret: 's3', userId: USER_ID, email: 'third@example.com' },
+  ],
+};
+
+const TWO_PROFILES = {
+  version: 1,
+  profiles: [
+    { alias: 'alpha', token: 't1', secret: 's1', userId: USER_ID, email: 'alpha@example.com' },
+    { alias: 'beta', token: 't2', secret: 's2', userId: USER_ID, email: 'beta@example.com' },
+  ],
+};
+
+const ONE_PROFILE = {
+  version: 1,
+  profiles: [{ alias: 'solo', token: 't', secret: 's', userId: USER_ID, email: 'solo@example.com' }],
+};
+
+describe('profile switch command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('interactive prompt', () => {
+    it('drives the select prompt and switches to the chosen profile (PTY)', async () => {
+      const result = await newScenario()
+        .withConfigFile(THREE_PROFILES)
+        .thenRunCli(['profile', 'switch'], {
+          pty: true,
+          interactions: [{ waitFor: /Select a profile/, send: keys.DOWN + keys.ENTER }],
+        })
+        .verifyFiles((files) => {
+          const after = files.readConfigFile();
+          assert.deepStrictEqual(
+            after.profiles.map((p: { alias: string }) => p.alias),
+            ['second', 'first', 'third'],
+          );
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+
+      assert.match(result.segments[0], /❯ first \(first@example.com\)/);
+      assert.match(result.segments[1], /✔ Select a profile: second \(second@example\.com\)/);
+      assert.match(result.segments[1], /✓ Switched to profile second \(second@example\.com\)/);
+    });
+  });
+
+  describe('non-interactive bypass', () => {
+    it('switches directly when --alias is given (no prompt)', async () => {
+      const result = await newScenario()
+        .withConfigFile(THREE_PROFILES)
+        .thenRunCli(['profile', 'switch', '--alias', 'third'])
+        .verifyFiles((files) => {
+          const after = files.readConfigFile();
+          assert.deepStrictEqual(
+            after.profiles.map((p: { alias: string }) => p.alias),
+            ['third', 'first', 'second'],
+          );
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(result.stdout, '✓ Switched to profile third (third@example.com)');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('accepts -a as an alias for --alias', async () => {
+      const result = await newScenario()
+        .withConfigFile(THREE_PROFILES)
+        .thenRunCli(['profile', 'switch', '-a', 'third'])
+        .verifyFiles((files) => {
+          const after = files.readConfigFile();
+          assert.deepStrictEqual(
+            after.profiles.map((p: { alias: string }) => p.alias),
+            ['third', 'first', 'second'],
+          );
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(result.stdout, '✓ Switched to profile third (third@example.com)');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('skips the prompt and auto-switches when there are exactly two profiles', async () => {
+      const result = await newScenario()
+        .withConfigFile(TWO_PROFILES)
+        .thenRunCli(['profile', 'switch'])
+        .verifyFiles((files) => {
+          const after = files.readConfigFile();
+          assert.deepStrictEqual(
+            after.profiles.map((p: { alias: string }) => p.alias),
+            ['beta', 'alpha'],
+          );
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(
+        result.stdout,
+        dedent`
+          i Switching to beta (beta@example.com)
+          ✓ Switched to profile beta (beta@example.com)
+        `,
+      );
+    });
+
+    it('reports already-active when --alias matches the current profile', async () => {
+      const result = await newScenario()
+        .withConfigFile(THREE_PROFILES)
+        .thenRunCli(['profile', 'switch', '--alias', 'first']);
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(result.stdout, 'i Already on profile first (first@example.com)');
+    });
+  });
+
+  describe('profile resolution errors', () => {
+    it('errors when --alias does not match any profile', async () => {
+      const result = await newScenario()
+        .withConfigFile(THREE_PROFILES)
+        .thenRunCli(['profile', 'switch', '--alias', 'unknown'], { expectExitCode: 1 });
+
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Profile "unknown" not found. Available profiles: first, second, third',
+      );
+    });
+  });
+
+  describe('no auth', () => {
+    it('errors when no profile is configured', async () => {
+      const result = await newScenario().thenRunCli(['profile', 'switch'], { expectExitCode: 1 });
+
+      assert.strictEqual(result.stderr, '[ERROR] No profile found.');
+    });
+
+    it('errors when only a single profile is configured', async () => {
+      const result = await newScenario()
+        .withConfigFile(ONE_PROFILE)
+        .thenRunCli(['profile', 'switch'], { expectExitCode: 1 });
+
+      assert.strictEqual(result.stderr, '[ERROR] Only one profile. Use clever login --alias <name> to add another.');
+    });
+
+    it('errors when CLEVER_TOKEN/CLEVER_SECRET env-based auth is in use', async () => {
+      const result = await newScenario()
+        .withConfigFile(TWO_PROFILES)
+        .thenRunCli(['profile', 'switch'], {
+          env: { CLEVER_TOKEN: 'env-token', CLEVER_SECRET: 'env-secret' },
+          expectExitCode: 1,
+        });
+
+      assert.match(result.stderr, /Cannot switch profiles while using environment-based authentication/);
+    });
+  });
+});

--- a/src/commands/ssh-keys/ssh-keys.add.command.js
+++ b/src/commands/ssh-keys/ssh-keys.add.command.js
@@ -30,7 +30,6 @@ export const sshKeysAddCommand = defineCommand({
     try {
       await addSshKey({ key: encodeURIComponent(keyName) }, JSON.stringify(pubKeyContent)).then(sendToApi);
     } catch (e) {
-      console.log(e?.responseBody?.id);
       if (e?.responseBody?.id === 505) {
         throw new Error("This SSH key is not valid, please make sure you're pointing to the public key file");
       }

--- a/src/commands/ssh-keys/ssh-keys.add.command.js
+++ b/src/commands/ssh-keys/ssh-keys.add.command.js
@@ -29,12 +29,12 @@ export const sshKeysAddCommand = defineCommand({
 
     try {
       await addSshKey({ key: encodeURIComponent(keyName) }, JSON.stringify(pubKeyContent)).then(sendToApi);
+      Logger.printSuccess(`SSH key ${keyName} added successfully`);
     } catch (e) {
       if (e?.responseBody?.id === 505) {
         throw new Error("This SSH key is not valid, please make sure you're pointing to the public key file");
       }
+      throw e;
     }
-
-    Logger.printSuccess(`SSH key ${keyName} added successfully`);
   },
 });

--- a/src/commands/ssh-keys/ssh-keys.add.command.test.ts
+++ b/src/commands/ssh-keys/ssh-keys.add.command.test.ts
@@ -1,0 +1,124 @@
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+
+const PUB_KEY_CONTENT = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyContent test@example.com';
+
+describe('ssh-keys add command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('adds an SSH key from a public key file', async () => {
+      const result = await newScenario()
+        .withAppFile('id_ed25519.pub', `${PUB_KEY_CONTENT}\n`)
+        .when({ method: 'PUT', path: '/v2/self/keys/:key' })
+        .respond({ status: 200, body: {} })
+        .thenRunCli(['ssh-keys', 'add', 'my-key', 'id_ed25519.pub'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.method, 'PUT');
+          assert.strictEqual(calls.first.pathParams?.key, 'my-key');
+          assert.strictEqual(calls.first.body, PUB_KEY_CONTENT);
+        });
+
+      assert.strictEqual(result.stdout, '✓ SSH key my-key added successfully');
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('URL-encodes key names with special characters', async () => {
+      const result = await newScenario()
+        .withAppFile('id_ed25519.pub', PUB_KEY_CONTENT)
+        .when({ method: 'PUT', path: '/v2/self/keys/:key' })
+        .respond({ status: 200, body: {} })
+        .thenRunCli(['ssh-keys', 'add', 'my key/with special', 'id_ed25519.pub'])
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.key, 'my key/with special');
+        });
+
+      assert.strictEqual(result.stdout, '✓ SSH key my key/with special added successfully');
+      assert.strictEqual(result.stderr, '');
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when the key name argument is missing', async () => {
+      const result = await newScenario()
+        .thenRunCli(['ssh-keys', 'add'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^ssh-key-name: missing value/);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('errors when the SSH key file path argument is missing', async () => {
+      const result = await newScenario()
+        .thenRunCli(['ssh-keys', 'add', 'my-key'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /ssh-key-path: missing value/);
+      assert.strictEqual(result.stderr, '');
+    });
+
+    it('errors when the public key file does not exist', async () => {
+      const result = await newScenario()
+        .withAppFile('placeholder.txt', 'placeholder')
+        .thenRunCli(['ssh-keys', 'add', 'my-key', 'missing.pub'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] File missing.pub does not exist');
+    });
+  });
+
+  describe('API errors on PUT /v2/self/keys/:key', () => {
+    it('reports a clear error for id=505 (invalid SSH key)', async () => {
+      const result = await newScenario()
+        .withAppFile('id_ed25519.pub', 'not a real ssh key')
+        .when({ method: 'PUT', path: '/v2/self/keys/:key' })
+        .respond({ status: 400, body: { id: 505 } })
+        .thenRunCli(['ssh-keys', 'add', 'my-key', 'id_ed25519.pub'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(
+        result.stderr,
+        "[ERROR] This SSH key is not valid, please make sure you're pointing to the public key file",
+      );
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when the API returns 401', async () => {
+      const result = await newScenario()
+        .withAppFile('id_ed25519.pub', PUB_KEY_CONTENT)
+        .when({ method: 'PUT', path: '/v2/self/keys/:key' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['ssh-keys', 'add', 'my-key', 'id_ed25519.pub'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -91,32 +91,45 @@ export const sshCommand = defineCommand({
     sshProcess.stdin.write(`exec $SHELL --login -c '${escapedCommand}'\n`);
     sshProcess.stdin.end();
 
-    // Skip gateway/login noise on both stdout and stderr, stream after the marker
+    // Skip gateway/login noise on both stdout and stderr, stream after the marker.
+    // If ssh never reaches the marker (auth failure, connection refused, bad key
+    // permissions, …) we flush the buffered pre-marker bytes on non-zero exit so
+    // the user actually sees the error instead of getting silent exit-255.
     let started = false;
-    let buf = '';
+    let stdoutBuf = '';
+    let stderrBuf = '';
     sshProcess.stdout.on('data', (chunk) => {
       if (started) {
         process.stdout.write(chunk);
         return;
       }
-      buf += chunk.toString();
-      const idx = buf.indexOf(marker + '\n');
+      stdoutBuf += chunk.toString();
+      const idx = stdoutBuf.indexOf(marker + '\n');
       if (idx !== -1) {
         started = true;
-        const rest = buf.slice(idx + marker.length + 1);
+        const rest = stdoutBuf.slice(idx + marker.length + 1);
         if (rest) process.stdout.write(rest);
-        buf = '';
+        stdoutBuf = '';
       }
     });
 
-    // Discard stderr noise before the marker, forward after
     sshProcess.stderr.on('data', (chunk) => {
       if (started) {
         process.stderr.write(chunk);
+      } else {
+        stderrBuf += chunk.toString();
       }
     });
 
     const exitCode = await new Promise((resolve) => sshProcess.on('exit', resolve));
+    if (exitCode !== 0 && !started) {
+      if (stdoutBuf) {
+        process.stdout.write(stdoutBuf);
+      }
+      if (stderrBuf) {
+        process.stderr.write(stderrBuf);
+      }
+    }
     process.exit(exitCode);
   },
 });

--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -1,6 +1,5 @@
 import { getAllInstances } from '@clevercloud/client/esm/api/v2/application.js';
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { config } from '../../config/config.js';
 import { defineCommand } from '../../lib/define-command.js';
@@ -8,6 +7,7 @@ import { defineOption } from '../../lib/define-option.js';
 import { selectAnswer } from '../../lib/prompts.js';
 import * as Application from '../../models/application.js';
 import { sendToApi } from '../../models/send-to-api.js';
+import { runMarkerProtocol } from '../../models/ssh-marker-protocol.js';
 import { aliasOption, appIdOrNameOption } from '../global.options.js';
 
 export const sshCommand = defineCommand({
@@ -78,58 +78,7 @@ export const sshCommand = defineCommand({
 
     // Single command mode (pipe stdio to filter gateway noise via a marker)
     const sshProcess = spawn('ssh', sshParams, { stdio: 'pipe' });
-
-    // We can't pass the command directly via `ssh gateway 'cmd'` because appId already occupies
-    // the remote command slot (used by the gateway for routing). So we write into stdin and use
-    // a marker to delimit the start of real output from gateway/login noise.
-    const marker = `__CLEVER_${randomUUID()}__`;
-    sshProcess.stdin.write(`echo '${marker}'\n`);
-
-    // `exec $SHELL --login -c` ensures the full login environment is loaded (.bashrc, env vars)
-    // while keeping stdout clean (no PTY = no prompt/ANSI noise).
-    const escapedCommand = command.replaceAll("'", "'\\''");
-    sshProcess.stdin.write(`exec $SHELL --login -c '${escapedCommand}'\n`);
-    sshProcess.stdin.end();
-
-    // Skip gateway/login noise on both stdout and stderr, stream after the marker.
-    // If ssh never reaches the marker (auth failure, connection refused, bad key
-    // permissions, …) we flush the buffered pre-marker bytes on non-zero exit so
-    // the user actually sees the error instead of getting silent exit-255.
-    let started = false;
-    let stdoutBuf = '';
-    let stderrBuf = '';
-    sshProcess.stdout.on('data', (chunk) => {
-      if (started) {
-        process.stdout.write(chunk);
-        return;
-      }
-      stdoutBuf += chunk.toString();
-      const idx = stdoutBuf.indexOf(marker + '\n');
-      if (idx !== -1) {
-        started = true;
-        const rest = stdoutBuf.slice(idx + marker.length + 1);
-        if (rest) process.stdout.write(rest);
-        stdoutBuf = '';
-      }
-    });
-
-    sshProcess.stderr.on('data', (chunk) => {
-      if (started) {
-        process.stderr.write(chunk);
-      } else {
-        stderrBuf += chunk.toString();
-      }
-    });
-
-    const exitCode = await new Promise((resolve) => sshProcess.on('exit', resolve));
-    if (exitCode !== 0 && !started) {
-      if (stdoutBuf) {
-        process.stdout.write(stdoutBuf);
-      }
-      if (stderrBuf) {
-        process.stderr.write(stderrBuf);
-      }
-    }
+    const exitCode = await runMarkerProtocol({ child: sshProcess, command });
     process.exit(exitCode);
   },
 });

--- a/src/commands/ssh/ssh.command.test.ts
+++ b/src/commands/ssh/ssh.command.test.ts
@@ -1,0 +1,314 @@
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { multiAppConfig, singleAppConfig } from '../../../test/fixtures/app-config.ts';
+import { APP_ALIAS_MUTEX_ERROR, NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { APP_ID, ORGA_ID } from '../../../test/fixtures/id.ts';
+import { idsCache } from '../../../test/fixtures/ids-cache.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+import { keys } from '../../../test/keys.ts';
+
+const INSTANCES_ENDPOINT = '/v2/organisations/:ownerId/applications/:appId/instances';
+
+const APP_NAME = 'test-app';
+const UNKNOWN_APP_ID = 'app_99999999-9999-4999-8999-999999999999';
+
+const SUMMARY = {
+  user: { ...SELF, applications: [], addons: [], consumers: [] },
+  organisations: [
+    {
+      id: ORGA_ID,
+      name: 'test-org',
+      applications: [{ id: APP_ID, name: APP_NAME, variantSlug: 'node' }],
+      addons: [],
+      consumers: [],
+    },
+  ],
+};
+
+const APP_IDS_CACHE = idsCache({ owners: { [APP_ID]: ORGA_ID } });
+
+const NO_INSTANCES_ERROR = '[ERROR] No running instances found for this application';
+
+describe('ssh command', () => {
+  // Note: the marker-protocol / stdin-escape / streaming behaviour of `clever ssh --command`
+  // is covered in ssh.marker-protocol.test.ts as in-process unit tests. The tests in this file
+  // exercise the command's pre-spawn path: app resolution, instance picking, error handling.
+
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+
+  before(async () => {
+    newScenario = await hooks.before();
+  });
+
+  beforeEach(async () => {
+    await hooks.beforeEach();
+  });
+
+  after(async () => {
+    await hooks.after();
+  });
+
+  describe('linked application resolution', () => {
+    it('errors when not in an app directory and --app is missing', async () => {
+      const result = await newScenario()
+        .thenRunCli(['ssh'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] There is no linked or targeted application. Use `--app` option or `clever link` command.',
+      );
+    });
+
+    it('errors when app config has multiple aliases and no --alias is given', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['ssh'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Several applications are linked. You can specify one with the "--alias" option. Run "clever applications" to list linked applications. Available aliases: prod, staging',
+      );
+    });
+
+    it('errors when --alias does not match any linked application', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(multiAppConfig())
+        .thenRunCli(['ssh', '--alias', 'unknown'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] There are no applications matching alias unknown');
+    });
+
+    it('errors when both --app and --alias are provided', async () => {
+      const result = await newScenario()
+        .thenRunCli(['ssh', '--app', APP_ID, '--alias', 'test-app'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, APP_ALIAS_MUTEX_ERROR);
+    });
+  });
+
+  describe('app ID resolution', () => {
+    function withEmptyInstances(scenario: ReturnType<NewCliScenario>) {
+      return scenario.when({ method: 'GET', path: INSTANCES_ENDPOINT }).respond({ status: 200, body: [] });
+    }
+
+    // === app ID (app_<UUID>) ===
+
+    it('resolves an app ID from cache without calling /v2/summary', async () => {
+      const result = await withEmptyInstances(newScenario().withIdsCacheFile(APP_IDS_CACHE))
+        .thenRunCli(['ssh', '--app', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stderr, NO_INSTANCES_ERROR);
+    });
+
+    it('resolves an app ID via /v2/summary when cache is empty', async () => {
+      const result = await withEmptyInstances(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['ssh', '--app', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.last.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stderr, NO_INSTANCES_ERROR);
+    });
+
+    it('errors when an app ID is not in cache and not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['ssh', '--app', UNKNOWN_APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Application not found');
+    });
+
+    it('errors when an app ID is not in cache and /v2/summary returns 404', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['ssh', '--app', APP_ID], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+
+    // === app name — goes directly to /v2/summary (no cache lookup) ===
+
+    it('resolves an app name via /v2/summary', async () => {
+      const result = await withEmptyInstances(
+        newScenario().when({ method: 'GET', path: '/v2/summary' }).respond({ status: 200, body: SUMMARY }),
+      )
+        .thenRunCli(['ssh', '--app', APP_NAME], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+          assert.strictEqual(calls.last.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stderr, NO_INSTANCES_ERROR);
+    });
+
+    it('errors when an app name is not in /v2/summary', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 200, body: SUMMARY })
+        .thenRunCli(['ssh', '--app', 'unknown-app'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Application not found');
+    });
+
+    it('errors when /v2/summary returns 404 for an app name', async () => {
+      const result = await newScenario()
+        .when({ method: 'GET', path: '/v2/summary' })
+        .respond({ status: 404, body: { error: 'not found' } })
+        .thenRunCli(['ssh', '--app', APP_NAME], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/summary');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] not found');
+    });
+  });
+
+  describe('instance selection', () => {
+    it('errors when the application has no running instances', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: INSTANCES_ENDPOINT })
+        .respond({ status: 200, body: [] })
+        .thenRunCli(['ssh'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.pathParams?.ownerId, ORGA_ID);
+          assert.strictEqual(calls.first.pathParams?.appId, APP_ID);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] No running instances found for this application');
+    });
+
+    it('errors when multiple instances are running and stdout is not a TTY', async () => {
+      const instances = [
+        { id: 'instance_1', displayName: 'Instance one', instanceNumber: 0, state: 'UP' },
+        { id: 'instance_2', displayName: 'Instance two', instanceNumber: 1, state: 'UP' },
+      ];
+
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: INSTANCES_ENDPOINT })
+        .respond({ status: 200, body: instances })
+        .thenRunCli(['ssh'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(
+        result.stderr,
+        '[ERROR] Multiple instances are running. Cannot select in non-interactive mode.',
+      );
+    });
+
+    it('drives the select prompt and picks an instance when multiple are running (PTY)', async () => {
+      // Pass instances out of order to also verify the sort-by-instanceNumber.
+      const instances = [
+        { id: 'instance_2', displayName: 'Instance two', instanceNumber: 2, state: 'UP' },
+        { id: 'instance_0', displayName: 'Instance zero', instanceNumber: 0, state: 'UP' },
+        { id: 'instance_1', displayName: 'Instance one', instanceNumber: 1, state: 'UP' },
+      ];
+
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: INSTANCES_ENDPOINT })
+        .respond({ status: 200, body: instances })
+        .thenRunCli(['ssh'], {
+          pty: true,
+          interactions: [{ waitFor: /Select an instance/, send: keys.DOWN + keys.ENTER }],
+          // Point ssh at an unresolvable host so it fails fast instead of dialing the real gateway.
+          env: { SSH_GATEWAY: 'ssh@unreachable.invalid' },
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      // segments[0]: choices appear sorted by instanceNumber, cursor on the first.
+      assert.match(
+        result.segments[0],
+        /Select an instance:[\s\S]*❯ Instance zero - Instance 0 - UP \(instance_0\)[\s\S]*Instance one - Instance 1 - UP \(instance_1\)[\s\S]*Instance two - Instance 2 - UP \(instance_2\)/,
+      );
+
+      // segments[1]: after DOWN + ENTER, the confirmation line shows the chosen value.
+      assert.match(result.segments[1], /✔ Select an instance: Instance one - Instance 1 - UP \(instance_1\)/);
+    });
+  });
+
+  describe('API errors', () => {
+    it('reports the error body when the instances endpoint returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: INSTANCES_ENDPOINT })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['ssh'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when the instances endpoint returns 401', async () => {
+      const result = await newScenario()
+        .withAppConfigFile(singleAppConfig())
+        .when({ method: 'GET', path: INSTANCES_ENDPOINT })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['ssh'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stdout, '');
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/commands/tokens/tokens.create.command.js
+++ b/src/commands/tokens/tokens.create.command.js
@@ -72,7 +72,7 @@ export const tokensCreateCommand = defineCommand({
     const createdToken = await createApiToken(tokenData)
       .then(sendToAuthBridge)
       .catch((error) => {
-        const errorCode = error?.cause?.responseBody?.code;
+        const errorCode = error?.responseBody?.code;
         if (errorCode === 'invalid-credential') {
           throw new Error('Invalid credentials, check your password');
         }

--- a/src/commands/tokens/tokens.create.command.test.ts
+++ b/src/commands/tokens/tokens.create.command.test.ts
@@ -1,0 +1,334 @@
+import dedent from 'dedent';
+import * as assert from 'node:assert';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import type { NewCliScenario } from '../../../test/cli-hooks.ts';
+import { cliHooks } from '../../../test/cli-hooks.ts';
+import { NOT_LOGGED_IN_ERROR } from '../../../test/fixtures/errors.ts';
+import { profileConfig } from '../../../test/fixtures/profile.ts';
+import { SELF } from '../../../test/fixtures/self.ts';
+
+const PROFILE = profileConfig();
+
+const CREATED_TOKEN = {
+  apiTokenId: 'tk_00000000-0000-0000-0000-000000000001',
+  apiToken: 'cct_v1.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  expirationDate: '2026-10-01T00:00:00.000Z',
+};
+
+describe('tokens create command', () => {
+  const hooks = cliHooks();
+  let newScenario: NewCliScenario;
+  let mockHost: string;
+
+  before(async () => {
+    newScenario = await hooks.before();
+    mockHost = newScenario.mockClient.baseUrl;
+  });
+
+  beforeEach(hooks.beforeEach);
+
+  after(hooks.after);
+
+  describe('happy path', () => {
+    it('prompts for password and 2FA then creates the token (TOTP user)', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 200, body: CREATED_TOKEN })
+        .thenRunCli(['tokens', 'create', 'my-token', '--expiration', '2026-10-01'], {
+          interactions: [
+            { waitFor: /Enter your password/, send: 'hunter2\n' },
+            { waitFor: /Enter your 2FA code/, send: '123456\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.strictEqual(calls.first.path, '/v2/self');
+          assert.strictEqual(calls.last.method, 'POST');
+          assert.strictEqual(calls.last.path, '/api-tokens');
+          assert.deepStrictEqual(calls.last.body, {
+            email: SELF.email,
+            password: 'hunter2',
+            mfaCode: '123456',
+            name: 'my-token',
+            description: '',
+            expirationDate: '2026-10-01T00:00:00.000Z',
+          });
+        });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(
+        result.stdout,
+        dedent`
+          ✔ API token successfully created! Store it securely, you won't able to print it again.
+
+            - API token ID : ${CREATED_TOKEN.apiTokenId}
+            - API token    : ${CREATED_TOKEN.apiToken}
+            - Expiration   : 2026-10-01 00:00
+
+          Export this token and use it to make authenticated requests to the Clever Cloud API through the Auth Bridge:
+
+          export CC_API_TOKEN=${CREATED_TOKEN.apiToken}
+          curl -H "Authorization: Bearer $CC_API_TOKEN" ${mockHost}/v2/self
+
+          Then, to revoke this token, run:
+          clever tokens revoke ${CREATED_TOKEN.apiTokenId}
+        `,
+      );
+    });
+
+    it('prompts only for password when the user has no TOTP', async () => {
+      await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: { ...SELF, preferredMFA: 'NONE' } })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 200, body: CREATED_TOKEN })
+        .thenRunCli(['tokens', 'create', 'no-totp', '--expiration', '2026-10-01'], {
+          interactions: [{ waitFor: /Enter your password/, send: 'hunter2\n' }],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          assert.deepStrictEqual(calls.last.body, {
+            email: SELF.email,
+            password: 'hunter2',
+            name: 'no-totp',
+            description: '',
+            expirationDate: '2026-10-01T00:00:00.000Z',
+          });
+        });
+    });
+
+    it('prints JSON when --format json is given', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 200, body: CREATED_TOKEN })
+        .thenRunCli(['tokens', 'create', 'json-token', '--expiration', '2026-10-01', '--format', 'json'], {
+          interactions: [
+            { waitFor: /Enter your password/, send: 'hunter2\n' },
+            { waitFor: /Enter your 2FA code/, send: '123456\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.deepStrictEqual(JSON.parse(result.stdout), CREATED_TOKEN);
+    });
+
+    it('accepts -e as an alias for --expiration', async () => {
+      await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 200, body: CREATED_TOKEN })
+        .thenRunCli(['tokens', 'create', 'short-alias', '-e', '2026-10-01'], {
+          interactions: [
+            { waitFor: /Enter your password/, send: 'hunter2\n' },
+            { waitFor: /Enter your 2FA code/, send: '123456\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          const body = calls.last.body as { expirationDate: string };
+          assert.strictEqual(body.expirationDate, '2026-10-01T00:00:00.000Z');
+        });
+    });
+
+    it('accepts a duration (e.g. 1h) as --expiration', async () => {
+      await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 200, body: CREATED_TOKEN })
+        .thenRunCli(['tokens', 'create', 'duration-token', '--expiration', '1h'], {
+          interactions: [
+            { waitFor: /Enter your password/, send: 'hunter2\n' },
+            { waitFor: /Enter your 2FA code/, send: '123456\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          // The expiration date is "now + 1h"; we only check the shape (ISO 8601), not the value.
+          const body = calls.last.body as { expirationDate: string };
+          assert.match(body.expirationDate, /^\d{4}-\d{2}-\d{2}T/);
+        });
+    });
+
+    it('uses the default 1-year expiration when --expiration is omitted', async () => {
+      await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 200, body: CREATED_TOKEN })
+        .thenRunCli(['tokens', 'create', 'default-expiry'], {
+          interactions: [
+            { waitFor: /Enter your password/, send: 'hunter2\n' },
+            { waitFor: /Enter your 2FA code/, send: '123456\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+          const body = calls.last.body as { expirationDate: string };
+          assert.match(body.expirationDate, /^\d{4}-\d{2}-\d{2}T/);
+        });
+    });
+  });
+
+  describe('arguments and options', () => {
+    it('errors when the api-token-name argument is missing', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .thenRunCli(['tokens', 'create'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^api-token-name: missing value/);
+    });
+
+    // --expiration schema is `z.string().default('1y').transform(futureDateOrDuration)` — the
+    // transform throws when fed an ISO 8601 duration prefix it can't parse.
+    it('errors when --expiration is not a valid duration', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .thenRunCli(['tokens', 'create', 'foo', '--expiration', 'P_NOT_VALID'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^expiration: Invalid duration: "P_NOT_VALID"/);
+    });
+
+    // --format schema is `z.enum(['human', 'json'])`.
+    it('errors when --format is not in the allowed enum', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .thenRunCli(['tokens', 'create', 'foo', '--format', 'xml'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 0);
+        });
+
+      assert.match(result.stdout, /^format: Invalid option: expected one of "human"\|"json"/);
+    });
+  });
+
+  describe('preflight checks', () => {
+    it('errors when the account has no password (GitHub-only)', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: { ...SELF, hasPassword: false } })
+        .thenRunCli(['tokens', 'create', 'no-pw'], { expectExitCode: 1 })
+        .verify((calls) => {
+          // Only /v2/self should be called — no POST to /api-tokens.
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/self');
+        });
+
+      assert.strictEqual(
+        result.stderr,
+        dedent`
+          [ERROR] ! Your Clever Cloud account is linked via GitHub and has no password. Setting one is required to create API tokens.
+                  → To do so, go to the following URL: https://console.clever-cloud.com/users/me/api-tokens
+        `,
+      );
+    });
+
+    it('errors when --expiration is more than 1 year in the future', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .thenRunCli(['tokens', 'create', 'too-far', '--expiration', '2099-01-01'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+          assert.strictEqual(calls.first.path, '/v2/self');
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] You cannot set an expiration date greater than 1 year');
+    });
+  });
+
+  describe('API errors on POST /api-tokens', () => {
+    it('reports a clear error for code=invalid-credential', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 400, body: { code: 'invalid-credential' } })
+        .thenRunCli(['tokens', 'create', 'bad-pw', '--expiration', '2026-10-01'], {
+          expectExitCode: 1,
+          interactions: [
+            { waitFor: /Enter your password/, send: 'wrong\n' },
+            { waitFor: /Enter your 2FA code/, send: '000000\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Invalid credentials, check your password');
+    });
+
+    it('reports a clear error for code=invalid-mfa-code', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 200, body: SELF })
+        .when({ method: 'POST', path: '/api-tokens' })
+        .respond({ status: 400, body: { code: 'invalid-mfa-code' } })
+        .thenRunCli(['tokens', 'create', 'bad-2fa', '--expiration', '2026-10-01'], {
+          expectExitCode: 1,
+          interactions: [
+            { waitFor: /Enter your password/, send: 'hunter2\n' },
+            { waitFor: /Enter your 2FA code/, send: '999999\n' },
+          ],
+        })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 2);
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] Invalid credentials, check your 2FA code');
+    });
+  });
+
+  describe('API errors on GET /v2/self', () => {
+    it('reports the error body when /v2/self returns a non-2xx status', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 500, body: { error: 'oops' } })
+        .thenRunCli(['tokens', 'create', 'failing'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stderr, '[ERROR] oops');
+    });
+  });
+
+  describe('no auth', () => {
+    it('shows the not-logged-in error when /v2/self returns 401', async () => {
+      const result = await newScenario()
+        .withConfigFile(PROFILE)
+        .when({ method: 'GET', path: '/v2/self' })
+        .respond({ status: 401, body: { error: 'unauthorized' } })
+        .thenRunCli(['tokens', 'create', 'unauthorized'], { expectExitCode: 1 })
+        .verify((calls) => {
+          assert.strictEqual(calls.count, 1);
+        });
+
+      assert.strictEqual(result.stderr, NOT_LOGGED_IN_ERROR);
+    });
+  });
+});

--- a/src/config/cache.js
+++ b/src/config/cache.js
@@ -1,9 +1,7 @@
 import { z } from 'zod';
 import { readJson, writeJson } from '../lib/fs.js';
 import { Logger } from '../logger.js';
-import { getConfigPath } from './paths.js';
-
-const IDS_CACHE_FILEPATH = getConfigPath('ids-cache.json');
+import { baseConfig } from './config.js';
 
 const IdsCacheSchema = z.object({
   owners: z.record(z.string(), z.string()),
@@ -29,17 +27,18 @@ const EMPTY_CACHE = { owners: {}, addons: {} };
  * @returns {Promise<IdsCache>} The cached IDs or empty cache structure
  */
 export async function loadIdsCache() {
-  Logger.debug(`Get cache ID from ${IDS_CACHE_FILEPATH}`);
+  const filePath = baseConfig.IDS_CACHE_FILE;
+  Logger.debug(`Get cache ID from ${filePath}`);
   try {
-    const rawIdsCache = await readJson(IDS_CACHE_FILEPATH);
+    const rawIdsCache = await readJson(filePath);
     const parsed = IdsCacheSchema.safeParse(rawIdsCache);
     if (!parsed.success) {
-      Logger.info(`Invalid IDs cache format in ${IDS_CACHE_FILEPATH}`);
+      Logger.info(`Invalid IDs cache format in ${filePath}`);
       return EMPTY_CACHE;
     }
     return parsed.data;
   } catch (error) {
-    Logger.info(`Cannot load IDs cache from ${IDS_CACHE_FILEPATH}`);
+    Logger.info(`Cannot load IDs cache from ${filePath}`);
     return EMPTY_CACHE;
   }
 }
@@ -52,9 +51,10 @@ export async function loadIdsCache() {
  * @throws {Error} If the cache file cannot be written
  */
 export async function writeIdsCache(ids) {
+  const filePath = baseConfig.IDS_CACHE_FILE;
   try {
-    await writeJson(IDS_CACHE_FILEPATH, ids, { mode: 0o700 });
+    await writeJson(filePath, ids, { mode: 0o700 });
   } catch (error) {
-    throw new Error(`Cannot write IDs cache to ${IDS_CACHE_FILEPATH}\n${error.message}`);
+    throw new Error(`Cannot write IDs cache to ${filePath}\n${error.message}`);
   }
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -42,8 +42,9 @@ const ConfigFileSchema = z.object({
 
 const ConfigSchema = z
   .object({
-    CONFIGURATION_FILE: z.string().default(getConfigPath('clever-tools.json')),
-    EXPERIMENTAL_FEATURES_FILE: z.string().default(getConfigPath('clever-tools-experimental-features.json')),
+    CONFIGURATION_FILE: z.string().default(() => getConfigPath('clever-tools.json')),
+    EXPERIMENTAL_FEATURES_FILE: z.string().default(() => getConfigPath('clever-tools-experimental-features.json')),
+    IDS_CACHE_FILE: z.string().default(() => getConfigPath('ids-cache.json')),
     APP_CONFIGURATION_FILE: z.string().default(() => path.resolve('.', '.clever.json')),
 
     API_HOST: z.url().default('https://api.clever-cloud.com'),

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -3,9 +3,6 @@ import z from 'zod';
 import { readJson, writeJson } from '../lib/fs.js';
 import { Logger } from '../logger.js';
 import { config } from './config.js';
-import { getConfigPath } from './paths.js';
-
-const EXPERIMENTAL_FEATURES_FILEPATH = getConfigPath('clever-tools-experimental-features.json');
 
 export const EXPERIMENTAL_FEATURES = {
   'system-git': {
@@ -121,18 +118,19 @@ const FeaturesConfigSchema = z
  * @returns {Promise<FeaturesConfig>} The features configuration object
  */
 export async function getFeatures() {
-  Logger.debug(`Get features configuration from ${EXPERIMENTAL_FEATURES_FILEPATH}`);
+  const filePath = config.EXPERIMENTAL_FEATURES_FILE;
+  Logger.debug(`Get features configuration from ${filePath}`);
   try {
-    const rawFeatures = await readJson(EXPERIMENTAL_FEATURES_FILEPATH);
+    const rawFeatures = await readJson(filePath);
     const parsed = FeaturesConfigSchema.safeParse(rawFeatures);
     if (!parsed.success) {
-      Logger.info(`Invalid features format in ${EXPERIMENTAL_FEATURES_FILEPATH}`);
+      Logger.info(`Invalid features format in ${filePath}`);
       return {};
     }
     return parsed.data;
   } catch (error) {
     if (error.code !== 'ENOENT') {
-      throw new Error(`Cannot get experimental features configuration from ${EXPERIMENTAL_FEATURES_FILEPATH}`);
+      throw new Error(`Cannot get experimental features configuration from ${filePath}`);
     }
     return {};
   }
@@ -147,12 +145,13 @@ export async function getFeatures() {
  * @throws {Error} If the features file cannot be written
  */
 export async function setFeature(feature, value) {
+  const filePath = config.EXPERIMENTAL_FEATURES_FILE;
   const currentFeatures = await getFeatures();
   const newFeatures = { ...currentFeatures, [feature]: value };
   try {
-    await writeJson(EXPERIMENTAL_FEATURES_FILEPATH, newFeatures, { mode: 0o700 });
+    await writeJson(filePath, newFeatures, { mode: 0o700 });
   } catch (error) {
-    throw new Error(`Cannot write experimental features configuration to ${EXPERIMENTAL_FEATURES_FILEPATH}`);
+    throw new Error(`Cannot write experimental features configuration to ${filePath}`);
   }
 }
 

--- a/src/initial-setup.js
+++ b/src/initial-setup.js
@@ -16,4 +16,5 @@ const colorExplicitFalse = hasParam('--no-color') || hasParam('--color', 'false'
 const colorExplicitTrue = hasParam('--color', 'true');
 if (colorExplicitFalse || (!process.stdout.isTTY && !colorExplicitTrue)) {
   process.env.NO_COLOR = '1';
+  delete process.env.FORCE_COLOR;
 }

--- a/src/models/isomorphic-http-with-agent.js
+++ b/src/models/isomorphic-http-with-agent.js
@@ -1,13 +1,14 @@
 import * as git from 'isomorphic-git/http/node';
+import http from 'node:http';
 import https from 'node:https';
 
 // We use our own HTTP plugin, so we can customize the agent used for requests and configure a long timeout (default is 5 seconds).
 
-const agent = new https.Agent({
-  keepAlive: true,
-  timeout: 10 * 60 * 1000,
-});
+const KEEP_ALIVE_TIMEOUT = 10 * 60 * 1000;
 
 export function request(params) {
+  const agent = params.url.startsWith('https:')
+    ? new https.Agent({ keepAlive: true, timeout: KEEP_ALIVE_TIMEOUT })
+    : new http.Agent({ keepAlive: true, timeout: KEEP_ALIVE_TIMEOUT });
   return git.request({ ...params, agent });
 }

--- a/src/models/ssh-marker-protocol.js
+++ b/src/models/ssh-marker-protocol.js
@@ -1,0 +1,72 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Drive the single-command marker protocol over an already-spawned ssh
+ * subprocess: write the marker + login-shell exec line into stdin, filter
+ * gateway/login noise from stdout, and forward the rest to `outStream` /
+ * `errStream`. If ssh exits non-zero before emitting the marker, flush the
+ * buffered pre-marker bytes so the failure reason isn't swallowed.
+ *
+ * @param {object} args
+ * @param {{ stdin: NodeJS.WritableStream, stdout: NodeJS.ReadableStream, stderr: NodeJS.ReadableStream, on: (event: string, listener: (...args: any[]) => void) => void }} args.child
+ * @param {string} args.command - User command; single quotes get shell-escaped.
+ * @param {string} [args.marker] - Override the random marker (used by tests).
+ * @param {NodeJS.WritableStream} [args.outStream] - Defaults to `process.stdout`.
+ * @param {NodeJS.WritableStream} [args.errStream] - Defaults to `process.stderr`.
+ * @returns {Promise<number>} Resolves with ssh's exit code.
+ */
+export async function runMarkerProtocol({
+  child,
+  command,
+  marker = `__CLEVER_${randomUUID()}__`,
+  outStream = process.stdout,
+  errStream = process.stderr,
+}) {
+  // We can't pass the command directly via `ssh gateway 'cmd'` because appId already occupies
+  // the remote command slot (used by the gateway for routing). So we write into stdin and use
+  // a marker to delimit the start of real output from gateway/login noise.
+  child.stdin.write(`echo '${marker}'\n`);
+
+  // `exec $SHELL --login -c` ensures the full login environment is loaded (.bashrc, env vars)
+  // while keeping stdout clean (no PTY = no prompt/ANSI noise).
+  const escapedCommand = command.replaceAll("'", "'\\''");
+  child.stdin.write(`exec $SHELL --login -c '${escapedCommand}'\n`);
+  child.stdin.end();
+
+  let started = false;
+  let stdoutBuf = '';
+  let stderrBuf = '';
+
+  child.stdout.on('data', (chunk) => {
+    if (started) {
+      outStream.write(chunk);
+      return;
+    }
+    stdoutBuf += chunk.toString();
+    const idx = stdoutBuf.indexOf(marker + '\n');
+    if (idx !== -1) {
+      started = true;
+      const rest = stdoutBuf.slice(idx + marker.length + 1);
+      if (rest) outStream.write(rest);
+      stdoutBuf = '';
+    }
+  });
+
+  child.stderr.on('data', (chunk) => {
+    if (started) {
+      errStream.write(chunk);
+    } else {
+      stderrBuf += chunk.toString();
+    }
+  });
+
+  const exitCode = await new Promise((resolve) => child.on('exit', resolve));
+  // Surface buffered pre-marker output on failure so users see the actual ssh
+  // error (auth failure, connection refused, bad key permissions, …) instead
+  // of a silent exit-255.
+  if (exitCode !== 0 && !started) {
+    if (stdoutBuf) outStream.write(stdoutBuf);
+    if (stderrBuf) errStream.write(stderrBuf);
+  }
+  return exitCode;
+}

--- a/src/models/ssh-marker-protocol.test.ts
+++ b/src/models/ssh-marker-protocol.test.ts
@@ -1,0 +1,145 @@
+import * as assert from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, it } from 'node:test';
+import { runMarkerProtocol } from './ssh-marker-protocol.js';
+
+interface FakeChild extends EventEmitter {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+}
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  return child;
+}
+
+/** A minimal in-memory writable stream that accumulates writes into a string. */
+function captureStream() {
+  let buf = '';
+  return {
+    write(chunk: string | Buffer) {
+      buf += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    },
+    get text() {
+      return buf;
+    },
+  };
+}
+
+describe('runMarkerProtocol', () => {
+  it('strips pre-marker stdout noise and forwards post-marker output', async () => {
+    const child = makeFakeChild();
+    const out = captureStream();
+    const err = captureStream();
+
+    const promise = runMarkerProtocol({
+      child,
+      command: 'echo hello',
+      marker: 'MARK',
+      outStream: out as unknown as NodeJS.WritableStream,
+      errStream: err as unknown as NodeJS.WritableStream,
+    });
+
+    child.stdout.write('Welcome to gateway\nLast login: never\n');
+    child.stdout.write('MARK\n');
+    child.stdout.write('hello\n');
+    child.emit('exit', 0);
+
+    const exitCode = await promise;
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(out.text, 'hello\n');
+    assert.strictEqual(err.text, '');
+  });
+
+  it('escapes single quotes in the user command when writing exec to stdin', async () => {
+    const child = makeFakeChild();
+    const stdinReceived = captureStream();
+    child.stdin.on('data', (chunk: Buffer) => stdinReceived.write(chunk));
+
+    const promise = runMarkerProtocol({
+      child,
+      command: `echo "it's working"`,
+      marker: 'MARK',
+      outStream: captureStream() as unknown as NodeJS.WritableStream,
+      errStream: captureStream() as unknown as NodeJS.WritableStream,
+    });
+
+    child.stdout.write('MARK\n');
+    child.emit('exit', 0);
+    await promise;
+
+    assert.strictEqual(stdinReceived.text, `echo 'MARK'\nexec $SHELL --login -c 'echo "it'\\''s working"'\n`);
+  });
+
+  it('forwards post-marker stderr unchanged', async () => {
+    const child = makeFakeChild();
+    const out = captureStream();
+    const err = captureStream();
+
+    const promise = runMarkerProtocol({
+      child,
+      command: 'true',
+      marker: 'MARK',
+      outStream: out as unknown as NodeJS.WritableStream,
+      errStream: err as unknown as NodeJS.WritableStream,
+    });
+
+    child.stdout.write('MARK\n');
+    child.stderr.write('real-error\n');
+    child.emit('exit', 0);
+    await promise;
+
+    assert.strictEqual(out.text, '');
+    assert.strictEqual(err.text, 'real-error\n');
+  });
+
+  it('flushes buffered pre-marker output on non-zero exit when the marker never arrives', async () => {
+    const child = makeFakeChild();
+    const out = captureStream();
+    const err = captureStream();
+
+    const promise = runMarkerProtocol({
+      child,
+      command: 'echo hello',
+      marker: 'MARK',
+      outStream: out as unknown as NodeJS.WritableStream,
+      errStream: err as unknown as NodeJS.WritableStream,
+    });
+
+    child.stderr.write('Host key verification failed.\n');
+    child.emit('exit', 255);
+    const exitCode = await promise;
+
+    assert.strictEqual(exitCode, 255);
+    assert.strictEqual(err.text, 'Host key verification failed.\n');
+  });
+
+  it('does not flush pre-marker output on a clean (zero) exit', async () => {
+    // Defensive: if ssh exits 0 without ever emitting the marker (shouldn't happen
+    // in practice), don't pollute the user's output with gateway banner noise.
+    const child = makeFakeChild();
+    const out = captureStream();
+    const err = captureStream();
+
+    const promise = runMarkerProtocol({
+      child,
+      command: 'true',
+      marker: 'MARK',
+      outStream: out as unknown as NodeJS.WritableStream,
+      errStream: err as unknown as NodeJS.WritableStream,
+    });
+
+    child.stdout.write('Welcome to gateway\n');
+    child.emit('exit', 0);
+    await promise;
+
+    assert.strictEqual(out.text, '');
+    assert.strictEqual(err.text, '');
+  });
+});

--- a/test/cli-hooks.ts
+++ b/test/cli-hooks.ts
@@ -1,0 +1,195 @@
+import type { Mock, MockClient } from '@clevercloud/doublure';
+import {
+  MockScenario as ApiMockScenario,
+  MockScenarioVerifier as ApiMockScenarioVerifier,
+} from '@clevercloud/doublure';
+import { doublureHooks } from '@clevercloud/doublure/testing';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { CliResult, CliRunnerOptions } from './cli-runner.ts';
+import { runCli } from './cli-runner.ts';
+import type { FileMockContent } from './mocks/file-system.ts';
+import { FileSystem, FileSystemRead } from './mocks/file-system.ts';
+import { GitRepo } from './mocks/git-repo.ts';
+import type { GitClient, GitServer } from './mocks/git-server.ts';
+import { startGitServer } from './mocks/git-server.ts';
+
+type Client = MockClient;
+
+export interface CliHooks {
+  before(): Promise<NewCliScenario>;
+  beforeEach(): Promise<void>;
+  after(): Promise<void>;
+}
+
+export type NewCliScenario = (() => CliMockScenario) & {
+  readonly mockClient: MockClient;
+  readonly gitClient: GitClient;
+};
+
+export interface CliHooksOptions {
+  enableGit?: boolean;
+}
+
+export function cliHooks(options?: CliHooksOptions): CliHooks {
+  const apiHooks = doublureHooks();
+  const fileSystem = new FileSystem();
+  let gitServer: GitServer;
+
+  return {
+    ...apiHooks,
+    before: async (): Promise<NewCliScenario> => {
+      const apiNewScenario = await apiHooks.before();
+      const mockClient = apiNewScenario.mockClient;
+      if (options?.enableGit) {
+        gitServer = await startGitServer();
+      }
+      const newScenario = () => new CliMockScenario(mockClient, fileSystem, gitServer?.client);
+      return Object.assign(newScenario, { mockClient, gitClient: gitServer?.client });
+    },
+    beforeEach: async () => {
+      fileSystem.reset();
+      gitServer?.client.reset();
+      await apiHooks.beforeEach();
+    },
+    after: async () => {
+      fileSystem.clear();
+      await gitServer?.stop();
+      await apiHooks.after();
+    },
+  };
+}
+
+export class CliMockScenario extends ApiMockScenario {
+  private readonly _fileSystem: FileSystem;
+  private readonly _gitClient: GitClient | undefined;
+
+  constructor(mockClient: Client, fileSystem: FileSystem, gitClient: GitClient | undefined) {
+    super(mockClient);
+    this._fileSystem = fileSystem;
+    this._gitClient = gitClient;
+  }
+
+  withAppFile(filePath: string, content: FileMockContent) {
+    if (path.isAbsolute(filePath)) {
+      throw new Error(`path must be relative, got "${filePath}"`);
+    }
+    if (path.normalize(filePath).split(path.sep)[0] === '..') {
+      throw new Error(`path must not escape the app directory, got "${filePath}"`);
+    }
+    this._fileSystem.addFile({ type: 'app', path: filePath, content });
+    return this;
+  }
+
+  withAppConfigFile(content: FileMockContent) {
+    this._fileSystem.addFile({ type: 'app', path: '.clever.json', content });
+    return this;
+  }
+
+  withConfigFile(content: FileMockContent) {
+    this._fileSystem.addFile({ type: 'config', content });
+    return this;
+  }
+
+  withExperimentalFeaturesFile(content: FileMockContent) {
+    this._fileSystem.addFile({ type: 'experimental-features', content });
+    return this;
+  }
+
+  withIdsCacheFile(content: FileMockContent) {
+    this._fileSystem.addFile({ type: 'ids-cache', content });
+    return this;
+  }
+
+  withAppGit(appId: string, onSeeded?: (repo: GitRepo) => void) {
+    if (this._gitClient == null) {
+      throw new Error('Git server not started. Enable git in the test hooks options.');
+    }
+    this._gitClient.addRepo(appId);
+    const repo = new GitRepo(this._gitClient.baseUrl, this._fileSystem.getAppDirectory(), appId);
+    if (onSeeded) {
+      onSeeded(repo);
+    }
+    return this;
+  }
+
+  thenCall<T>(callback: () => Promise<T>): CliMockScenarioVerifier<T> {
+    return new CliMockScenarioVerifier(this._mockClient, this._fileSystem, callback, this._mocks);
+  }
+
+  /**
+   * Run the CLI binary with the given arguments.
+   */
+  thenRunCli(args: string[], options: Partial<CliRunnerOptions> = {}): CliMockScenarioVerifier<CliResult> {
+    // Capture the test's stack here, synchronously. The async chain from
+    // `await scenario.thenRunCli(...)` is broken by a .then() boundary in the
+    // verifier's thenable, so an error thrown from runCli during ._toss()
+    // would otherwise lose every frame above _toss. Attaching this stack on
+    // re-throw points the failure back at the test that called thenRunCli.
+    const callSite: { stack: string } = { stack: '' };
+    Error.captureStackTrace(callSite, this.thenRunCli);
+
+    const homeDir = this._fileSystem.getHomeDirectory();
+
+    return this.thenCall(async () => {
+      const env: Record<string, string> = {
+        HOME: homeDir,
+        APPDATA: homeDir,
+        API_HOST: this._mockClient.baseUrl,
+        AUTH_BRIDGE_HOST: this._mockClient.baseUrl,
+        CONFIGURATION_FILE: this._fileSystem.getConfigFile(),
+        EXPERIMENTAL_FEATURES_FILE: this._fileSystem.getExperimentalFeaturesFile(),
+        IDS_CACHE_FILE: this._fileSystem.getIdsCacheFile(),
+      };
+
+      const workingDir = fs.existsSync(this._fileSystem.getAppDirectory())
+        ? this._fileSystem.getAppDirectory()
+        : undefined;
+
+      const opts: Partial<CliRunnerOptions> = {
+        cwd: workingDir,
+        ...options,
+        env: {
+          ...env,
+          ...options.env,
+        },
+      };
+
+      try {
+        return await runCli(args, opts);
+      } catch (err: any) {
+        const callerFrames = callSite.stack.split('\n').slice(1).join('\n');
+        err.stack = `${err.stack}\n${callerFrames}`;
+        throw err;
+      }
+    });
+  }
+}
+
+class CliMockScenarioVerifier<T> extends ApiMockScenarioVerifier<T> {
+  private readonly _fileSystem: FileSystem;
+  private readonly _cliExpectations: Array<() => void> = [];
+
+  constructor(apiMockClient: Client, fileSystemClient: FileSystem, callback: () => Promise<T>, mocks: Mock[]) {
+    super(apiMockClient, callback, mocks);
+    this._fileSystem = fileSystemClient;
+  }
+
+  verifyFiles(verifyCallback: (fileSystemRead: FileSystemRead) => void): CliMockScenarioVerifier<T> {
+    const fileSystemRead = new FileSystemRead(this._fileSystem);
+    this._cliExpectations.push(() => {
+      verifyCallback(fileSystemRead);
+    });
+    return this;
+  }
+
+  async _toss() {
+    const result = await super._toss();
+
+    for (const expectation of this._cliExpectations) {
+      expectation();
+    }
+
+    return result;
+  }
+}

--- a/test/cli-runner.test.ts
+++ b/test/cli-runner.test.ts
@@ -1,0 +1,164 @@
+import * as assert from 'node:assert';
+import { dirname, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { runCli } from './cli-runner.ts';
+import { keys } from './keys.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const FIXTURE_PATH = resolve(dirname(__filename), 'fixtures/prompt-script.ts');
+const SELECT_FIXTURE_PATH = resolve(dirname(__filename), 'fixtures/select-script.ts');
+
+// Fixtures are .ts files. The CLI runner spawns them as bare scripts via node, so we
+// have to wedge the strip-types flag in front of the script path. cli-runner.ts treats
+// args as either CLI flags (when CLEVER_BIN points at a native binary) or as
+// "[clever-binary, ...args]" (default). Here we set CLEVER_BIN=process.execPath so the
+// args we pass are read as `node <args>`; prepending the flag puts it in front of the
+// script.
+const TS_RUN_ARGS = ['--experimental-strip-types', '--disable-warning=ExperimentalWarning'];
+
+describe('cli-runner', () => {
+  let originalBin: string | undefined;
+
+  beforeEach(() => {
+    originalBin = process.env.CLEVER_BIN;
+    // Point the runner at the fixture as if it were a native binary so spawn calls it directly.
+    process.env.CLEVER_BIN = process.execPath;
+  });
+
+  afterEach(() => {
+    if (originalBin == null) {
+      delete process.env.CLEVER_BIN;
+    } else {
+      process.env.CLEVER_BIN = originalBin;
+    }
+  });
+
+  it('drives sequential prompts via the interactions queue', async () => {
+    const result = await runCli([...TS_RUN_ARGS, FIXTURE_PATH], {
+      interactions: [
+        { waitFor: /Q1\?/, send: 'alpha\n' },
+        { waitFor: /Q2\?/, send: 'beta\n' },
+      ],
+    });
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.strictEqual(result.stdout, 'A1=alpha\nA2=beta');
+  });
+
+  it('exposes per-interaction output via result.segments', async () => {
+    const result = await runCli([...TS_RUN_ARGS, FIXTURE_PATH], {
+      interactions: [
+        { waitFor: /Q1\?/, send: 'alpha\n' },
+        { waitFor: /Q2\?/, send: 'beta\n' },
+      ],
+    });
+
+    assert.strictEqual(result.segments.length, 3);
+    assert.strictEqual(result.segments[0], 'Q1? ');
+    assert.strictEqual(result.segments[1], 'Q2? ');
+    assert.strictEqual(result.segments[2], 'A1=alpha\nA2=beta\n');
+  });
+
+  it('returns a single-element segments array when no interactions are configured', async () => {
+    const result = await runCli([...TS_RUN_ARGS, FIXTURE_PATH], { stdin: 'first\nsecond\n' });
+
+    assert.strictEqual(result.segments.length, 1);
+    assert.ok(result.segments[0].includes('A1=first'));
+    assert.ok(result.segments[0].includes('A2=second'));
+  });
+
+  it('strips ANSI escapes when matching waitFor', async () => {
+    // The fixture renders Q1 with cyan color codes; without ANSI stripping, an anchored
+    // regex like /^Q1\? $/m would not match the raw "\x1B[36mQ1?\x1B[39m ".
+    const result = await runCli([...TS_RUN_ARGS, FIXTURE_PATH], {
+      interactions: [
+        { waitFor: /^Q1\? $/m, send: 'one\n' },
+        { waitFor: /Q2\?/, send: 'two\n' },
+      ],
+    });
+
+    assert.strictEqual(result.stdout, 'A1=one\nA2=two');
+  });
+
+  it('fails fast when a prompt never appears', async () => {
+    await assert.rejects(
+      runCli([...TS_RUN_ARGS, FIXTURE_PATH], {
+        interactions: [
+          { waitFor: /Q1\?/, send: 'x\n' },
+          { waitFor: /never-shown/, send: 'y\n', timeoutMs: 200 },
+        ],
+      }),
+      /Interaction timed out after 200ms waiting for/,
+    );
+  });
+
+  it('rejects when the CLI exits with interactions still queued', async () => {
+    await assert.rejects(
+      runCli([...TS_RUN_ARGS, FIXTURE_PATH], {
+        interactions: [
+          { waitFor: /Q1\?/, send: 'a\n' },
+          { waitFor: /Q2\?/, send: 'b\n' },
+          { waitFor: /Q3\?/, send: 'c\n', timeoutMs: 1000 },
+        ],
+      }),
+      /CLI exited before all interactions ran|Interaction timed out/,
+    );
+  });
+
+  it('still supports the existing static stdin path', async () => {
+    const result = await runCli([...TS_RUN_ARGS, FIXTURE_PATH], { stdin: 'first\nsecond\n' });
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.strictEqual(result.stdout, 'A1=first\nA2=second');
+  });
+
+  describe('PTY mode', () => {
+    beforeEach(() => {
+      process.env.CLEVER_BIN = process.execPath;
+    });
+
+    it('drives a raw-mode @inquirer/select prompt with arrow keys', async () => {
+      const result = await runCli([...TS_RUN_ARGS, SELECT_FIXTURE_PATH], {
+        pty: true,
+        interactions: [{ waitFor: /Pick one/, send: keys.DOWN + keys.DOWN + keys.ENTER }],
+      });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(result.stderr, '');
+      assert.strictEqual(
+        result.output,
+        [
+          '? Pick one',
+          '  Alpha',
+          '❯ Beta',
+          '  Gamma? Pick one',
+          '  Alpha',
+          '  Beta',
+          '❯ Gamma✔ Pick one Gamma',
+          'PICKED=gamma',
+        ].join('\n'),
+      );
+    });
+
+    it('selects the first choice with ENTER alone', async () => {
+      const result = await runCli([...TS_RUN_ARGS, SELECT_FIXTURE_PATH], {
+        pty: true,
+        interactions: [{ waitFor: /Pick one/, send: keys.ENTER }],
+      });
+
+      assert.strictEqual(result.exitCode, 0);
+      assert.strictEqual(result.output, '✔ Pick one Alpha\nPICKED=alpha');
+    });
+
+    it('times out cleanly when the expected prompt never appears', async () => {
+      await assert.rejects(
+        runCli([...TS_RUN_ARGS, SELECT_FIXTURE_PATH], {
+          pty: true,
+          interactions: [{ waitFor: /never-shown/, send: keys.ENTER, timeoutMs: 500 }],
+        }),
+        /Interaction timed out after 500ms/,
+      );
+    });
+  });
+});

--- a/test/cli-runner.ts
+++ b/test/cli-runner.ts
@@ -1,0 +1,497 @@
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import stripAnsiLib from 'strip-ansi';
+
+export interface CliRunnerOptions {
+  env: Record<string, string>;
+  cwd: string;
+  timeout: number;
+  expectExitCode: number | null;
+  stdin: string | Buffer | null;
+  interactions: CliInteraction[] | null;
+  /** Strip ANSI escape sequences from the captured stdout/stderr (default: true). */
+  stripAnsi: boolean;
+  /**
+   * Run the CLI under a pseudo-terminal so raw-mode prompts (select / checkbox /
+   * confirm via @inquirer/prompts) work. Default: false (uses pipes).
+   *
+   * Trade-off: PTYs have one channel between parent and child, so stdout and
+   * stderr merge into a single stream. Under `pty: true`, assert against
+   * `result.output`; `result.stdout` and `result.stderr` are empty strings.
+   */
+  pty: boolean;
+  /** PTY columns (default: 120). Only used when `pty: true`. */
+  cols: number;
+  /** PTY rows (default: 30). Only used when `pty: true`. */
+  rows: number;
+}
+
+export interface CliInteraction {
+  waitFor: RegExp;
+  send: string;
+  timeoutMs?: number;
+}
+
+export interface CliResult {
+  /** Captured stdout (pipe mode only — empty under `pty: true`). */
+  stdout: string;
+  /** Captured stderr (pipe mode only — empty under `pty: true`). */
+  stderr: string;
+  /**
+   * Combined output. Under pipe mode, `stdout + '\n' + stderr` (whichever are
+   * non-empty). Under PTY mode, the merged ANSI-stripped PTY stream. Always
+   * populated.
+   */
+  output: string;
+  /**
+   * ANSI-stripped output split per interaction. For N interactions, this has
+   * N+1 entries: `segments[i]` (i < N) is the output captured between the
+   * previous answer (or start) and the moment `interactions[i].waitFor` matched
+   * and its answer was sent; `segments[N]` is everything emitted after the last
+   * answer. With no interactions, this is a single-element array containing the
+   * full stripped output.
+   */
+  segments: string[];
+  exitCode: number;
+}
+
+interface RunCommonArgs {
+  file: string;
+  fileArgs: string[];
+  workingDir: string;
+  env: Record<string, string>;
+  timeout: number;
+  stdin: string | Buffer | null;
+  interactions: CliInteraction[] | null;
+  stripAnsi: boolean;
+}
+
+type RunUnderPipesArgs = RunCommonArgs & { cliBin: string };
+type RunUnderPtyArgs = RunCommonArgs & { cols: number; rows: number };
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = resolve(__dirname, '..');
+const DEFAULT_OPTIONS: CliRunnerOptions = {
+  env: {},
+  cwd: PROJECT_ROOT,
+  timeout: 30000,
+  expectExitCode: 0,
+  stdin: null,
+  interactions: null,
+  stripAnsi: true,
+  pty: false,
+  cols: 120,
+  rows: 30,
+};
+const DEFAULT_INTERACTION_TIMEOUT_MS = 5000;
+
+/**
+ * Merge OS-essential env vars into the test's hermetic env. Without `SystemRoot`,
+ * the spawned process can't load `bcryptprimitives.dll`, which aborts Node's
+ * OpenSSL init at `Assertion failed: ncrypto::CSPRNG`. `child_process.spawn`
+ * (libuv) auto-injects `SystemRoot`; node-pty's native CreateProcess does not,
+ * so the PTY-mode spawn must propagate it explicitly. Test-provided keys win.
+ */
+function withOsEnv(env: Record<string, string>): Record<string, string> {
+  if (process.platform !== 'win32') {
+    return env;
+  }
+  const passthrough = ['SystemRoot', 'SystemDrive', 'windir', 'TEMP', 'TMP', 'PATHEXT', 'COMSPEC', 'PATH'];
+  const osEnv: Record<string, string> = {};
+  for (const key of passthrough) {
+    if (process.env[key] != null) {
+      osEnv[key] = process.env[key] as string;
+    }
+  }
+  return { ...osEnv, ...env };
+}
+
+/**
+ * Split a buffer at the given boundary offsets, producing `boundaries.length + 1`
+ * segments. The last segment runs from the final boundary (or 0) to the end.
+ * PTY emits "\r\n" for "\n"; normalize so segments look the same in both modes.
+ */
+function sliceSegments(buffer: string, boundaries: number[]): string[] {
+  const segments: string[] = [];
+  let prev = 0;
+  for (const b of boundaries) {
+    segments.push(buffer.slice(prev, b).replace(/\r\n/g, '\n'));
+    prev = b;
+  }
+  segments.push(buffer.slice(prev).replace(/\r\n/g, '\n'));
+  return segments;
+}
+
+/**
+ * Run the CLI binary with the given arguments.
+ */
+export async function runCli(args: string[], options: Partial<CliRunnerOptions> = {}): Promise<CliResult> {
+  const { env, cwd, timeout, expectExitCode, stdin, interactions, stripAnsi, pty, cols, rows } = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+
+  const workingDir = cwd ?? PROJECT_ROOT;
+  const isNativeBin = process.env.CLEVER_BIN != null;
+  const cliBin = process.env.CLEVER_BIN ?? resolve(PROJECT_ROOT, 'bin/clever.js');
+  const [file, fileArgs] = isNativeBin ? [cliBin, args] : [process.execPath, [cliBin, ...args]];
+
+  const result = pty
+    ? await runUnderPty({ file, fileArgs, workingDir, env, timeout, cols, rows, stdin, interactions, stripAnsi })
+    : await runUnderPipes({ file, fileArgs, workingDir, env, timeout, stdin, interactions, stripAnsi, cliBin });
+
+  if (expectExitCode != null && result.exitCode !== expectExitCode) {
+    throw new Error(
+      `CLI exited with ${result.exitCode} (expected ${expectExitCode})\n` +
+        `args: ${JSON.stringify(args)}\n` +
+        `--- stdout ---\n${result.stdout}\n` +
+        `--- stderr ---\n${result.stderr}\n` +
+        `------`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Pipe-mode runner: spawn the CLI with piped stdio and capture stdout/stderr separately.
+ * This is the default. Existing tests rely on the stdout/stderr split.
+ */
+async function runUnderPipes({
+  file,
+  fileArgs,
+  workingDir,
+  env,
+  timeout,
+  stdin,
+  interactions,
+  stripAnsi,
+  cliBin,
+}: RunUnderPipesArgs): Promise<CliResult> {
+  return new Promise((resolveResult, rejectResult) => {
+    const child = spawn(file, fileArgs, { cwd: workingDir, env: withOsEnv(env) });
+
+    let stdout = '';
+    let stderr = '';
+    // Concatenated and ANSI-stripped stream of stdout+stderr, used to match interaction patterns.
+    // Inquirer renders prompts on stderr, so we watch both streams here.
+    let combined = '';
+    const queue: CliInteraction[] = Array.isArray(interactions) ? [...interactions] : [];
+    let stepTimer: NodeJS.Timeout | null = null;
+    // Boundaries in `combined` recorded at each interaction shift; used to split
+    // the ANSI-stripped output into per-interaction segments.
+    const segmentBoundaries: number[] = [];
+    // Once the last interaction has been answered, slice the captured streams from these
+    // offsets so result.stdout/stderr only contain what the command itself produced.
+    // -1 means "no slice" (no interactions, or the last answer was never sent).
+    let stdoutSliceFrom = -1;
+    let stderrSliceFrom = -1;
+    // After the last answer is sent, the prompt library writes one trailing line
+    // (e.g. "✔ Enter your password: *******\n") to whichever stream renders prompts.
+    // Skip past the next "\n" we observe on that stream so that line is dropped too.
+    let promptEndStream: 'stdout' | 'stderr' | null = null;
+    let lastChunkStream: 'stdout' | 'stderr' | null = null;
+
+    const overallTimer = setTimeout(() => {
+      child.kill('SIGKILL');
+      rejectResult(new Error(`CLI command timed out after ${timeout}ms`));
+    }, timeout);
+
+    function clearStepTimer() {
+      if (stepTimer != null) {
+        clearTimeout(stepTimer);
+        stepTimer = null;
+      }
+    }
+
+    function armStepTimer() {
+      clearStepTimer();
+      if (queue.length === 0) return;
+      const ms = queue[0].timeoutMs ?? DEFAULT_INTERACTION_TIMEOUT_MS;
+      stepTimer = setTimeout(() => {
+        const re = queue[0]?.waitFor;
+        child.kill('SIGKILL');
+        rejectResult(
+          new Error(
+            `Interaction timed out after ${ms}ms waiting for ${re}\n` + `--- output so far ---\n${combined}\n------`,
+          ),
+        );
+      }, ms);
+    }
+
+    function tryWriteStdin(data: string | Buffer) {
+      try {
+        child.stdin.write(data);
+      } catch (_e) {
+        // Child may have closed stdin already; surfaced via 'close' / 'error'.
+      }
+    }
+
+    function tryEndStdin(data?: string | Buffer) {
+      try {
+        child.stdin.end(data);
+      } catch (_e) {
+        // ignored
+      }
+    }
+
+    function processBuffer() {
+      while (queue.length > 0) {
+        const next = queue[0];
+        if (!next.waitFor.test(combined)) break;
+        queue.shift();
+        segmentBoundaries.push(combined.length);
+        clearStepTimer();
+        tryWriteStdin(next.send);
+        if (queue.length > 0) {
+          armStepTimer();
+        } else {
+          // Last answer sent: mark current positions; everything after is the command's
+          // own output (modulo the trailing prompt confirmation that the prompt library
+          // emits on the same stream that rendered the prompt).
+          stdoutSliceFrom = stdout.length;
+          stderrSliceFrom = stderr.length;
+          promptEndStream = lastChunkStream;
+          tryEndStdin();
+        }
+      }
+    }
+
+    function advancePromptEndMarker() {
+      if (promptEndStream === 'stdout') {
+        const idx = stdout.indexOf('\n', stdoutSliceFrom);
+        if (idx >= 0) {
+          stdoutSliceFrom = idx + 1;
+          promptEndStream = null;
+        }
+      } else if (promptEndStream === 'stderr') {
+        const idx = stderr.indexOf('\n', stderrSliceFrom);
+        if (idx >= 0) {
+          stderrSliceFrom = idx + 1;
+          promptEndStream = null;
+        }
+      }
+    }
+
+    child.stdout.on('data', (buf) => {
+      const text = buf.toString();
+      stdout += text;
+      combined += stripAnsiLib(text);
+      lastChunkStream = 'stdout';
+      processBuffer();
+      advancePromptEndMarker();
+    });
+    child.stderr.on('data', (buf) => {
+      const text = buf.toString();
+      stderr += text;
+      combined += stripAnsiLib(text);
+      lastChunkStream = 'stderr';
+      processBuffer();
+      advancePromptEndMarker();
+    });
+
+    // Swallow EPIPE on stdin once the child exits early; the real cause surfaces via 'close'.
+    child.stdin.on('error', () => {});
+
+    child.on('error', (err) => {
+      clearTimeout(overallTimer);
+      clearStepTimer();
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        rejectResult(new Error(`CLI binary not found at ${cliBin}`));
+        return;
+      }
+      rejectResult(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(overallTimer);
+      clearStepTimer();
+      if (queue.length > 0) {
+        rejectResult(
+          new Error(
+            `CLI exited before all interactions ran (${queue.length} remaining)\n` +
+              `--- stdout ---\n${stdout.trim()}\n` +
+              `--- stderr ---\n${stderr.trim()}\n------`,
+          ),
+        );
+        return;
+      }
+      const exitCode = typeof code === 'number' ? code : 1;
+      const slicedStdout = stdoutSliceFrom >= 0 ? stdout.slice(stdoutSliceFrom) : stdout;
+      const slicedStderr = stderrSliceFrom >= 0 ? stderr.slice(stderrSliceFrom) : stderr;
+      const finalStdout = stripAnsi ? stripAnsiLib(slicedStdout) : slicedStdout;
+      const finalStderr = stripAnsi ? stripAnsiLib(slicedStderr) : slicedStderr;
+      const trimmedStdout = finalStdout.trim();
+      const trimmedStderr = finalStderr.trim();
+      const output =
+        trimmedStderr.length > 0
+          ? trimmedStdout.length > 0
+            ? `${trimmedStdout}\n${trimmedStderr}`
+            : trimmedStderr
+          : trimmedStdout;
+      const segments = sliceSegments(combined, segmentBoundaries);
+      resolveResult({ stdout: trimmedStdout, stderr: trimmedStderr, output, segments, exitCode });
+    });
+
+    if (queue.length === 0) {
+      // No prompts to drive: keep existing behaviour — write any upfront stdin, then close.
+      tryEndStdin(stdin ?? '');
+    } else {
+      // Interactions will close stdin once the queue drains.
+      if (stdin != null) {
+        tryWriteStdin(stdin);
+      }
+      armStepTimer();
+    }
+  });
+}
+
+/**
+ * PTY-mode runner: spawn the CLI under a pseudo-terminal so raw-mode prompts
+ * (select / checkbox / confirm via @inquirer/prompts) can be driven.
+ *
+ * The PTY model has only one channel between parent and child: stdout and
+ * stderr merge into a single stream by design (see Microsoft node-pty issue #71).
+ * Under PTY mode `result.output` carries the merged ANSI-stripped stream, and
+ * `result.stdout` / `result.stderr` are empty strings.
+ */
+async function runUnderPty({
+  file,
+  fileArgs,
+  workingDir,
+  env,
+  timeout,
+  cols,
+  rows,
+  stdin,
+  interactions,
+  stripAnsi,
+}: RunUnderPtyArgs): Promise<CliResult> {
+  // Lazy-load node-pty so pipe-mode tests don't pay the native module cost.
+  const ptyMod: any = await import('node-pty');
+  const ptyApi = ptyMod.default ?? ptyMod;
+
+  return new Promise((resolveResult, rejectResult) => {
+    // child_process.spawn auto-propagates NODE_V8_COVERAGE even with an explicit env,
+    // but node-pty's native spawn doesn't — pass it through manually so c8 sees the
+    // subprocess coverage emitted while driving raw-mode prompts.
+    const coverageEnv = process.env.NODE_V8_COVERAGE != null ? { NODE_V8_COVERAGE: process.env.NODE_V8_COVERAGE } : {};
+    const ptyProcess = ptyApi.spawn(file, fileArgs, {
+      cwd: workingDir,
+      // TERM matches `name` so @inquirer/figures picks Unicode glyphs (❯, ✔) on Windows ConPTY,
+      // which otherwise lacks the env hints (WT_SESSION, etc.) is-unicode-supported looks for.
+      env: { TERM: 'xterm-256color', ...coverageEnv, ...withOsEnv(env) },
+      name: 'xterm-256color',
+      cols,
+      rows,
+    });
+
+    let raw = '';
+    let combined = '';
+    const queue: CliInteraction[] = Array.isArray(interactions) ? [...interactions] : [];
+    let stepTimer: NodeJS.Timeout | null = null;
+    const segmentBoundaries: number[] = [];
+    let outputSliceFrom = -1;
+    let exited = false;
+
+    const overallTimer = setTimeout(() => {
+      try {
+        ptyProcess.kill('SIGKILL');
+      } catch (_e) {
+        // process may already be gone
+      }
+      rejectResult(new Error(`CLI command timed out after ${timeout}ms`));
+    }, timeout);
+
+    function clearStepTimer() {
+      if (stepTimer != null) {
+        clearTimeout(stepTimer);
+        stepTimer = null;
+      }
+    }
+
+    function armStepTimer() {
+      clearStepTimer();
+      if (queue.length === 0) return;
+      const ms = queue[0].timeoutMs ?? DEFAULT_INTERACTION_TIMEOUT_MS;
+      stepTimer = setTimeout(() => {
+        const re = queue[0]?.waitFor;
+        try {
+          ptyProcess.kill('SIGKILL');
+        } catch (_e) {
+          // ignored
+        }
+        rejectResult(
+          new Error(
+            `Interaction timed out after ${ms}ms waiting for ${re}\n` + `--- output so far ---\n${combined}\n------`,
+          ),
+        );
+      }, ms);
+    }
+
+    function tryWrite(data: string) {
+      if (exited) return;
+      try {
+        ptyProcess.write(data);
+      } catch (_e) {
+        // child may have exited
+      }
+    }
+
+    function processBuffer() {
+      while (queue.length > 0) {
+        const next = queue[0];
+        if (!next.waitFor.test(combined)) break;
+        queue.shift();
+        segmentBoundaries.push(combined.length);
+        clearStepTimer();
+        tryWrite(next.send);
+        if (queue.length > 0) {
+          armStepTimer();
+        } else {
+          // Last answer sent: mark slice point so result.output drops everything
+          // emitted while prompts were active.
+          outputSliceFrom = raw.length;
+        }
+      }
+    }
+
+    ptyProcess.onData((chunk: string) => {
+      raw += chunk;
+      combined += stripAnsiLib(chunk);
+      processBuffer();
+    });
+
+    ptyProcess.onExit(({ exitCode, signal }: { exitCode: number; signal?: number }) => {
+      exited = true;
+      clearTimeout(overallTimer);
+      clearStepTimer();
+      if (queue.length > 0) {
+        rejectResult(
+          new Error(
+            `CLI exited before all interactions ran (${queue.length} remaining)\n` + `--- output ---\n${raw}\n------`,
+          ),
+        );
+        return;
+      }
+      const code = typeof exitCode === 'number' ? exitCode : signal != null ? 1 : 0;
+      const slicedRaw = outputSliceFrom >= 0 ? raw.slice(outputSliceFrom) : raw;
+      // PTYs translate '\n' -> '\r\n'; normalize so assertions look natural.
+      const normalized = slicedRaw.replace(/\r\n/g, '\n');
+      const finalOutput = stripAnsi ? stripAnsiLib(normalized) : normalized;
+      const segments = sliceSegments(combined, segmentBoundaries);
+      resolveResult({ stdout: '', stderr: '', output: finalOutput.trim(), segments, exitCode: code });
+    });
+
+    if (queue.length === 0) {
+      // No prompts to drive: write any upfront stdin, then send EOF (Ctrl-D).
+      if (stdin != null) tryWrite(typeof stdin === 'string' ? stdin : stdin.toString('utf8'));
+      tryWrite('\x04');
+    } else {
+      if (stdin != null) tryWrite(typeof stdin === 'string' ? stdin : stdin.toString('utf8'));
+      armStepTimer();
+    }
+  });
+}

--- a/test/fixtures/app-config.ts
+++ b/test/fixtures/app-config.ts
@@ -1,0 +1,47 @@
+import { APP_ID, ORGA_ID } from './id.ts';
+
+const DEFAULT_DEPLOY_URL = `https://push-n3-par-clevercloud-customers.services.clever-cloud.com/${APP_ID}.git`;
+
+/**
+ * Build an `.clever.json` (app config) with a single linked application.
+ */
+export function singleAppConfig(
+  overrides: Partial<{ app_id: string; org_id: string; deploy_url: string; name: string; alias: string }> = {},
+) {
+  return {
+    apps: [
+      {
+        app_id: APP_ID,
+        org_id: ORGA_ID,
+        deploy_url: DEFAULT_DEPLOY_URL,
+        name: 'test-app',
+        alias: 'test-app',
+        ...overrides,
+      },
+    ],
+  };
+}
+
+/**
+ * Build an `.clever.json` (app config) with two linked applications (aliases: prod, staging).
+ */
+export function multiAppConfig() {
+  return {
+    apps: [
+      {
+        app_id: APP_ID,
+        org_id: ORGA_ID,
+        deploy_url: DEFAULT_DEPLOY_URL,
+        name: 'test-app (prod)',
+        alias: 'prod',
+      },
+      {
+        app_id: APP_ID,
+        org_id: ORGA_ID,
+        deploy_url: DEFAULT_DEPLOY_URL,
+        name: 'test-app (staging)',
+        alias: 'staging',
+      },
+    ],
+  };
+}

--- a/test/fixtures/errors.ts
+++ b/test/fixtures/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Canonical error text the CLI emits when the API returns 401.
+ * Mapped in src/models/send-to-api.js (`processError`).
+ */
+export const NOT_LOGGED_IN_ERROR =
+  "[ERROR] You're not logged in, use clever login command to connect to your Clever Cloud account";
+
+/**
+ * Canonical error text the CLI emits when both `--app` and `--alias` are passed.
+ * Thrown in src/models/application.js (`resolveId`).
+ */
+export const APP_ALIAS_MUTEX_ERROR = '[ERROR] Only one of the `--app` or `--alias` options can be set at a time';

--- a/test/fixtures/id.ts
+++ b/test/fixtures/id.ts
@@ -1,0 +1,5 @@
+export const UUID = '00000000-0000-2222-aaaa-000000000001';
+export const USER_ID = `user_${UUID}`;
+export const ORGA_ID = `orga_${UUID}`;
+export const APP_ID = `app_${UUID}`;
+export const ADDON_ID = `addon_${UUID}`;

--- a/test/fixtures/ids-cache.ts
+++ b/test/fixtures/ids-cache.ts
@@ -1,0 +1,11 @@
+/**
+ * Build an IDs cache file (config/ids-cache.json) keyed by app/addon IDs.
+ * Pass `owners` and/or `addons` to fill in the cache contents.
+ * Both keys are required by IdsCacheSchema (src/config/cache.js); empty defaults are fine.
+ */
+export function idsCache({
+  owners = {},
+  addons = {},
+}: { owners?: Record<string, string>; addons?: Record<string, { addonId: string; realId: string }> } = {}) {
+  return { owners, addons };
+}

--- a/test/fixtures/profile.ts
+++ b/test/fixtures/profile.ts
@@ -1,0 +1,23 @@
+import { SELF } from './self.ts';
+
+/**
+ * Build a default profile config (version 1) seeded by `withConfigFile(...)`.
+ * Pass overrides to customize the active profile (alias, token, secret, …).
+ */
+export function profileConfig(
+  overrides: Partial<{ alias: string; token: string; secret: string; userId: string; email: string }> = {},
+) {
+  return {
+    version: 1,
+    profiles: [
+      {
+        alias: 'default',
+        token: 'profile-token',
+        secret: 'profile-secret',
+        userId: SELF.id,
+        email: SELF.email,
+        ...overrides,
+      },
+    ],
+  };
+}

--- a/test/fixtures/prompt-script.ts
+++ b/test/fixtures/prompt-script.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Tiny fixture used by test/cli-runner.test.ts to exercise interactive prompt handling.
+// Reads two lines from stdin, prompting on stderr (mirroring how @inquirer/prompts renders).
+
+import { createInterface } from 'node:readline';
+
+const rl = createInterface({ input: process.stdin });
+const lines: string[] = [];
+const expected = 2;
+
+process.stderr.write('\x1B[36mQ1?\x1B[39m ');
+rl.on('line', (line) => {
+  lines.push(line);
+  if (lines.length === 1) {
+    process.stderr.write('Q2? ');
+  } else if (lines.length === expected) {
+    rl.close();
+  }
+});
+rl.on('close', () => {
+  process.stdout.write(`A1=${lines[0]}\nA2=${lines[1]}\n`);
+  process.exit(0);
+});

--- a/test/fixtures/select-script.ts
+++ b/test/fixtures/select-script.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Tiny fixture used by test/cli-runner.test.ts to exercise raw-mode prompts.
+// Renders an @inquirer/select with three choices and prints the chosen value.
+import { select } from '@inquirer/prompts';
+
+const answer = await select({
+  message: 'Pick one',
+  choices: [
+    { name: 'Alpha', value: 'alpha' },
+    { name: 'Beta', value: 'beta' },
+    { name: 'Gamma', value: 'gamma' },
+  ],
+});
+
+console.log(`PICKED=${answer}`);

--- a/test/fixtures/self.ts
+++ b/test/fixtures/self.ts
@@ -1,0 +1,24 @@
+import { USER_ID } from './id.ts';
+
+export const SELF = {
+  id: USER_ID,
+  email: 'test.user@example.com',
+  name: 'Test User',
+  phone: '+33600000000',
+  address: '1 rue de Test',
+  city: 'Paris',
+  zipcode: '75001',
+  country: 'FRANCE',
+  avatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000000.jpg',
+  creationDate: 1700000000000,
+  lang: 'EN',
+  emailValidated: true,
+  oauthApps: ['github'],
+  admin: false,
+  canPay: true,
+  preferredMFA: 'TOTP',
+  hasPassword: true,
+  partnerId: '00000000-0000-0000-0000-000000000000',
+  partnerName: 'default',
+  partnerConsoleUrl: 'https://console.clever-cloud.com',
+};

--- a/test/keys.ts
+++ b/test/keys.ts
@@ -1,0 +1,15 @@
+// Keypress byte sequences for driving raw-mode prompts (select / checkbox /
+// confirm) under PTY mode. Use as e.g. `send: keys.DOWN + keys.ENTER`.
+export const keys = {
+  UP: '\x1B[A',
+  DOWN: '\x1B[B',
+  RIGHT: '\x1B[C',
+  LEFT: '\x1B[D',
+  ENTER: '\r',
+  SPACE: ' ',
+  TAB: '\t',
+  ESC: '\x1B',
+  BACKSPACE: '\x7F',
+  CTRL_C: '\x03',
+  CTRL_D: '\x04',
+};

--- a/test/manual-tests-todo.md
+++ b/test/manual-tests-todo.md
@@ -1,0 +1,9 @@
+What can't be tested today (~10–15 commands)
+- activity --follow (WS, Doublure unsupported)
+
+
+# to discuss
+- CLEVER_BIN new env var (naming ok?)
+- CLEVER_SSH_FLAGS new env var (is it ok?)
+- code coverage
+- env var names (vs CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET)

--- a/test/mocks/file-system.ts
+++ b/test/mocks/file-system.ts
@@ -1,0 +1,177 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export type FileMock = AppFileMock | ConfigFileMock | ExperimentalFeaturesFileMock | IdsCacheFileMock;
+
+export type FileMockContent = string | object;
+
+export interface AppFileMock {
+  type: 'app';
+  path: string;
+  content: FileMockContent;
+}
+
+export interface ConfigFileMock {
+  type: 'config';
+  content: FileMockContent;
+}
+
+export interface ExperimentalFeaturesFileMock {
+  type: 'experimental-features';
+  content: FileMockContent;
+}
+
+export interface IdsCacheFileMock {
+  type: 'ids-cache';
+  content: FileMockContent;
+}
+
+const HOME_DIR = 'home';
+const APP_DIR = 'app';
+const CONFIG_DIR = 'config';
+const CONFIG_FILE = 'clever-tools.json';
+const EXPERIMENTAL_FEATURES_FILE = 'clever-tools-experimental-features.json';
+const IDS_CACHE_FILE = 'ids-cache.json';
+
+export class FileSystem {
+  private readonly _rootDir: string;
+
+  constructor() {
+    this._rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clever-tools-test-'));
+  }
+
+  getHomeDirectory() {
+    return path.resolve(this._rootDir, HOME_DIR);
+  }
+
+  getAppDirectory() {
+    return path.resolve(this._rootDir, APP_DIR);
+  }
+
+  getConfigFile() {
+    return path.resolve(this._rootDir, `${CONFIG_DIR}/${CONFIG_FILE}`);
+  }
+
+  getExperimentalFeaturesFile() {
+    return path.resolve(this._rootDir, `${CONFIG_DIR}/${EXPERIMENTAL_FEATURES_FILE}`);
+  }
+
+  getIdsCacheFile() {
+    return path.resolve(this._rootDir, `${CONFIG_DIR}/${IDS_CACHE_FILE}`);
+  }
+
+  addFile(fileMock: FileMock) {
+    let filePath: string;
+    if (fileMock.type === 'config') {
+      const configDir = path.resolve(this._rootDir, CONFIG_DIR);
+      this.#createDirIfNotExists(configDir);
+      filePath = path.resolve(configDir, CONFIG_FILE);
+    } else if (fileMock.type === 'experimental-features') {
+      const configDir = path.resolve(this._rootDir, CONFIG_DIR);
+      this.#createDirIfNotExists(configDir);
+      filePath = path.resolve(configDir, EXPERIMENTAL_FEATURES_FILE);
+    } else if (fileMock.type === 'ids-cache') {
+      const configDir = path.resolve(this._rootDir, CONFIG_DIR);
+      this.#createDirIfNotExists(configDir);
+      filePath = path.resolve(configDir, IDS_CACHE_FILE);
+    } else {
+      const appDir = path.resolve(this._rootDir, APP_DIR);
+      filePath = path.resolve(appDir, fileMock.path);
+      this.#createDirIfNotExists(path.dirname(filePath));
+    }
+
+    const content = typeof fileMock.content === 'object' ? JSON.stringify(fileMock.content, null, 2) : fileMock.content;
+    fs.writeFileSync(filePath, content ?? '');
+  }
+
+  reset() {
+    this.clear();
+  }
+
+  clear() {
+    fs.rmSync(this._rootDir, { recursive: true, force: true });
+    fs.mkdirSync(this._rootDir);
+  }
+
+  #createDirIfNotExists(dirPath: string) {
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    }
+  }
+}
+
+export class FileSystemRead {
+  #fileSystemClient: FileSystem;
+
+  constructor(fileSystemClient: FileSystem) {
+    this.#fileSystemClient = fileSystemClient;
+  }
+
+  readAppFile(relativePath: string): string {
+    if (path.isAbsolute(relativePath)) {
+      throw new Error(`path must be relative, got "${relativePath}"`);
+    }
+    const appDirectory = this.#fileSystemClient.getAppDirectory();
+    if (appDirectory == null) {
+      throw new Error('app directory does not exist yet — seed it with withAppFile or withAppConfigFile first');
+    }
+    const resolved = path.resolve(appDirectory, relativePath);
+    if (resolved !== appDirectory && !resolved.startsWith(appDirectory + path.sep)) {
+      throw new Error(`path escapes app directory: "${relativePath}"`);
+    }
+    return fs.readFileSync(resolved, 'utf-8');
+  }
+
+  readAppFileAsObject(relativePath: string): any {
+    const str = this.readAppFile(relativePath);
+    try {
+      return JSON.parse(str);
+    } catch (e: any) {
+      throw new Error(`Failed to parse JSON file "${relativePath}": ${e.message}`);
+    }
+  }
+
+  readAppConfigFile() {
+    return this.readAppFileAsObject('.clever.json');
+  }
+
+  readConfigFile() {
+    const file = this.#fileSystemClient.getConfigFile();
+    if (file == null) {
+      throw new Error('config file does not exist yet — seed it with withConfigFile');
+    }
+    const str = fs.readFileSync(file, 'utf-8');
+    try {
+      return JSON.parse(str);
+    } catch (e: any) {
+      throw new Error(`Failed to parse JSON file "${file}": ${e.message}`);
+    }
+  }
+
+  readExperimentalFeaturesFile() {
+    const file = this.#fileSystemClient.getExperimentalFeaturesFile();
+    if (file == null) {
+      throw new Error('experimental features file does not exist yet — seed it with withExperimentalFeaturesFile');
+    }
+    const str = fs.readFileSync(file, 'utf-8');
+    try {
+      return JSON.parse(str);
+    } catch (e: any) {
+      throw new Error(`Failed to parse JSON file "${file}": ${e.message}`);
+    }
+  }
+
+  readIdsCacheFile() {
+    const file = this.#fileSystemClient.getIdsCacheFile();
+    if (file == null) {
+      throw new Error('ids cache file does not exist yet — seed it with withIdsCacheFile');
+    }
+    const str = fs.readFileSync(file, 'utf-8');
+    try {
+      return JSON.parse(str);
+    } catch (e: any) {
+      throw new Error(`Failed to parse JSON file "${file}": ${e.message}`);
+    }
+  }
+}

--- a/test/mocks/git-repo.ts
+++ b/test/mocks/git-repo.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process';
+
+export class GitRepo {
+  private readonly _branch = 'master';
+  private readonly _remoteUrl: string;
+  private readonly _rootDir: string;
+  private _headCommit: string | undefined;
+
+  constructor(serverUrl: string, directory: string, appId: string) {
+    this._remoteUrl = `${serverUrl}/${appId}.git`;
+    this._rootDir = directory;
+
+    git(this._rootDir, 'init', '--initial-branch', this._branch);
+    git(this._rootDir, 'config', 'user.name', 'clever-tools-test');
+    git(this._rootDir, 'config', 'user.email', 'test@clever.cloud');
+    git(this._rootDir, 'config', 'commit.gpgsign', 'false');
+  }
+
+  get remoteUrl() {
+    return this._remoteUrl;
+  }
+
+  get headCommit() {
+    return this._headCommit;
+  }
+
+  commitAll(message = 'commit all') {
+    git(this._rootDir, 'add', '--all');
+    git(this._rootDir, 'commit', '-v', '-m', message);
+    this._headCommit = git(this._rootDir, 'rev-parse', 'HEAD');
+    return this._headCommit;
+  }
+
+  push() {
+    return git(this._rootDir, 'push', this._remoteUrl, `${this._branch}:refs/heads/${this._branch}`);
+  }
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}

--- a/test/mocks/git-server.ts
+++ b/test/mocks/git-server.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Worker } from 'node:worker_threads';
+
+export interface GitServer {
+  client: GitClient;
+  stop: () => Promise<void>;
+}
+
+export async function startGitServer(): Promise<GitServer> {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clever-tools-git-'));
+
+  const worker = new Worker(new URL('./git-server.worker.ts', import.meta.url), {
+    workerData: { root: rootDir },
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    worker.once('message', (msg) => {
+      if (msg?.type === 'ready' && typeof msg.port === 'number') resolve(msg.port);
+      else reject(new Error(`unexpected worker message: ${JSON.stringify(msg)}`));
+    });
+    worker.once('error', reject);
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  return {
+    client: new GitClient(baseUrl, rootDir),
+    async stop() {
+      worker.postMessage({ type: 'close' });
+      await new Promise((resolve) => worker.once('exit', resolve));
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export class GitClient {
+  private readonly _baseUrl: string;
+  private readonly _rootDir: string;
+
+  constructor(baseUrl: string, rootDir: string) {
+    this._baseUrl = baseUrl;
+    this._rootDir = rootDir;
+  }
+
+  get baseUrl() {
+    return this._baseUrl;
+  }
+
+  getRepoUrl(appId: string): string {
+    return `${this._baseUrl}/${appId}.git`;
+  }
+
+  addRepo(appId: string): string {
+    const repoDir = path.join(this._rootDir, `${appId}.git`);
+    fs.mkdirSync(repoDir, { recursive: true });
+    git(repoDir, 'init', '--bare');
+    // `git http-backend` rejects push (`git-receive-pack`) with 403 unless
+    // the repo is explicitly marked as accepting it.
+    git(repoDir, 'config', 'http.receivepack', 'true');
+    return `${this._baseUrl}/${appId}.git`;
+  }
+
+  reset() {
+    fs.rmSync(this._rootDir, { recursive: true, force: true });
+    fs.mkdirSync(this._rootDir);
+  }
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}

--- a/test/mocks/git-server.worker.ts
+++ b/test/mocks/git-server.worker.ts
@@ -1,0 +1,113 @@
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import { parentPort, workerData } from 'node:worker_threads';
+
+const { root } = workerData as { root: string };
+
+const server = http.createServer((req, res) => handle(req, res, root));
+
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address() as { port: number };
+  parentPort?.postMessage({ type: 'ready', port });
+});
+
+parentPort?.on('message', (msg) => {
+  if (msg?.type === 'close') {
+    server.close(() => process.exit(0));
+  }
+});
+
+function handle(req: http.IncomingMessage, res: http.ServerResponse, projectRoot: string) {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+
+  const ps = spawn('git', ['http-backend'], {
+    env: {
+      ...process.env,
+      GIT_PROJECT_ROOT: projectRoot,
+      // Bypass the per-repo `git-daemon-export-ok` marker file requirement.
+      GIT_HTTP_EXPORT_ALL: '1',
+      PATH_INFO: url.pathname,
+      QUERY_STRING: url.search.slice(1),
+      REQUEST_METHOD: req.method ?? 'GET',
+      CONTENT_TYPE: (req.headers['content-type'] ?? '') as string,
+      CONTENT_LENGTH: (req.headers['content-length'] ?? '') as string,
+    },
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+
+  ps.on('error', (err) => fail(res, err));
+  req.pipe(ps.stdin);
+  pipeCgiResponse(ps.stdout, res);
+}
+
+/**
+ * Read the CGI header block from `stdout`, apply it to `res`, then pipe the
+ * remaining body. CGI headers end at the first blank line (`\r\n\r\n` per
+ * spec, but we tolerate `\n\n` for robustness).
+ */
+function pipeCgiResponse(stdout: NodeJS.ReadableStream, res: http.ServerResponse) {
+  let buf = Buffer.alloc(0);
+  let headersDone = false;
+
+  const onData = (chunk: Buffer) => {
+    buf = Buffer.concat([buf, chunk]);
+    const sep = findHeaderEnd(buf);
+    if (sep == null) return;
+
+    const [idx, len] = sep;
+    applyCgiHeaders(res, buf.subarray(0, idx).toString('utf-8'));
+    const rest = buf.subarray(idx + len);
+
+    headersDone = true;
+    stdout.off('data', onData);
+
+    if (rest.length > 0) res.write(rest);
+    stdout.pipe(res);
+  };
+
+  stdout.on('data', onData);
+  stdout.on('end', () => {
+    if (!headersDone && !res.headersSent) {
+      res.statusCode = 500;
+      res.end('git http-backend produced no output\n');
+    }
+  });
+}
+
+function findHeaderEnd(buf: Buffer): [number, number] | null {
+  const crlf = buf.indexOf('\r\n\r\n');
+  const lf = buf.indexOf('\n\n');
+  if (crlf < 0 && lf < 0) return null;
+  if (crlf < 0) return [lf, 2];
+  if (lf < 0) return [crlf, 4];
+  return crlf < lf ? [crlf, 4] : [lf, 2];
+}
+
+function applyCgiHeaders(res: http.ServerResponse, block: string) {
+  for (const line of block.split(/\r?\n/)) {
+    if (line === '') continue;
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const name = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    // CGI's `Status:` header maps onto the HTTP status line.
+    if (name.toLowerCase() === 'status') {
+      const m = /^(\d+)(?:\s+(.*))?$/.exec(value);
+      if (m) {
+        res.statusCode = Number(m[1]);
+        if (m[2]) res.statusMessage = m[2];
+      }
+    } else {
+      res.setHeader(name, value);
+    }
+  }
+}
+
+function fail(res: http.ServerResponse, err: Error) {
+  if (res.headersSent) {
+    res.destroy(err);
+    return;
+  }
+  res.statusCode = 500;
+  res.end(String(err) + '\n');
+}

--- a/test/mocks/redis-server-mock.ts
+++ b/test/mocks/redis-server-mock.ts
@@ -1,0 +1,105 @@
+import net from 'node:net';
+
+export interface MockRedisServer {
+  url: string;
+  received: string[][];
+  setReply: (command: string, respReply: string) => void;
+  reset: () => void;
+  close: () => Promise<void>;
+}
+
+const OK_REPLY = '+OK\r\n';
+// ioredis only inspects `loading:` in the INFO reply; absence is treated as ready.
+const INFO_REPLY = bulkString('# Server\r\nredis_version:7.0.0\r\nrole:master\r\n');
+
+/**
+ * Start a minimal RESP-protocol TCP server for testing the kv command.
+ * Handles RESP2 array-of-bulk-strings requests (what ioredis sends).
+ *
+ * `CLIENT *` and `INFO` are sent by ioredis on connect; they are auto-acknowledged
+ * and not recorded in `received`. Every other command is recorded and answered
+ * with the scripted reply, falling back to `+OK\r\n`.
+ */
+export async function startMockRedisServer(): Promise<MockRedisServer> {
+  const replies = new Map<string, string>();
+  const received: string[][] = [];
+
+  const server = net.createServer((socket) => {
+    let buffer = Buffer.alloc(0);
+    socket.on('data', (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (true) {
+        const frame = parseFrame(buffer);
+        if (frame == null) break;
+        buffer = buffer.subarray(frame.end);
+
+        const [verb, ...rest] = frame.args;
+        const upper = verb.toUpperCase();
+
+        if (upper === 'CLIENT') {
+          socket.write(OK_REPLY);
+          continue;
+        }
+        if (upper === 'INFO') {
+          socket.write(INFO_REPLY);
+          continue;
+        }
+
+        received.push([verb, ...rest]);
+        const fullKey = [upper, ...rest].join(' ');
+        const reply = replies.get(fullKey) ?? replies.get(upper) ?? OK_REPLY;
+        socket.write(reply);
+      }
+    });
+    socket.on('error', () => {});
+  });
+
+  await new Promise<void>((resolve) => server.listen({ port: 0, host: '127.0.0.1' }, () => resolve()));
+  const { port } = server.address() as net.AddressInfo;
+
+  return {
+    url: `redis://127.0.0.1:${port}`,
+    received,
+    setReply(command, respReply) {
+      const [verb, ...rest] = command.split(' ');
+      const key = [verb.toUpperCase(), ...rest].join(' ');
+      replies.set(key, respReply);
+    },
+    reset() {
+      replies.clear();
+      received.length = 0;
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/**
+ * Parse one RESP array-of-bulk-strings frame.
+ */
+function parseFrame(buf: Buffer): { args: string[]; end: number } | null {
+  if (buf.length === 0 || buf[0] !== 0x2a /* '*' */) return null;
+  const eol = buf.indexOf('\r\n');
+  if (eol === -1) return null;
+  const count = Number.parseInt(buf.toString('ascii', 1, eol), 10);
+  let pos = eol + 2;
+  const args: string[] = [];
+  for (let i = 0; i < count; i++) {
+    if (buf.length <= pos || buf[pos] !== 0x24 /* '$' */) return null;
+    const lenEnd = buf.indexOf('\r\n', pos);
+    if (lenEnd === -1) return null;
+    const len = Number.parseInt(buf.toString('ascii', pos + 1, lenEnd), 10);
+    pos = lenEnd + 2;
+    if (buf.length < pos + len + 2) return null;
+    args.push(buf.toString('utf8', pos, pos + len));
+    pos += len + 2;
+  }
+  return { args, end: pos };
+}
+
+function bulkString(s: string): string {
+  return `$${Buffer.byteLength(s)}\r\n${s}\r\n`;
+}

--- a/test/reporter/reporter.ts
+++ b/test/reporter/reporter.ts
@@ -1,0 +1,76 @@
+import path from 'node:path';
+import type { TestEvent } from 'node:test/reporters';
+import { styleText } from 'node:util';
+
+const green = (s: string) => styleText('green', s, { validateStream: false });
+const red = (s: string) => styleText('red', s, { validateStream: false });
+const yellow = (s: string) => styleText('yellow', s, { validateStream: false });
+const dim = (s: string) => styleText('dim', s, { validateStream: false });
+
+interface Failure {
+  name: string;
+  file: string;
+  line: number | undefined;
+  column: number | undefined;
+  error: unknown;
+}
+
+export default async function* reporter(source: AsyncGenerator<TestEvent, void>) {
+  const failures: Failure[] = [];
+  let pass = 0;
+  let fail = 0;
+  let skip = 0;
+  let cancelled = 0;
+  const startedAt = Date.now();
+  const cwd = process.cwd();
+
+  for await (const event of source) {
+    if (event.type !== 'test:pass' && event.type !== 'test:fail') continue;
+    if (event.data.details?.type === 'suite') continue;
+
+    const { name, file, line, column, details } = event.data;
+    const skipped = event.data.skip || event.data.todo;
+    const ms = Math.round(details?.duration_ms ?? 0);
+    const rel = file ? dim(path.relative(cwd, file)) + ' ' : '';
+
+    if (skipped) {
+      skip++;
+      yield `${yellow('-')} ${rel}${name} ${dim('(skipped)')}\n`;
+    } else if (event.type === 'test:pass') {
+      pass++;
+      yield `${green('✓')} ${rel}${name} ${dim(`(${ms}ms)`)}\n`;
+    } else {
+      const error = event.data.details?.error;
+      const errAny = error as any;
+      const isCancelled = errAny?.failureType === 'cancelledByParent' || errAny?.cause?.code === 'ERR_TEST_CANCELLED';
+      if (isCancelled) {
+        cancelled++;
+        yield `${yellow('!')} ${rel}${name} ${dim('(cancelled)')}\n`;
+      } else {
+        fail++;
+        failures.push({ name, file: file ? path.relative(cwd, file) : '', line, column, error });
+        yield `${red('✗')} ${rel}${name} ${dim(`(${ms}ms)`)}\n`;
+      }
+    }
+  }
+
+  const totalSec = ((Date.now() - startedAt) / 1000).toFixed(2);
+  const total = pass + fail + skip + cancelled;
+
+  yield `\n${dim('─'.repeat(40))}\n`;
+  yield `Total: ${total}  ${green(`pass: ${pass}`)}  ${red(`fail: ${fail}`)}  ${yellow(`skip: ${skip}`)}  ${yellow(`cancelled: ${cancelled}`)}  ${dim(`(${totalSec}s)`)}\n`;
+
+  if (failures.length > 0) {
+    yield `\n${red('Failures:')}\n`;
+    for (const f of failures) {
+      const err = f.error as any;
+      yield `\n${red(`✗ ${f.name}`)}\n`;
+      yield `  ${dim(`at ${f.file}:${f.line}:${f.column}`)}\n`;
+      const stack: string = err?.cause?.stack ?? err?.stack ?? String(f.error);
+      yield stack
+        .split('\n')
+        .map((l: string) => `  ${l}`)
+        .join('\n') + '\n';
+    }
+  }
+}

--- a/test/tests-checklist.md
+++ b/test/tests-checklist.md
@@ -1,0 +1,72 @@
+# Test checklist for `*.command.test.js`
+
+When you write or update a `*.command.test.js`, every rule in §1, §2, §4, §5, §6 applies. Rules in §3 only apply to commands with the matching capability — read the command's source first to know which sub-sections kick in.
+
+References use repo-relative paths and line ranges. Open them to copy the exact pattern.
+
+## 1. File skeleton
+
+- Before writing anything, look for an existing `*.command.test.js` covering a related command (same capability surface — writes files, streams logs, resolves an addon, interactive command, etc.) and use it as a template. The conventions below are easier to apply by pattern-matching than from scratch.
+- One top-level `describe` per command, many `it` closures inside it. Sub-`describe` blocks are fine for grouping (e.g. ID resolution variants).
+- Use the standard hooks wiring: `cliHooks()` + `before` / `beforeEach` / `after` — see `src/commands/database/database.backups.download.command.test.js:47-61`.
+
+## 2. Coverage — always
+
+- Test **all** combinations of options and args, including aliases and the case where the option is omitted — see `src/commands/database/database.backups.download.command.test.js:63-161` (`--output`, `--out`, no flag).
+- Test invalid options — see `src/commands/ssh/ssh.command.test.js:56-65`.
+- Test invalid args — see `src/commands/database/database.backups.download.command.test.js:228-239`.
+- Test invalid combinations of options and args (e.g. mutually exclusive flags) — see `src/commands/ssh/ssh.command.test.js:56-65`.
+- Test a non-2xx response for **every** API endpoint the command calls — see `src/commands/database/database.backups.download.command.test.js:201-226`.
+- When the API returns a collection, test the empty-collection case — see `src/commands/database/database.backups.download.command.test.js:187-199`.
+- Test the no-auth-state case (no profile configured): seed nothing with `.withConfigFile(...)` and assert the command errors. The `withConfigFile` mock is at `test/cli-hooks.js:91-94`.
+- When env vars change command behavior, cover that with a custom `env` block on `thenRunCli` — see `src/commands/ssh/ssh.command.test.js:174-179` (`realSshEnv()`).
+
+## 3. Coverage — gated on command capability
+
+### Commands using `AppConfiguration.addLinkedApplication`
+
+Reference for all five rules: `src/commands/ssh/ssh.command.test.js:67-106`.
+
+- Not in an app directory (no `.withAppConfigFile(...)`) → command errors.
+- App config has multiple aliases and no `--alias` is given → command errors and lists available aliases.
+- App config has multiple aliases and an unknown `--alias` is given → command errors.
+- App config has multiple aliases and an existing `--alias` is given → command succeeds.
+- App config has a single alias (no `--alias` needed) → command succeeds.
+
+### Commands resolving an org / app / addon ID
+
+Canonical reference: `src/commands/database/database.backups.download.command.test.js:270-426`.
+
+- For each ID kind the command accepts (orga id / orga name, app id / app name, addon id / addon real id / addon name), test the cache-hit path (with `.withIdsCacheFile(...)`, no `/v2/summary` call expected) and the cache-miss path (no cache file, `/v2/summary` is called).
+- Test an unknown ID that is in neither the cache nor `/v2/summary`.
+- When both an org and an app/addon are passed, test the case where the app/addon exists but not inside that org.
+
+### Commands that write files
+
+- Assert file content with `.verifyFiles((fsRead) => { ... })` — see usage at `src/commands/database/database.backups.download.command.test.js:99-129` and the `FileSystemRead` API surface (`readAppFile`, `readAppFileAsObject`, `readAppConfigFile`, `readConfigFile`, `readExperimentalFeaturesFile`, `readIdsCacheFile`) at `test/cli-hooks.js:241-326`.
+
+### Commands streaming logs / SSE
+
+- Use the `events` + `delayBetween` + final `{ type: 'close' }` pattern — see `src/commands/logs/logs.command.test.js:35-72`.
+
+### Interactive commands (prompts)
+
+- For raw-mode select / checkbox prompts (arrow keys), enable PTY mode and drive it with keypress sequences from `test/keys.js`: `thenRunCli([...], { pty: true, interactions: [{ waitFor: /…/, send: keys.DOWN + keys.ENTER }] })` — see `src/commands/profile/profile.switch.command.test.js:41-67`. Under PTY, stdout and stderr are merged into `result.output`; assert against that, not `result.stdout`.
+- For plain text / password prompts, skip PTY and just pass `interactions: [{ waitFor: /…/, send: 'value\n' }]` — see `src/commands/tokens/tokens.create.command.test.js:46-93`.
+- Cover the non-interactive bypass path too (e.g. `--alias` skipping a select prompt) — see `src/commands/profile/profile.switch.command.test.js:88-102`.
+
+## 4. Mocking API responses
+
+- To know what fields a mock must include, read the command source for what it consumes; cross-reference https://github.com/CleverCloud/clever-client.js when needed.
+- API field names are often snake_case. That's expected — disable the relevant eslint rule locally if it triggers on mock object literals.
+
+## 5. Fixtures
+
+- Shared fixtures live in `test/fixtures/`. Reuse what's there before defining new ones — see `test/fixtures/id.js` (IDs) and `test/fixtures/self.js` (SELF user).
+- Promote a local constant to `test/fixtures/` as soon as a second test file needs it.
+- When the shared shape needs per-test variation, promote it as a function that returns the fixture rather than a frozen constant — callers pass overrides (or get fresh IDs/timestamps) without copy-pasting.
+
+## 6. Assertions and output
+
+- Prefer `assert.strictEqual` over `assert.match` for `stdout` / `stderr` / file content. Use `match` only when the output is non-deterministic — see `src/commands/database/database.backups.download.command.test.js:95-96` and `:127-128`.
+- Exception: invalid-option / invalid-arg cases print the full CLI help after the error, which is long and brittle. Use `assert.match` against the error message portion instead of `strictEqual` for those.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "declarationMap": false,
     "sourceMap": false,
     "lib": ["ES2024", "ESNext.Collection"],
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "allowImportingTsExtensions": true
   },
   "include": [
     "scripts",
@@ -24,7 +25,9 @@
     "src/logger.js",
     "src/lib/fs.js",
     "src/lib/date-utils.js",
-    "src/config/*"
+    "src/config/*",
+    "test",
+    "src/**/*.test.ts"
   ],
   "exclude": ["build", "docs", "node_modules", "scripts/generate-docs.js"]
 }


### PR DESCRIPTION
## Context

The CLI ships without automated command-level coverage — every release leans on manual
smoke testing, so per-command regressions only
surface once users hit them. This branch lays down the infrastructure to drive the CLI
end-to-end against mocked API / KV / Git backends, seeds the first wave of command
tests, and wires both the suite and a per-PR coverage report into CI.

## Changes

### Test harness

- Subprocess-based `runCli` harness (`test/cli-runner.ts`) with PTY support, interactive
  prompt scripting, and per-interaction ANSI-stripped output segments.
- Reusable fixtures and mocks (`test/fixtures/*`, `test/mocks/*` covering filesystem,
  Git server, Redis, in-process API doublure).
- `CLEVER_BIN` switch so the same suite runs against the source tree locally and against
  the packaged binary in CI — catching bundling / pkg regressions a source-tree-only
  suite would miss.
- `test/tests-checklist.md` documents the conventions so new command tests stay
  consistent.

### Custom test reporter

Node's bundled reporters don't fit a large command-level suite well: TAP buffers output
and the `spec` reporter prints noisy per-file summaries. A small custom reporter at
`test/reporter/reporter.ts`, wired into the `test` npm script, gives:

- one line per test as it completes (✓ / ✗ / - / !) with relative path and duration —
  progress is visible while a long run is in flight,
- a single totals line at the end (pass / fail / skip / cancelled, elapsed seconds),
- a deferred failures block at the very end of the run with each failing test's location
  and full stack trace, so diagnostics aren't buried mid-stream.

### First-wave command coverage

Tests added for `emails`, `env import`, `login`, `logs`, `ssh`, `ssh-keys add`,
`tokens create`, `kv`, `link`, `deploy`, `curl`, `database backups download`,
`notify-email`, and `profile switch`.

### Fixes uncovered while writing the tests

- `ssh`: surface pre-marker errors instead of exiting silently.
- `ssh-keys`: don't report success when the add call fails; remove a leftover debug log.
- `tokens`: read the error code from `responseBody` directly.
- `cli`: clear `FORCE_COLOR` when disabling colors.
- `git`: pick the agent matching the URL scheme.

### Refactors that fell out of the test work

- `ssh`: extract the marker protocol into its own module.
- `config`: centralize config file paths in the schema.
- `login`: use the shared `openBrowser` helper.

### CI

- New `tests.yml` workflow builds + packages the CLI, then runs the suite against that
  binary on Linux, macOS and Windows.
- `setup-node` action caches `node_modules` so the test job skips `npm ci` on hit.
- New per-PR coverage workflow publishes the c8 report to Cellar and posts a sticky
  comment with the link on the PR.
- `scripts/lib/cellar-client.js` gains a bounded-concurrency `uploadFiles` helper used
  by the coverage publisher.

## How to review

1. Start with `test/cli-runner.ts` and `test/cli-hooks.ts` — these are the load-bearing
   pieces every command test builds on.
2. Read `test/tests-checklist.md` for the conventions, then sample one of the per-command
   test files (e.g. `src/commands/database/database.backups.download.command.test.ts`)
   to see them applied.
3. Run locally: `npm test` for the source tree, or
   `npm run build && CLEVER_BIN=<built-bin> npm test` for the packaged path.
4. The per-PR coverage workflow needs the Cellar secrets to be available on the target
   remote — the sticky `Code coverage` comment is where the report link will appear.
