### PR TITLE
k8s: more commands & options

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1675,6 +1675,72 @@ cluster-id|cluster-name                 Kubernetes cluster ID or name
     --tag <tag[,tag...]>                Replace tags (comma-separated, e.g.: env:prod,team:platform)
 ```
 
+### k8s version
+
+**Description:** Check a Kubernetes cluster deployed version
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s version <cluster-id|cluster-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
+#### k8s version check
+
+**Description:** Check a Kubernetes cluster deployed version
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s version check <cluster-id|cluster-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
+#### k8s version update
+
+**Description:** Update a Kubernetes cluster to a target version
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s version update <cluster-id|cluster-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+```
+
+**Options**
+```
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+    --target <version>                  Target version to upgrade to (e.g.: 24, 2.4, 2.4.1)
+```
+
 ## keycloak
 
 **Description:** Manage Clever Cloud Keycloak services

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -348,7 +348,7 @@ addon-id|addon-name                     Add-on ID (or name, if unambiguous)
 **Options**
 ```
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
--y, --yes                               Skip confirmation and proceed with deletion directly
+-y, --yes                               Skip confirmation prompts
 ```
 
 ### addon env
@@ -1536,7 +1536,7 @@ cluster-id|cluster-name                 Kubernetes cluster ID or name
 **Options**
 ```
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
--y, --yes                               Skip confirmation and proceed with deletion directly
+-y, --yes                               Skip confirmation prompts
 ```
 
 ### k8s get
@@ -2570,7 +2570,7 @@ consumer-key|consumer-name    OAuth consumer key (or name, if unambiguous)
 
 **Options**
 ```
--y, --yes                     Skip confirmation and proceed with deletion directly
+-y, --yes                     Skip confirmation prompts
 ```
 
 ### oauth-consumers get

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1474,6 +1474,29 @@ clever help
 clever k8s
 ```
 
+### k8s activity
+
+**Description:** Show recent deployment events of a Kubernetes cluster
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s activity <cluster-id|cluster-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+    --limit <limit>                     Number of events to fetch (1 to 1000) (default: 50)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
 ### k8s add-persistent-storage
 
 **Description:** Activate persistent storage to a deployed Kubernetes cluster

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1632,6 +1632,23 @@ clever k8s list [options]
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
+### k8s quota
+
+**Description:** Get the Kubernetes quota, usage and remaining of an organisation
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s quota [options]
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
 ### k8s update
 
 **Description:** Update a Kubernetes cluster metadata or features

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1609,6 +1609,32 @@ clever k8s list [options]
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
+### k8s update
+
+**Description:** Update a Kubernetes cluster metadata or features
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s update <cluster-id|cluster-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+```
+
+**Options**
+```
+    --autoscaling                       Enable the cluster autoscaler
+    --description <description>         Free-form cluster description
+    --disable-autoscaling               Disable the cluster autoscaler
+    --name <name>                       Rename the cluster
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+    --tag <tag[,tag...]>                Replace tags (comma-separated, e.g.: env:prod,team:platform)
+```
+
 ## keycloak
 
 **Description:** Manage Clever Cloud Keycloak services

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1508,13 +1508,23 @@ clever k8s create <cluster-name> [options]
 
 **Arguments**
 ```
-cluster-name                            Kubernetes cluster name
+cluster-name                                     Kubernetes cluster name
 ```
 
 **Options**
 ```
--o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
--w, --watch                             Watch the deployment until the cluster is deployed
+    --autoscaling                                Enable the cluster autoscaler
+    --cluster-version <cluster-version>          Kubernetes version to deploy (e.g.: 1.36)
+    --description <description>                  Free-form cluster description
+    --flavor <flavor>                            Control plane flavor
+    --nodegroup <flavor:count>                   Initial node group (format: <flavor>:<count>, e.g.: XS:3)
+-o, --org, --owner <org-id|org-name>             Organisation to target by its ID (or name, if unambiguous)
+    --persistent-storage                         Enable persistent storage (Ceph CSI)
+    --replication-factor <replication-factor>    Control plane replication factor
+    --tag <tag[,tag...]>                         Semantic tags (comma-separated, e.g.: env:prod,team:platform)
+    --topology <topology>                        Cluster topology (must be set with --flavor and --replication-factor)
+-w, --watch                                      Watch the deployment until the cluster is deployed
+-y, --yes                                        Skip confirmation prompts
 ```
 
 ### k8s delete

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1632,6 +1632,142 @@ clever k8s list [options]
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
+### k8s nodegroups
+
+**Description:** Manage Kubernetes node groups
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s nodegroups
+```
+
+#### k8s nodegroups create
+
+**Description:** Create a node group on a Kubernetes cluster
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s nodegroups create <cluster-id|cluster-name> <nodegroup-name> <flavor:count> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+nodegroup-name                          Node group name (lowercase RFC 1123, max 63 chars)
+flavor:count                            Node group flavor and target node count (format: <flavor>:<count>, e.g.: XS:3)
+```
+
+**Options**
+```
+    --autoscaling                       Enable cluster autoscaler for this node group (requires --min and --max)
+    --description <description>         Free-form node group description
+    --max <max>                         Maximum node count when autoscaling is enabled
+    --min <min>                         Minimum node count when autoscaling is enabled
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+    --tag <tag>                         Arbitrary tag attached to the node group
+```
+
+#### k8s nodegroups delete
+
+**Description:** Delete a node group from a Kubernetes cluster
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s nodegroups delete <cluster-id|cluster-name> <nodegroup-id|nodegroup-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+nodegroup-id|nodegroup-name             Kubernetes node group ID or name
+```
+
+**Options**
+```
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+-y, --yes                               Skip confirmation prompts
+```
+
+#### k8s nodegroups get
+
+**Description:** Get information about a Kubernetes node group
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s nodegroups get <cluster-id|cluster-name> <nodegroup-id|nodegroup-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+nodegroup-id|nodegroup-name             Kubernetes node group ID or name
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
+#### k8s nodegroups list
+
+**Description:** List the node groups of a Kubernetes cluster
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s nodegroups list <cluster-id|cluster-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+```
+
+**Options**
+```
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+```
+
+#### k8s nodegroups update
+
+**Description:** Update a node group on a Kubernetes cluster
+
+**Since:** unreleased
+
+**Usage**
+```
+clever k8s nodegroups update <cluster-id|cluster-name> <nodegroup-id|nodegroup-name> [options]
+```
+
+**Arguments**
+```
+cluster-id|cluster-name                 Kubernetes cluster ID or name
+nodegroup-id|nodegroup-name             Kubernetes node group ID or name
+```
+
+**Options**
+```
+    --autoscaling                       Enable the cluster autoscaler
+    --count <count>                     Target node count
+    --description <description>         Free-form node group description
+    --disable-autoscaling               Disable the cluster autoscaler
+    --max <max>                         Maximum node count (autoscaling bound)
+    --min <min>                         Minimum node count (autoscaling bound)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+    --tag <tag>                         Arbitrary tag attached to the node group
+```
+
 ### k8s quota
 
 **Description:** Get the Kubernetes quota, usage and remaining of an organisation

--- a/src/clever-client/k8s.js
+++ b/src/clever-client/k8s.js
@@ -17,6 +17,23 @@ export function createK8sCluster(params, body) {
 }
 
 /**
+ * PATCH /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {Object} body
+ */
+export function updateK8sCluster(params, body) {
+  return Promise.resolve({
+    method: 'PATCH',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}`,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    // no queryParams
+    body,
+  });
+}
+
+/**
  * DELETE /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}
  * @param {Object} params
  * @param {String} params.ownerId
@@ -89,6 +106,186 @@ export function addK8sPersistentStorage(params) {
   return Promise.resolve({
     method: 'post',
     url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/csi/ceph`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * PATCH /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/node-groups/{nodeGroupId}
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {String} params.nodeGroupId
+ * @param {Object} body
+ */
+export function updateK8sNodeGroup(params, body) {
+  return Promise.resolve({
+    method: 'PATCH',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/node-groups/${params.nodeGroupId}`,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    // no queryParams
+    body,
+  });
+}
+
+/**
+ * DELETE /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/node-groups/{nodeGroupId}
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {String} params.nodeGroupId
+ */
+export function deleteK8sNodeGroup(params) {
+  return Promise.resolve({
+    method: 'delete',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/node-groups/${params.nodeGroupId}`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * POST /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/node-groups
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {Object} body
+ */
+export function createK8sNodeGroup(params, body) {
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/node-groups`,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    // no queryParams
+    body,
+  });
+}
+
+/**
+ * GET /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/node-groups
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ */
+export function listK8sNodeGroups(params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/node-groups`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * GET /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/node-groups/{nodeGroupId}
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {String} params.nodeGroupId
+ */
+export function getK8sNodeGroup(params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/node-groups/${params.nodeGroupId}`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * GET /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/deployment-events
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {Object} [queryParams]
+ * @param {Number} [queryParams.limit]
+ */
+export function listK8sDeploymentEvents(params, queryParams = {}) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/deployment-events`,
+    headers: { Accept: 'application/json' },
+    queryParams,
+    // no body
+  });
+}
+
+/**
+ * GET /v4/kubernetes-product
+ */
+export function getK8sProduct() {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes-product`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * GET /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/version/check
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ */
+export function getK8sVersionCheck(params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/version/check`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * POST /v4/kubernetes/organisations/{ownerId}/clusters/{clusterId}/version/update
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.clusterId
+ * @param {Object} body
+ * @param {String} body.targetVersion
+ */
+export function updateK8sVersion(params, body) {
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/clusters/${params.clusterId}/version/update`,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    // no queryParams
+    body,
+  });
+}
+
+/**
+ * GET /v4/kubernetes/organisations/{ownerId}/quota
+ * @param {Object} params
+ * @param {String} params.ownerId
+ */
+export function getK8sQuota(params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/quota`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * GET /v4/kubernetes/organisations/{ownerId}/usage
+ * @param {Object} params
+ * @param {String} params.ownerId
+ */
+export function listK8sUsage(params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/kubernetes/organisations/${params.ownerId}/usage`,
     headers: { Accept: 'application/json' },
     // no queryParams
     // no body

--- a/src/commands/addon/addon.docs.md
+++ b/src/commands/addon/addon.docs.md
@@ -62,7 +62,7 @@ clever addon delete <addon-id|addon-name> [options]
 |Name|Description|
 |---|---|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
-|`-y`, `--yes`|Skip confirmation and proceed with deletion directly|
+|`-y`, `--yes`|Skip confirmation prompts|
 
 ## ➡️ `clever addon env` <kbd>Since 2.11.0</kbd>
 

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -70,6 +70,7 @@ import { k8sDeleteCommand } from './k8s/k8s.delete.command.js';
 import { k8sGetKubeconfigCommand } from './k8s/k8s.get-kubeconfig.command.js';
 import { k8sGetCommand } from './k8s/k8s.get.command.js';
 import { k8sListCommand } from './k8s/k8s.list.command.js';
+import { k8sQuotaCommand } from './k8s/k8s.quota.command.js';
 import { k8sUpdateCommand } from './k8s/k8s.update.command.js';
 import { keycloakCommand } from './keycloak/keycloak.command.js';
 import { keycloakDisableNgCommand } from './keycloak/keycloak.disable-ng.command.js';
@@ -303,6 +304,7 @@ export const globalCommands = {
       get: k8sGetCommand,
       'get-kubeconfig': k8sGetKubeconfigCommand,
       list: k8sListCommand,
+      quota: k8sQuotaCommand,
       update: k8sUpdateCommand,
     },
   ],

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -69,6 +69,7 @@ import { k8sDeleteCommand } from './k8s/k8s.delete.command.js';
 import { k8sGetKubeconfigCommand } from './k8s/k8s.get-kubeconfig.command.js';
 import { k8sGetCommand } from './k8s/k8s.get.command.js';
 import { k8sListCommand } from './k8s/k8s.list.command.js';
+import { k8sUpdateCommand } from './k8s/k8s.update.command.js';
 import { keycloakCommand } from './keycloak/keycloak.command.js';
 import { keycloakDisableNgCommand } from './keycloak/keycloak.disable-ng.command.js';
 import { keycloakEnableNgCommand } from './keycloak/keycloak.enable-ng.command.js';
@@ -300,6 +301,7 @@ export const globalCommands = {
       get: k8sGetCommand,
       'get-kubeconfig': k8sGetKubeconfigCommand,
       list: k8sListCommand,
+      update: k8sUpdateCommand,
     },
   ],
   keycloak: [

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -72,6 +72,9 @@ import { k8sGetCommand } from './k8s/k8s.get.command.js';
 import { k8sListCommand } from './k8s/k8s.list.command.js';
 import { k8sQuotaCommand } from './k8s/k8s.quota.command.js';
 import { k8sUpdateCommand } from './k8s/k8s.update.command.js';
+import { k8sVersionCheckCommand } from './k8s/k8s.version.check.command.js';
+import { k8sVersionCommand } from './k8s/k8s.version.command.js';
+import { k8sVersionUpdateCommand } from './k8s/k8s.version.update.command.js';
 import { keycloakCommand } from './keycloak/keycloak.command.js';
 import { keycloakDisableNgCommand } from './keycloak/keycloak.disable-ng.command.js';
 import { keycloakEnableNgCommand } from './keycloak/keycloak.enable-ng.command.js';
@@ -306,6 +309,13 @@ export const globalCommands = {
       list: k8sListCommand,
       quota: k8sQuotaCommand,
       update: k8sUpdateCommand,
+      version: [
+        k8sVersionCommand,
+        {
+          check: k8sVersionCheckCommand,
+          update: k8sVersionUpdateCommand,
+        },
+      ],
     },
   ],
   keycloak: [

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -70,6 +70,12 @@ import { k8sDeleteCommand } from './k8s/k8s.delete.command.js';
 import { k8sGetKubeconfigCommand } from './k8s/k8s.get-kubeconfig.command.js';
 import { k8sGetCommand } from './k8s/k8s.get.command.js';
 import { k8sListCommand } from './k8s/k8s.list.command.js';
+import { k8sNodeGroupCommand } from './k8s/k8s.nodegroups.command.js';
+import { k8sNodeGroupCreateCommand } from './k8s/k8s.nodegroups.create.command.js';
+import { k8sNodeGroupDeleteCommand } from './k8s/k8s.nodegroups.delete.command.js';
+import { k8sNodeGroupGetCommand } from './k8s/k8s.nodegroups.get.command.js';
+import { k8sNodeGroupListCommand } from './k8s/k8s.nodegroups.list.command.js';
+import { k8sNodeGroupUpdateCommand } from './k8s/k8s.nodegroups.update.command.js';
 import { k8sQuotaCommand } from './k8s/k8s.quota.command.js';
 import { k8sUpdateCommand } from './k8s/k8s.update.command.js';
 import { k8sVersionCheckCommand } from './k8s/k8s.version.check.command.js';
@@ -307,6 +313,16 @@ export const globalCommands = {
       get: k8sGetCommand,
       'get-kubeconfig': k8sGetKubeconfigCommand,
       list: k8sListCommand,
+      nodegroups: [
+        k8sNodeGroupCommand,
+        {
+          create: k8sNodeGroupCreateCommand,
+          delete: k8sNodeGroupDeleteCommand,
+          get: k8sNodeGroupGetCommand,
+          list: k8sNodeGroupListCommand,
+          update: k8sNodeGroupUpdateCommand,
+        },
+      ],
       quota: k8sQuotaCommand,
       update: k8sUpdateCommand,
       version: [

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -62,6 +62,7 @@ import { featuresEnableCommand } from './features/features.enable.command.js';
 import { featuresInfoCommand } from './features/features.info.command.js';
 import { featuresListCommand } from './features/features.list.command.js';
 import { helpCommand } from './help/help.command.js';
+import { k8sActivityCommand } from './k8s/k8s.activity.command.js';
 import { k8sAddPersistentStorageCommand } from './k8s/k8s.add-persistent-storage.command.js';
 import { k8sCommand } from './k8s/k8s.command.js';
 import { k8sCreateCommand } from './k8s/k8s.create.command.js';
@@ -295,6 +296,7 @@ export const globalCommands = {
   k8s: [
     k8sCommand,
     {
+      activity: k8sActivityCommand,
       'add-persistent-storage': k8sAddPersistentStorageCommand,
       create: k8sCreateCommand,
       delete: k8sDeleteCommand,

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -70,7 +70,7 @@ export const humanJsonOutputFormatOption = defineOption({
 export const skipConfirmationOption = defineOption({
   name: 'yes',
   schema: z.boolean().default(false),
-  description: 'Skip confirmation and proceed with deletion directly',
+  description: 'Skip confirmation prompts',
   aliases: ['y'],
 });
 

--- a/src/commands/k8s/k8s.activity.command.js
+++ b/src/commands/k8s/k8s.activity.command.js
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { k8sListActivity } from '../../lib/k8s.js';
+import { Logger } from '../../logger.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sActivityCommand = defineCommand({
+  description: 'Show recent deployment events of a Kubernetes cluster',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+    limit: defineOption({
+      name: 'limit',
+      schema: z.coerce.number().int().min(1).max(1000).default(50),
+      description: 'Number of events to fetch (1 to 1000)',
+      placeholder: 'limit',
+    }),
+  },
+  args: [k8sIdOrNameArg],
+  async handler(options, clusterIdOrName) {
+    const { format, org: orgIdOrName, limit } = options;
+    const events = await k8sListActivity(orgIdOrName, clusterIdOrName, limit);
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(events);
+        break;
+      case 'human':
+      default:
+        if (events.length === 0) {
+          Logger.println('🔎 No deployment event found');
+          return;
+        }
+        console.table(
+          events.map((e) => ({
+            Date: formatDate(e.createdAt),
+            Operation: e.operation,
+            Step: e.stepName ?? '-',
+            Status: e.status,
+          })),
+        );
+        break;
+    }
+  },
+});
+
+function formatDate(iso) {
+  if (iso == null) return '-';
+  return `${iso.slice(0, 19).replace('T', ' ')}Z`;
+}

--- a/src/commands/k8s/k8s.args.js
+++ b/src/commands/k8s/k8s.args.js
@@ -7,3 +7,9 @@ export const k8sIdOrNameArg = defineArgument({
   description: 'Kubernetes cluster ID or name',
   placeholder: 'cluster-id|cluster-name',
 });
+
+export const k8sNodeGroupIdOrNameArg = defineArgument({
+  schema: z.string(),
+  description: 'Kubernetes node group ID or name',
+  placeholder: 'nodegroup-id|nodegroup-name',
+});

--- a/src/commands/k8s/k8s.create.command.js
+++ b/src/commands/k8s/k8s.create.command.js
@@ -3,10 +3,11 @@ import { typewriterLogo } from '../../lib/ascii.js';
 import { defineArgument } from '../../lib/define-argument.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { defineOption } from '../../lib/define-option.js';
-import { getK8sCluster, k8sCreate } from '../../lib/k8s.js';
+import { getK8sCluster, k8sCreate, k8sGetProduct } from '../../lib/k8s.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import { orgaIdOrNameOption } from '../global.options.js';
+import { flavorCount, tags } from '../../parsers.js';
+import { orgaIdOrNameOption, skipConfirmationOption } from '../global.options.js';
 
 const DEPLOY_POLL_DELAY_MS = 10000;
 
@@ -14,6 +15,78 @@ export const k8sCreateCommand = defineCommand({
   description: 'Create a Kubernetes cluster',
   since: '4.3.0',
   options: {
+    clusterVersion: defineOption({
+      name: 'cluster-version',
+      schema: z.string().optional(),
+      description: 'Kubernetes version to deploy (e.g.: 1.36)',
+      placeholder: 'cluster-version',
+      complete: async () => {
+        const product = await k8sGetProduct();
+        return product.versions?.available ?? [];
+      },
+    }),
+    description: defineOption({
+      name: 'description',
+      schema: z.string().max(4096).optional(),
+      description: 'Free-form cluster description',
+      placeholder: 'description',
+    }),
+    tag: defineOption({
+      name: 'tag',
+      schema: z.string().transform(tags).optional(),
+      description: 'Semantic tags (comma-separated, e.g.: env:prod,team:platform)',
+      placeholder: 'tag[,tag...]',
+    }),
+    autoscaling: defineOption({
+      name: 'autoscaling',
+      schema: z.boolean().default(false),
+      description: 'Enable the cluster autoscaler',
+    }),
+    persistentStorage: defineOption({
+      name: 'persistent-storage',
+      schema: z.boolean().default(false),
+      description: 'Enable persistent storage (Ceph CSI)',
+    }),
+    topology: defineOption({
+      name: 'topology',
+      schema: z
+        .string()
+        .transform((v) => v.toUpperCase())
+        .optional(),
+      description: 'Cluster topology (must be set with --flavor and --replication-factor)',
+      placeholder: 'topology',
+      complete: async () => {
+        const product = await k8sGetProduct();
+        return (product.topologies ?? []).map((t) => t.topology);
+      },
+    }),
+    flavor: defineOption({
+      name: 'flavor',
+      schema: z
+        .string()
+        .transform((v) => v.toUpperCase())
+        .optional(),
+      description: 'Control plane flavor',
+      placeholder: 'flavor',
+      complete: async () => {
+        const product = await k8sGetProduct();
+        const flavors = new Set((product.topologies ?? []).flatMap((t) => t.availableFlavors ?? []));
+        return [...flavors];
+      },
+    }),
+    replicationFactor: defineOption({
+      name: 'replication-factor',
+      schema: z.coerce.number().int().optional(),
+      description: 'Control plane replication factor',
+      placeholder: 'replication-factor',
+    }),
+    nodeGroup: defineOption({
+      name: 'nodegroup',
+      schema: z.string().transform(flavorCount).optional(),
+      description: 'Initial node group (format: <flavor>:<count>, e.g.: XS:3)',
+      placeholder: 'flavor:count',
+    }),
+    yes: skipConfirmationOption,
     watch: defineOption({
       name: 'watch',
       schema: z.boolean().default(false),
@@ -34,7 +107,18 @@ export const k8sCreateCommand = defineCommand({
     const orgIdOrName = options.org;
 
     try {
-      const cluster = await k8sCreate(clusterName, orgIdOrName);
+      const cluster = await k8sCreate(clusterName, orgIdOrName, {
+        version: options.clusterVersion,
+        description: options.description,
+        tags: options.tag,
+        autoscaling: options.autoscaling,
+        persistentStorage: options.persistentStorage,
+        topology: options.topology,
+        flavor: options.flavor,
+        replicationFactor: options.replicationFactor,
+        nodeGroup: options.nodeGroup,
+        yes: options.yes,
+      });
 
       if (options.watch) {
         await typewriterLogo();

--- a/src/commands/k8s/k8s.delete.command.js
+++ b/src/commands/k8s/k8s.delete.command.js
@@ -1,6 +1,6 @@
 import { defineCommand } from '../../lib/define-command.js';
 import { k8sDelete } from '../../lib/k8s.js';
-import { confirm } from '../../lib/prompts.js';
+import { ask } from '../../lib/prompts.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import { orgaIdOrNameOption, skipConfirmationOption } from '../global.options.js';
@@ -15,26 +15,21 @@ export const k8sDeleteCommand = defineCommand({
   },
   args: [k8sIdOrNameArg],
   async handler(options, clusterIdOrName) {
-    const { org: orgIdOrName, yes: confirmDeletion } = options;
+    const { org: orgIdOrName, yes } = options;
+    const display = clusterIdOrName.addon_name || clusterIdOrName.operator_id;
 
-    let proceedDeletion;
-    if (confirmDeletion) {
-      proceedDeletion = true;
-    } else {
-      proceedDeletion = await confirm(
-        `Are you sure you want to delete the Kubernetes cluster ${styleText(
-          'blue',
-          clusterIdOrName.addon_name || clusterIdOrName.operator_id,
-        )}?`,
-        'Kubernetes cluster deletion cancelled.',
+    if (!yes) {
+      const proceed = await ask(
+        `Are you sure you want to delete the Kubernetes cluster ${styleText('blue', display)}?`,
+        false,
       );
+      if (!proceed) {
+        Logger.println('Kubernetes cluster deletion cancelled');
+        return;
+      }
     }
 
-    if (proceedDeletion) {
-      await k8sDelete(orgIdOrName, clusterIdOrName);
-      Logger.printSuccess(
-        `Kubernetes cluster ${styleText('green', clusterIdOrName.addon_name || clusterIdOrName.operator_id)} successfully deleted`,
-      );
-    }
+    await k8sDelete(orgIdOrName, clusterIdOrName);
+    Logger.printSuccess(`Kubernetes cluster ${styleText('green', display)} successfully deleted`);
   },
 });

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -72,7 +72,7 @@ clever k8s delete <cluster-id|cluster-name> [options]
 |Name|Description|
 |---|---|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
-|`-y`, `--yes`|Skip confirmation and proceed with deletion directly|
+|`-y`, `--yes`|Skip confirmation prompts|
 
 ## ➡️ `clever k8s get` <kbd>Since 4.3.0</kbd>
 

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -12,6 +12,28 @@ Manage Kubernetes clusters
 clever k8s
 ```
 
+## ➡️ `clever k8s activity` <kbd>Since unreleased</kbd>
+
+Show recent deployment events of a Kubernetes cluster
+
+```bash
+clever k8s activity <cluster-id|cluster-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`--limit` `<limit>`|Number of events to fetch (1 to 1000) (default: 50)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
 ## ➡️ `clever k8s add-persistent-storage` <kbd>Since 4.3.0</kbd>
 
 Activate persistent storage to a deployed Kubernetes cluster

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -139,3 +139,28 @@ clever k8s list [options]
 |---|---|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever k8s update` <kbd>Since unreleased</kbd>
+
+Update a Kubernetes cluster metadata or features
+
+```bash
+clever k8s update <cluster-id|cluster-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`--autoscaling`|Enable the cluster autoscaler|
+|`--description` `<description>`|Free-form cluster description|
+|`--disable-autoscaling`|Disable the cluster autoscaler|
+|`--name` `<name>`|Rename the cluster|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--tag` `<tag[,tag...]>`|Replace tags (comma-separated, e.g.: env:prod,team:platform)|

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -162,6 +162,134 @@ clever k8s list [options]
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 
+## ➡️ `clever k8s nodegroups` <kbd>Since unreleased</kbd>
+
+Manage Kubernetes node groups
+
+```bash
+clever k8s nodegroups
+```
+
+## ➡️ `clever k8s nodegroups create` <kbd>Since unreleased</kbd>
+
+Create a node group on a Kubernetes cluster
+
+```bash
+clever k8s nodegroups create <cluster-id|cluster-name> <nodegroup-name> <flavor:count> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-name`|Node group name (lowercase RFC 1123, max 63 chars)|
+|`flavor:count`|Node group flavor and target node count (format: <flavor>:<count>, e.g.: XS:3)|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`--autoscaling`|Enable cluster autoscaler for this node group (requires --min and --max)|
+|`--description` `<description>`|Free-form node group description|
+|`--max` `<max>`|Maximum node count when autoscaling is enabled|
+|`--min` `<min>`|Minimum node count when autoscaling is enabled|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--tag` `<tag>`|Arbitrary tag attached to the node group|
+
+## ➡️ `clever k8s nodegroups delete` <kbd>Since unreleased</kbd>
+
+Delete a node group from a Kubernetes cluster
+
+```bash
+clever k8s nodegroups delete <cluster-id|cluster-name> <nodegroup-id|nodegroup-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-id|nodegroup-name`|Kubernetes node group ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`-y`, `--yes`|Skip confirmation prompts|
+
+## ➡️ `clever k8s nodegroups get` <kbd>Since unreleased</kbd>
+
+Get information about a Kubernetes node group
+
+```bash
+clever k8s nodegroups get <cluster-id|cluster-name> <nodegroup-id|nodegroup-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-id|nodegroup-name`|Kubernetes node group ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever k8s nodegroups list` <kbd>Since unreleased</kbd>
+
+List the node groups of a Kubernetes cluster
+
+```bash
+clever k8s nodegroups list <cluster-id|cluster-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever k8s nodegroups update` <kbd>Since unreleased</kbd>
+
+Update a node group on a Kubernetes cluster
+
+```bash
+clever k8s nodegroups update <cluster-id|cluster-name> <nodegroup-id|nodegroup-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-id|nodegroup-name`|Kubernetes node group ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`--autoscaling`|Enable the cluster autoscaler|
+|`--count` `<count>`|Target node count|
+|`--description` `<description>`|Free-form node group description|
+|`--disable-autoscaling`|Disable the cluster autoscaler|
+|`--max` `<max>`|Maximum node count (autoscaling bound)|
+|`--min` `<min>`|Minimum node count (autoscaling bound)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--tag` `<tag>`|Arbitrary tag attached to the node group|
+
 ## ➡️ `clever k8s quota` <kbd>Since unreleased</kbd>
 
 Get the Kubernetes quota, usage and remaining of an organisation

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -201,3 +201,66 @@ clever k8s update <cluster-id|cluster-name> [options]
 |`--name` `<name>`|Rename the cluster|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 |`--tag` `<tag[,tag...]>`|Replace tags (comma-separated, e.g.: env:prod,team:platform)|
+
+## ➡️ `clever k8s version` <kbd>Since unreleased</kbd>
+
+Check a Kubernetes cluster deployed version
+
+```bash
+clever k8s version <cluster-id|cluster-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever k8s version check` <kbd>Since unreleased</kbd>
+
+Check a Kubernetes cluster deployed version
+
+```bash
+clever k8s version check <cluster-id|cluster-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
+## ➡️ `clever k8s version update` <kbd>Since unreleased</kbd>
+
+Update a Kubernetes cluster to a target version
+
+```bash
+clever k8s version update <cluster-id|cluster-name> [options]
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--target` `<version>`|Target version to upgrade to (e.g.: 24, 2.4, 2.4.1)|

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -162,6 +162,21 @@ clever k8s list [options]
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 
+## ➡️ `clever k8s quota` <kbd>Since unreleased</kbd>
+
+Get the Kubernetes quota, usage and remaining of an organisation
+
+```bash
+clever k8s quota [options]
+```
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+
 ## ➡️ `clever k8s update` <kbd>Since unreleased</kbd>
 
 Update a Kubernetes cluster metadata or features

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -50,8 +50,18 @@ clever k8s create <cluster-name> [options]
 
 |Name|Description|
 |---|---|
+|`--autoscaling`|Enable the cluster autoscaler|
+|`--cluster-version` `<cluster-version>`|Kubernetes version to deploy (e.g.: 1.36)|
+|`--description` `<description>`|Free-form cluster description|
+|`--flavor` `<flavor>`|Control plane flavor|
+|`--nodegroup` `<flavor:count>`|Initial node group (format: <flavor>:<count>, e.g.: XS:3)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`--persistent-storage`|Enable persistent storage (Ceph CSI)|
+|`--replication-factor` `<replication-factor>`|Control plane replication factor|
+|`--tag` `<tag[,tag...]>`|Semantic tags (comma-separated, e.g.: env:prod,team:platform)|
+|`--topology` `<topology>`|Cluster topology (must be set with --flavor and --replication-factor)|
 |`-w`, `--watch`|Watch the deployment until the cluster is deployed|
+|`-y`, `--yes`|Skip confirmation prompts|
 
 ## ➡️ `clever k8s delete` <kbd>Since 4.3.0</kbd>
 

--- a/src/commands/k8s/k8s.get.command.js
+++ b/src/commands/k8s/k8s.get.command.js
@@ -23,13 +23,67 @@ export const k8sGetCommand = defineCommand({
         Logger.printJson(k8sInfo);
         break;
       case 'human':
-      default:
-        console.table({
+      default: {
+        const topo = k8sInfo.topologyConfig;
+        const overview = {
           Name: k8sInfo.name,
           ID: k8sInfo.id,
-          Version: k8sInfo.version,
           Status: k8sInfo.status,
-        });
+          Version: k8sInfo.version,
+          Topology: formatTopology(topo),
+          Autoscaling: k8sInfo.features?.autoscalingEnabled ? 'enabled' : 'disabled',
+          'Persistent storage': k8sInfo.features?.csi != null ? 'enabled' : 'disabled',
+        };
+        if (k8sInfo.tags?.length) overview.Tags = k8sInfo.tags.join(', ');
+        if (k8sInfo.description) overview.Description = k8sInfo.description;
+        if (k8sInfo.storageUsageBytes != null) {
+          overview.Storage = `${Math.round((k8sInfo.storageUsageBytes / 1024 ** 3) * 100) / 100} GB`;
+        }
+        console.table(overview);
+
+        if (topo?.topology === 'DISTRIBUTED' && topo.components) {
+          Logger.println('');
+          Logger.println('🧩 Control plane components');
+          console.table(
+            Object.fromEntries(
+              Object.entries(topo.components).map(([name, c]) => [
+                name,
+                { Flavor: c?.flavor ?? '-', RF: c?.replicationFactor ?? '-' },
+              ]),
+            ),
+          );
+        }
+
+        if (k8sInfo.nodeGroups?.length) {
+          Logger.println('');
+          Logger.println(`🧮 Node groups (${k8sInfo.nodeGroups.length})`);
+          console.table(
+            Object.fromEntries(
+              k8sInfo.nodeGroups.map((ng) => [
+                ng.id,
+                {
+                  Name: ng.name,
+                  Status: ng.status,
+                  Flavor: ng.flavor,
+                  Nodes: `${ng.currentNodeCount}/${ng.targetNodeCount}`,
+                },
+              ]),
+            ),
+          );
+        }
+
+        if (k8sInfo.loadBalancers?.length) {
+          Logger.println('');
+          Logger.println(`🔀 Load balancers (${k8sInfo.loadBalancers.length})`);
+          k8sInfo.loadBalancers.forEach((lb) => {
+            console.table({
+              ID: lb.id,
+              Flavor: lb.flavor,
+              IPs: lb.ips?.join(', ') ?? '-',
+              Domain: lb.domainName ?? '-',
+            });
+          });
+        }
 
         Logger.println('');
         const orgMessageComplement = orgIdOrName ? `--org "${orgIdOrName.orga_id || orgIdOrName.orga_name}"` : '';
@@ -38,6 +92,13 @@ export const k8sGetCommand = defineCommand({
           `Once ACTIVE, get the kubeconfig with ${styleText('blue', `clever k8s get-kubeconfig ${k8sInfo.id} ${orgMessageComplement}`)}`,
         );
         break;
+      }
     }
   },
 });
+
+function formatTopology(topo) {
+  if (topo == null) return '-';
+  if (topo.topology === 'DISTRIBUTED') return 'DISTRIBUTED';
+  return `${topo.topology} (${topo.flavor}, rf=${topo.replicationFactor})`;
+}

--- a/src/commands/k8s/k8s.nodegroups.command.js
+++ b/src/commands/k8s/k8s.nodegroups.command.js
@@ -1,0 +1,7 @@
+import { defineCommand } from '../../lib/define-command.js';
+
+export const k8sNodeGroupCommand = defineCommand({
+  description: 'Manage Kubernetes node groups',
+  since: 'unreleased',
+  featureFlag: 'k8s',
+});

--- a/src/commands/k8s/k8s.nodegroups.create.command.js
+++ b/src/commands/k8s/k8s.nodegroups.create.command.js
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { defineArgument } from '../../lib/define-argument.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { k8sCreateNodeGroup } from '../../lib/k8s.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { flavorCount } from '../../parsers.js';
+import { orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sNodeGroupCreateCommand = defineCommand({
+  description: 'Create a node group on a Kubernetes cluster',
+  since: 'unreleased',
+  options: {
+    description: defineOption({
+      name: 'description',
+      schema: z.string().max(4096).optional(),
+      description: 'Free-form node group description',
+      placeholder: 'description',
+    }),
+    tag: defineOption({
+      name: 'tag',
+      schema: z.string().max(1024).optional(),
+      description: 'Arbitrary tag attached to the node group',
+      placeholder: 'tag',
+    }),
+    autoscaling: defineOption({
+      name: 'autoscaling',
+      schema: z.boolean().default(false),
+      description: 'Enable cluster autoscaler for this node group (requires --min and --max)',
+    }),
+    min: defineOption({
+      name: 'min',
+      schema: z.coerce.number().int().min(0).max(256).optional(),
+      description: 'Minimum node count when autoscaling is enabled',
+      placeholder: 'min',
+    }),
+    max: defineOption({
+      name: 'max',
+      schema: z.coerce.number().int().min(0).max(256).optional(),
+      description: 'Maximum node count when autoscaling is enabled',
+      placeholder: 'max',
+    }),
+    org: orgaIdOrNameOption,
+  },
+  args: [
+    k8sIdOrNameArg,
+    defineArgument({
+      schema: z
+        .string()
+        .regex(
+          /^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$/,
+          'Must be lowercase RFC 1123 (letters, digits, "-"), start/end alphanumeric, max 63 chars',
+        ),
+      description: 'Node group name (lowercase RFC 1123, max 63 chars)',
+      placeholder: 'nodegroup-name',
+    }),
+    defineArgument({
+      schema: z.string().transform(flavorCount),
+      description: 'Node group flavor and target node count (format: <flavor>:<count>, e.g.: XS:3)',
+      placeholder: 'flavor:count',
+    }),
+  ],
+  async handler(options, clusterIdOrName, nodeGroupName, spec) {
+    const { org: orgIdOrName } = options;
+    const nodeGroup = await k8sCreateNodeGroup(orgIdOrName, clusterIdOrName, {
+      name: nodeGroupName,
+      flavor: spec.flavor,
+      targetNodeCount: spec.targetNodeCount,
+      description: options.description,
+      tag: options.tag,
+      autoscaling: options.autoscaling,
+      min: options.min,
+      max: options.max,
+    });
+    Logger.println(`🚀 Node group ${styleText('white', `${nodeGroup.name} (${nodeGroup.id})`)} is being deployed`);
+  },
+});

--- a/src/commands/k8s/k8s.nodegroups.delete.command.js
+++ b/src/commands/k8s/k8s.nodegroups.delete.command.js
@@ -1,0 +1,34 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sDeleteNodeGroup } from '../../lib/k8s.js';
+import { ask } from '../../lib/prompts.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { orgaIdOrNameOption, skipConfirmationOption } from '../global.options.js';
+import { k8sIdOrNameArg, k8sNodeGroupIdOrNameArg } from './k8s.args.js';
+
+export const k8sNodeGroupDeleteCommand = defineCommand({
+  description: 'Delete a node group from a Kubernetes cluster',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    yes: skipConfirmationOption,
+  },
+  args: [k8sIdOrNameArg, k8sNodeGroupIdOrNameArg],
+  async handler(options, clusterIdOrName, nodeGroupIdOrName) {
+    const { org: orgIdOrName, yes } = options;
+
+    if (!yes) {
+      const proceed = await ask(
+        `Are you sure you want to delete the node group ${styleText('blue', nodeGroupIdOrName)}?`,
+        false,
+      );
+      if (!proceed) {
+        Logger.println('Node group deletion cancelled');
+        return;
+      }
+    }
+
+    await k8sDeleteNodeGroup(orgIdOrName, clusterIdOrName, nodeGroupIdOrName);
+    Logger.printSuccess(`Node group ${styleText('green', nodeGroupIdOrName)} successfully deleted`);
+  },
+});

--- a/src/commands/k8s/k8s.nodegroups.get.command.js
+++ b/src/commands/k8s/k8s.nodegroups.get.command.js
@@ -1,0 +1,66 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sGetNodeGroup } from '../../lib/k8s.js';
+import { Logger } from '../../logger.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg, k8sNodeGroupIdOrNameArg } from './k8s.args.js';
+
+export const k8sNodeGroupGetCommand = defineCommand({
+  description: 'Get information about a Kubernetes node group',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [k8sIdOrNameArg, k8sNodeGroupIdOrNameArg],
+  async handler(options, clusterIdOrName, nodeGroupIdOrName) {
+    const { format, org: orgIdOrName } = options;
+    const nodeGroup = await k8sGetNodeGroup(orgIdOrName, clusterIdOrName, nodeGroupIdOrName);
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(nodeGroup);
+        break;
+      case 'human':
+      default: {
+        const overview = {
+          Name: nodeGroup.name,
+          ID: nodeGroup.id,
+          Status: nodeGroup.status,
+          Flavor: nodeGroup.flavor,
+          Nodes: `${nodeGroup.currentNodeCount}/${nodeGroup.targetNodeCount}`,
+          Autoscaling: nodeGroup.autoscalingEnabled ? 'enabled' : 'disabled',
+          'Min / Max': `${nodeGroup.minNodeCount} / ${nodeGroup.maxNodeCount}${nodeGroup.autoscalingEnabled ? '' : ' (inactive)'}`,
+          Created: formatDate(nodeGroup.createdAt),
+        };
+        const createdFmt = formatDate(nodeGroup.createdAt);
+        const updatedFmt = formatDate(nodeGroup.updatedAt);
+        if (nodeGroup.updatedAt && updatedFmt !== createdFmt) {
+          overview.Updated = updatedFmt;
+        }
+        if (nodeGroup.description) overview.Description = nodeGroup.description;
+        if (nodeGroup.tag) overview.Tag = nodeGroup.tag;
+        console.table(overview);
+
+        const labels = Object.entries(nodeGroup.labels ?? {});
+        if (labels.length > 0) {
+          Logger.println('');
+          Logger.println(`🏷️  Labels (${labels.length})`);
+          console.table(Object.fromEntries(labels.map(([k, v]) => [k, { Value: v }])));
+        }
+
+        const taints = nodeGroup.taints ?? [];
+        if (taints.length > 0) {
+          Logger.println('');
+          Logger.println(`🚫 Taints (${taints.length})`);
+          console.table(Object.fromEntries(taints.map((t) => [t.key, { Value: t.value ?? '-', Effect: t.effect }])));
+        }
+        break;
+      }
+    }
+  },
+});
+
+function formatDate(iso) {
+  if (iso == null) return '-';
+  return `${iso.slice(0, 16).replace('T', ' ')}Z`;
+}

--- a/src/commands/k8s/k8s.nodegroups.list.command.js
+++ b/src/commands/k8s/k8s.nodegroups.list.command.js
@@ -1,0 +1,49 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sListNodeGroups } from '../../lib/k8s.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sNodeGroupListCommand = defineCommand({
+  description: 'List the node groups of a Kubernetes cluster',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [k8sIdOrNameArg],
+  async handler(options, clusterIdOrName) {
+    const { format, org: orgIdOrName } = options;
+    const nodeGroups = await k8sListNodeGroups(orgIdOrName, clusterIdOrName);
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(nodeGroups);
+        break;
+      case 'human':
+      default:
+        if (nodeGroups.length === 0) {
+          Logger.println(
+            `🔎 No node group found, create one with ${styleText('blue', 'clever k8s nodegroups create')}`,
+          );
+          return;
+        }
+        console.table(
+          Object.fromEntries(
+            nodeGroups.map((ng) => [
+              ng.id,
+              {
+                Name: ng.name,
+                Status: ng.status,
+                Flavor: ng.flavor,
+                Nodes: `${ng.currentNodeCount}/${ng.targetNodeCount}`,
+                Autoscaling: ng.autoscalingEnabled ? `${ng.minNodeCount}-${ng.maxNodeCount}` : 'disabled',
+              },
+            ]),
+          ),
+        );
+        break;
+    }
+  },
+});

--- a/src/commands/k8s/k8s.nodegroups.update.command.js
+++ b/src/commands/k8s/k8s.nodegroups.update.command.js
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { k8sUpdateNodeGroup } from '../../lib/k8s.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg, k8sNodeGroupIdOrNameArg } from './k8s.args.js';
+
+export const k8sNodeGroupUpdateCommand = defineCommand({
+  description: 'Update a node group on a Kubernetes cluster',
+  since: 'unreleased',
+  options: {
+    count: defineOption({
+      name: 'count',
+      schema: z.coerce.number().int().min(0).max(256).optional(),
+      description: 'Target node count',
+      placeholder: 'count',
+    }),
+    min: defineOption({
+      name: 'min',
+      schema: z.coerce.number().int().min(0).max(256).optional(),
+      description: 'Minimum node count (autoscaling bound)',
+      placeholder: 'min',
+    }),
+    max: defineOption({
+      name: 'max',
+      schema: z.coerce.number().int().min(0).max(256).optional(),
+      description: 'Maximum node count (autoscaling bound)',
+      placeholder: 'max',
+    }),
+    autoscaling: defineOption({
+      name: 'autoscaling',
+      schema: z.boolean().default(false),
+      description: 'Enable the cluster autoscaler',
+    }),
+    disableAutoscaling: defineOption({
+      name: 'disable-autoscaling',
+      schema: z.boolean().default(false),
+      description: 'Disable the cluster autoscaler',
+    }),
+    description: defineOption({
+      name: 'description',
+      schema: z.string().max(4096).optional(),
+      description: 'Free-form node group description',
+      placeholder: 'description',
+    }),
+    tag: defineOption({
+      name: 'tag',
+      schema: z.string().max(1024).optional(),
+      description: 'Arbitrary tag attached to the node group',
+      placeholder: 'tag',
+    }),
+    org: orgaIdOrNameOption,
+  },
+  args: [k8sIdOrNameArg, k8sNodeGroupIdOrNameArg],
+  async handler(options, clusterIdOrName, nodeGroupIdOrName) {
+    const { org: orgIdOrName } = options;
+
+    if (options.autoscaling && options.disableAutoscaling) {
+      throw new Error('--autoscaling and --disable-autoscaling are mutually exclusive');
+    }
+
+    const updates = {};
+    if (options.count != null) updates.targetNodeCount = options.count;
+    if (options.min != null) updates.minNodeCount = options.min;
+    if (options.max != null) updates.maxNodeCount = options.max;
+    if (options.autoscaling) updates.autoscalingEnabled = true;
+    if (options.disableAutoscaling) updates.autoscalingEnabled = false;
+    if (options.description != null) updates.description = options.description;
+    if (options.tag != null) updates.tag = options.tag;
+
+    if (Object.keys(updates).length === 0) {
+      throw new Error(
+        'No update specified. Provide at least one of --count, --min, --max, --autoscaling, --disable-autoscaling, --description, --tag',
+      );
+    }
+
+    if (updates.minNodeCount != null && updates.maxNodeCount != null && updates.minNodeCount > updates.maxNodeCount) {
+      throw new Error('--min must be less than or equal to --max');
+    }
+
+    const nodeGroup = await k8sUpdateNodeGroup(orgIdOrName, clusterIdOrName, nodeGroupIdOrName, updates);
+    Logger.printSuccess(`Node group ${styleText('green', nodeGroup.name)} updated`);
+  },
+});

--- a/src/commands/k8s/k8s.quota.command.js
+++ b/src/commands/k8s/k8s.quota.command.js
@@ -1,0 +1,77 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sGetQuota, k8sListUsage } from '../../lib/k8s.js';
+import { Logger } from '../../logger.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+
+const BYTES_PER_GB = 1024 ** 3;
+const UNIT_TO_BYTES = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 ** 2,
+  GB: BYTES_PER_GB,
+  TB: 1024 ** 4,
+  PB: 1024 ** 5,
+};
+
+export const k8sQuotaCommand = defineCommand({
+  description: 'Get the Kubernetes quota, usage and remaining of an organisation',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [],
+  async handler(options) {
+    const { format, org: orgIdOrName } = options;
+    const [quota, usageItems] = await Promise.all([k8sGetQuota(orgIdOrName), k8sListUsage(orgIdOrName)]);
+
+    const cpuQuota = quota.quotas?.find((i) => i.type === 'MillivCPUMaxLimit');
+    const ramQuota = quota.quotas?.find((i) => i.type === 'RamMaxUsage');
+    const usedMillicores = usageItems.reduce((sum, i) => sum + i.cpuMillicores, 0);
+    const usedBytes = usageItems.reduce((sum, i) => sum + i.ramBytes, 0);
+
+    switch (format) {
+      case 'json': {
+        const { quotas, ...quotaRest } = quota;
+        Logger.printJson({
+          quota: {
+            ...quotaRest,
+            vCPUMax: cpuQuota != null ? { maximum: cpuQuota.maximum, unit: 'mCPU' } : null,
+            ramMax: ramQuota != null ? { maximum: ramQuota.information.number, unit: ramQuota.information.unit } : null,
+          },
+          usage: { cpuMillicores: usedMillicores, ramBytes: usedBytes },
+          remaining: {
+            cpuMillicores: cpuQuota != null ? cpuQuota.maximum - usedMillicores : null,
+            ramBytes: ramQuota != null ? ramToBytes(ramQuota.information) - usedBytes : null,
+          },
+        });
+        break;
+      }
+      case 'human':
+      default: {
+        const ramQuotaBytes = ramQuota != null ? ramToBytes(ramQuota.information) : null;
+        console.table({
+          'Max CPU': {
+            Quota: cpuQuota != null ? `${cpuQuota.maximum / 1000} vCPU` : 'unlimited',
+            Usage: `${usedMillicores / 1000} vCPU`,
+            Remaining: cpuQuota != null ? `${(cpuQuota.maximum - usedMillicores) / 1000} vCPU` : 'unlimited',
+          },
+          'Max RAM': {
+            Quota: ramQuota != null ? `${ramQuota.information.number} ${ramQuota.information.unit}` : 'unlimited',
+            Usage: `${formatGb(usedBytes)} GB`,
+            Remaining: ramQuotaBytes != null ? `${formatGb(ramQuotaBytes - usedBytes)} GB` : 'unlimited',
+          },
+        });
+        break;
+      }
+    }
+  },
+});
+
+function ramToBytes({ number, unit }) {
+  return number * (UNIT_TO_BYTES[unit] ?? BYTES_PER_GB);
+}
+
+function formatGb(bytes) {
+  return Math.round((bytes / BYTES_PER_GB) * 100) / 100;
+}

--- a/src/commands/k8s/k8s.update.command.js
+++ b/src/commands/k8s/k8s.update.command.js
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { k8sUpdate } from '../../lib/k8s.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import { tags } from '../../parsers.js';
+import { orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sUpdateCommand = defineCommand({
+  description: 'Update a Kubernetes cluster metadata or features',
+  since: 'unreleased',
+  options: {
+    name: defineOption({
+      name: 'name',
+      schema: z.string().max(128).optional(),
+      description: 'Rename the cluster',
+      placeholder: 'name',
+    }),
+    description: defineOption({
+      name: 'description',
+      schema: z.string().max(4096).optional(),
+      description: 'Free-form cluster description',
+      placeholder: 'description',
+    }),
+    tag: defineOption({
+      name: 'tag',
+      schema: z.string().transform(tags).optional(),
+      description: 'Replace tags (comma-separated, e.g.: env:prod,team:platform)',
+      placeholder: 'tag[,tag...]',
+    }),
+    autoscaling: defineOption({
+      name: 'autoscaling',
+      schema: z.boolean().default(false),
+      description: 'Enable the cluster autoscaler',
+    }),
+    disableAutoscaling: defineOption({
+      name: 'disable-autoscaling',
+      schema: z.boolean().default(false),
+      description: 'Disable the cluster autoscaler',
+    }),
+    org: orgaIdOrNameOption,
+  },
+  args: [k8sIdOrNameArg],
+  async handler(options, clusterIdOrName) {
+    const { org: orgIdOrName } = options;
+
+    if (options.autoscaling && options.disableAutoscaling) {
+      throw new Error('--autoscaling and --disable-autoscaling are mutually exclusive');
+    }
+
+    const updates = {};
+    if (options.name != null) updates.name = options.name;
+    if (options.description != null) updates.description = options.description;
+    if (options.tag != null) updates.tags = options.tag;
+
+    const features = {};
+    if (options.autoscaling) features.autoscalingEnabled = true;
+    if (options.disableAutoscaling) features.autoscalingEnabled = false;
+    if (Object.keys(features).length > 0) updates.features = features;
+
+    if (Object.keys(updates).length === 0) {
+      throw new Error(
+        'No update specified. Provide at least one of --name, --description, --tag, --autoscaling, --disable-autoscaling',
+      );
+    }
+
+    const cluster = await k8sUpdate(orgIdOrName, clusterIdOrName, updates);
+    Logger.printSuccess(`Cluster ${styleText('green', cluster.name)} updated`);
+  },
+});

--- a/src/commands/k8s/k8s.version.check.command.js
+++ b/src/commands/k8s/k8s.version.check.command.js
@@ -1,0 +1,18 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sCheckVersion } from '../../lib/k8s.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sVersionCheckCommand = defineCommand({
+  description: 'Check a Kubernetes cluster deployed version',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [k8sIdOrNameArg],
+  async handler(options, clusterIdOrName) {
+    const { format, org: orgIdOrName } = options;
+    await k8sCheckVersion(orgIdOrName, clusterIdOrName, format);
+  },
+});

--- a/src/commands/k8s/k8s.version.command.js
+++ b/src/commands/k8s/k8s.version.command.js
@@ -1,0 +1,18 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sCheckVersion } from '../../lib/k8s.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sVersionCommand = defineCommand({
+  description: 'Check a Kubernetes cluster deployed version',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [k8sIdOrNameArg],
+  async handler(options, clusterIdOrName) {
+    const { format, org: orgIdOrName } = options;
+    await k8sCheckVersion(orgIdOrName, clusterIdOrName, format);
+  },
+});

--- a/src/commands/k8s/k8s.version.update.command.js
+++ b/src/commands/k8s/k8s.version.update.command.js
@@ -1,0 +1,18 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { k8sUpdateVersion } from '../../lib/k8s.js';
+import { orgaIdOrNameOption, targetVersionOption } from '../global.options.js';
+import { k8sIdOrNameArg } from './k8s.args.js';
+
+export const k8sVersionUpdateCommand = defineCommand({
+  description: 'Update a Kubernetes cluster to a target version',
+  since: 'unreleased',
+  options: {
+    org: orgaIdOrNameOption,
+    target: targetVersionOption,
+  },
+  args: [k8sIdOrNameArg],
+  async handler(options, clusterIdOrName) {
+    const { target, org: orgIdOrName } = options;
+    await k8sUpdateVersion(orgIdOrName, clusterIdOrName, target);
+  },
+});

--- a/src/commands/oauth-consumers/oauth-consumers.docs.md
+++ b/src/commands/oauth-consumers/oauth-consumers.docs.md
@@ -52,7 +52,7 @@ clever oauth-consumers delete <consumer-key|consumer-name> [options]
 
 |Name|Description|
 |---|---|
-|`-y`, `--yes`|Skip confirmation and proceed with deletion directly|
+|`-y`, `--yes`|Skip confirmation prompts|
 
 ## ➡️ `clever oauth-consumers get` <kbd>Since 4.8.0</kbd>
 

--- a/src/lib/k8s.js
+++ b/src/lib/k8s.js
@@ -1,13 +1,28 @@
+import dedent from 'dedent';
+import { ask, confirm, selectAnswer } from './prompts.js';
 import { styleText } from './style-text.js';
 
 import {
   addK8sPersistentStorage,
   createK8sCluster,
+  createK8sNodeGroup,
   deleteK8sCluster,
+  deleteK8sNodeGroup,
   getK8sAddon,
   getK8sConfig,
+  getK8sNodeGroup,
+  getK8sProduct,
+  getK8sQuota,
+  getK8sVersionCheck,
   listK8sClusters,
+  listK8sDeploymentEvents,
+  listK8sNodeGroups,
+  listK8sUsage,
+  updateK8sCluster,
+  updateK8sNodeGroup,
+  updateK8sVersion,
 } from '../clever-client/k8s.js';
+import { Logger } from '../logger.js';
 import { getOwnerIdFromOrgIdOrName } from '../models/ids-resolver.js';
 import { sendToApi } from '../models/send-to-api.js';
 
@@ -28,13 +43,119 @@ export async function isK8sClusterActive(orgIdOrName, clusterIdOrName) {
 /**
  * Create a kubernetes cluster
  * @param {string} name The name of the cluster
- * @param {string} ownerId The owner ID
- * @returns {Promise<void>}
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {object} [options]
+ * @param {string} [options.version] The Kubernetes version to deploy
+ * @param {string} [options.description] A free-form description
+ * @param {string[]} [options.tags] Semantic tags ("tag" or "key:value")
+ * @param {boolean} [options.autoscaling] Enable the cluster autoscaler
+ * @param {boolean} [options.persistentStorage] Enable the Ceph CSI persistent storage
+ * @param {string} [options.topology] Topology kind (ALL_IN_ONE, DEDICATED_COMPUTE, DISTRIBUTED)
+ * @param {string} [options.flavor] Control plane flavor
+ * @param {number} [options.replicationFactor] Control plane replication factor
+ * @param {{flavor: string, targetNodeCount: number}} [options.nodeGroup] Initial node group
+ * @returns {Promise<object>}
  */
-export async function k8sCreate(name, ownerId) {
-  ownerId = await getOwnerIdFromOrgIdOrName(ownerId);
+export async function k8sCreate(name, orgIdOrName, options = {}) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const product = await k8sGetProduct();
 
-  return createK8sCluster({ ownerId }, { name }).then(sendToApi);
+  const body = { name };
+  if (options.version != null) {
+    const available = product.versions?.available ?? [];
+    if (!available.includes(options.version)) {
+      throw new Error(`Version "${options.version}" is not available. Supported: ${available.join(', ')}`);
+    }
+    body.version = options.version;
+  }
+  if (options.description != null) body.description = options.description;
+  if (options.tags?.length) body.tags = options.tags;
+
+  const features = {};
+  if (options.autoscaling) features.autoscalingEnabled = true;
+  if (options.persistentStorage) features.csi = true;
+  if (Object.keys(features).length > 0) body.features = features;
+
+  body.topologyConfig = resolveTopologyConfig(options, product);
+
+  if (options.nodeGroup != null) {
+    const supported = getNodeGroupFlavors(product);
+    if (!supported.includes(options.nodeGroup.flavor)) {
+      throw new Error(
+        `Flavor "${options.nodeGroup.flavor}" is not a valid node group flavor. Supported: ${supported.join(', ')}`,
+      );
+    }
+    let addNodeGroup = true;
+    if (body.topologyConfig.topology === 'ALL_IN_ONE' && !options.yes) {
+      Logger.println(
+        styleText(
+          'yellow',
+          '⚠️  ALL_IN_ONE topology already schedules pods on control plane VMs — an additional node group is usually unnecessary.',
+        ),
+      );
+      addNodeGroup = await ask('Add the node group anyway?', false);
+      if (!addNodeGroup) {
+        Logger.println('Node group creation skipped, cluster will be deployed without it');
+      }
+    }
+    if (addNodeGroup) {
+      body.nodeGroups = [
+        { name: 'default', flavor: options.nodeGroup.flavor, targetNodeCount: options.nodeGroup.targetNodeCount },
+      ];
+    }
+  }
+
+  return createK8sCluster({ ownerId }, body).then(sendToApi);
+}
+
+const FLAVOR_ORDER = ['2XS', 'XS', 'S', 'M', 'L', 'XL'];
+const DEFAULT_TOPOLOGY = 'ALL_IN_ONE';
+const DISTRIBUTED_COMPONENTS = [
+  'apiserver',
+  'controllerManager',
+  'scheduler',
+  'nodeGroupOperator',
+  'cloudControllerManager',
+];
+
+function resolveTopologyConfig({ topology, flavor, replicationFactor }, product) {
+  const resolvedTopology = topology ?? DEFAULT_TOPOLOGY;
+  const constraint = product.topologies?.find((t) => t.topology === resolvedTopology);
+  if (constraint == null) {
+    const supported = (product.topologies ?? []).map((t) => t.topology).join(', ');
+    throw new Error(`Unknown topology "${resolvedTopology}". Supported: ${supported}`);
+  }
+
+  const resolvedFlavor = flavor ?? FLAVOR_ORDER.find((f) => constraint.availableFlavors?.includes(f));
+  if (resolvedFlavor == null || !constraint.availableFlavors?.includes(resolvedFlavor)) {
+    throw new Error(
+      `Flavor "${resolvedFlavor}" is not available for ${resolvedTopology}. Supported: ${(constraint.availableFlavors ?? []).join(', ')}`,
+    );
+  }
+
+  const { min, max } = constraint.replicationFactor;
+  const resolvedRf = replicationFactor ?? min;
+  if (resolvedRf < min || resolvedRf > max) {
+    throw new Error(`Replication factor for ${resolvedTopology} must be between ${min} and ${max}`);
+  }
+
+  if (resolvedTopology === 'DISTRIBUTED') {
+    const component = { flavor: resolvedFlavor, replicationFactor: resolvedRf };
+    return {
+      topology: 'DISTRIBUTED',
+      components: Object.fromEntries(DISTRIBUTED_COMPONENTS.map((c) => [c, component])),
+    };
+  }
+
+  return { topology: resolvedTopology, flavor: resolvedFlavor, replicationFactor: resolvedRf };
+}
+
+/**
+ * Get the Kubernetes service configuration (supported topologies, flavors, versions)
+ * @returns {Promise<object>}
+ */
+export async function k8sGetProduct() {
+  return getK8sProduct().then(sendToApi);
 }
 
 /**
@@ -76,6 +197,20 @@ export async function k8sGetConfig(orgIdOrName, clusterIdOrName) {
 }
 
 /**
+ * Update a Kubernetes cluster metadata or features
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {object} updates Patch fields (name, description, tags, features)
+ * @returns {Promise<object>}
+ */
+export async function k8sUpdate(orgIdOrName, clusterIdOrName, updates) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+
+  return updateK8sCluster({ ownerId, clusterId }, updates).then(sendToApi);
+}
+
+/**
  * Delete a kubernetes cluster
  * @param {string} orgIdOrName The organisation ID or name
  * @param {string} clusterIdOrName The cluster ID or name
@@ -100,13 +235,21 @@ export async function getClusterIdFromAddonIdOrName(addonIdOrName, ownerId) {
   } else if (typeof addonIdOrName === 'object' && addonIdOrName.operator_id) {
     return addonIdOrName.operator_id;
   } else if (typeof addonIdOrName === 'object' && addonIdOrName.addon_name) {
-    const clusters = await listK8sClusters({ ownerId }).then(sendToApi);
-    const matchingCluster = clusters.find((cluster) => cluster.name === addonIdOrName.addon_name);
-    if (matchingCluster) {
-      return matchingCluster.id;
-    } else {
-      throw new Error(`No Kubernetes cluster found with the name ${styleText('red', addonIdOrName.addon_name)}`);
+    const name = addonIdOrName.addon_name;
+    const matches = await listK8sClusters({ ownerId })
+      .then(sendToApi)
+      .then((clusters) => clusters.filter((c) => c.name === name && c.status !== 'DELETED'));
+
+    if (matches.length === 0) {
+      throw new Error(`No Kubernetes cluster found with the name ${styleText('red', name)}`);
     }
+    if (matches.length > 1) {
+      const listing = matches.map((c) => `- ${c.name} (${c.id})`).join('\n');
+      throw new Error(
+        `Multiple Kubernetes clusters found with the name ${styleText('red', name)}, use the ID instead:\n${styleText('grey', listing)}`,
+      );
+    }
+    return matches[0].id;
   } else {
     throw new Error('Invalid Kubernetes Cluster identifier provided');
   }
@@ -123,4 +266,261 @@ export async function k8sAddPersistentStorage(orgIdOrName, clusterIdOrName) {
   const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
 
   return addK8sPersistentStorage({ ownerId, clusterId }).then(sendToApi);
+}
+
+/**
+ * Get the Kubernetes quota of an organisation
+ * @param {object} [orgIdOrName] The organisation ID or name
+ * @returns {Promise<object>} The quota payload (id, tenantId, tags, quotas)
+ */
+export async function k8sGetQuota(orgIdOrName) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+
+  return getK8sQuota({ ownerId }).then(sendToApi);
+}
+
+/**
+ * List the current Kubernetes usage items of an organisation
+ * @param {object} [orgIdOrName] The organisation ID or name
+ * @returns {Promise<object[]>} The list of cluster usage items
+ */
+export async function k8sListUsage(orgIdOrName) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+
+  return listK8sUsage({ ownerId }).then(sendToApi);
+}
+
+/**
+ * List deployment events for a Kubernetes cluster
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {number} [limit] Max number of events to return
+ * @returns {Promise<object[]>}
+ */
+export async function k8sListActivity(orgIdOrName, clusterIdOrName, limit) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const queryParams = limit != null ? { limit } : {};
+
+  return listK8sDeploymentEvents({ ownerId, clusterId }, queryParams).then(sendToApi);
+}
+
+/**
+ * List the node groups of a Kubernetes cluster
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @returns {Promise<object[]>}
+ */
+export async function k8sListNodeGroups(orgIdOrName, clusterIdOrName) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+
+  return listK8sNodeGroups({ ownerId, clusterId }).then(sendToApi);
+}
+
+/**
+ * Create a node group on a Kubernetes cluster
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {object} options
+ * @param {string} options.name Node group name
+ * @param {string} options.flavor Node flavor (2XS..XL)
+ * @param {number} options.targetNodeCount Target node count
+ * @param {string} [options.description]
+ * @param {string} [options.tag]
+ * @param {boolean} [options.autoscaling]
+ * @param {number} [options.min] Minimum node count (autoscaling)
+ * @param {number} [options.max] Maximum node count (autoscaling)
+ * @returns {Promise<object>}
+ */
+export async function k8sCreateNodeGroup(orgIdOrName, clusterIdOrName, options) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const product = await k8sGetProduct();
+
+  const supported = getNodeGroupFlavors(product);
+  if (!supported.includes(options.flavor)) {
+    throw new Error(`Flavor "${options.flavor}" is not a valid node group flavor. Supported: ${supported.join(', ')}`);
+  }
+
+  const wantsAutoscaling = options.autoscaling || options.min != null || options.max != null;
+  if (wantsAutoscaling && (options.min == null || options.max == null)) {
+    throw new Error('--autoscaling requires both --min and --max');
+  }
+  if (wantsAutoscaling && options.min > options.max) {
+    throw new Error('--min must be less than or equal to --max');
+  }
+
+  const body = { name: options.name, flavor: options.flavor, targetNodeCount: options.targetNodeCount };
+  if (options.description != null) body.description = options.description;
+  if (options.tag != null) body.tag = options.tag;
+  if (wantsAutoscaling) {
+    body.autoscalingEnabled = true;
+    body.minNodeCount = options.min;
+    body.maxNodeCount = options.max;
+  }
+
+  return createK8sNodeGroup({ ownerId, clusterId }, body).then(sendToApi);
+}
+
+function getNodeGroupFlavors(product) {
+  const available = new Set((product.topologies ?? []).flatMap((t) => t.availableFlavors ?? []));
+  return FLAVOR_ORDER.filter((f) => available.has(f));
+}
+
+/**
+ * Update a node group on a Kubernetes cluster
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {string} nodeGroupIdOrName The node group ID or name
+ * @param {object} updates Patch fields (targetNodeCount, minNodeCount, maxNodeCount, autoscalingEnabled, description, tag)
+ * @returns {Promise<object>}
+ */
+export async function k8sUpdateNodeGroup(orgIdOrName, clusterIdOrName, nodeGroupIdOrName, updates) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const nodeGroupId = await resolveNodeGroupId(ownerId, clusterId, nodeGroupIdOrName);
+  const current = await getK8sNodeGroup({ ownerId, clusterId, nodeGroupId }).then(sendToApi);
+
+  const body = { name: current.name, targetNodeCount: current.targetNodeCount, ...updates };
+
+  return updateK8sNodeGroup({ ownerId, clusterId, nodeGroupId }, body).then(sendToApi);
+}
+
+/**
+ * Delete a node group from a Kubernetes cluster
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {string} nodeGroupIdOrName The node group ID or name
+ * @returns {Promise<void>}
+ */
+export async function k8sDeleteNodeGroup(orgIdOrName, clusterIdOrName, nodeGroupIdOrName) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const nodeGroupId = await resolveNodeGroupId(ownerId, clusterId, nodeGroupIdOrName);
+
+  return deleteK8sNodeGroup({ ownerId, clusterId, nodeGroupId }).then(sendToApi);
+}
+
+/**
+ * Get a specific node group of a Kubernetes cluster
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {string} nodeGroupIdOrName The node group ID or name
+ * @returns {Promise<object>}
+ */
+export async function k8sGetNodeGroup(orgIdOrName, clusterIdOrName, nodeGroupIdOrName) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const nodeGroupId = await resolveNodeGroupId(ownerId, clusterId, nodeGroupIdOrName);
+
+  return getK8sNodeGroup({ ownerId, clusterId, nodeGroupId }).then(sendToApi);
+}
+
+const NODE_GROUP_ID_REGEX = /^node_group_[0-9A-HJ-NP-TV-Z]{26}$/i;
+
+/**
+ * Resolve a node group ID from either an ID or a name (scoped to a cluster)
+ * @param {string} ownerId
+ * @param {string} clusterId
+ * @param {string} nodeGroupIdOrName
+ * @returns {Promise<string>}
+ */
+async function resolveNodeGroupId(ownerId, clusterId, nodeGroupIdOrName) {
+  if (NODE_GROUP_ID_REGEX.test(nodeGroupIdOrName)) {
+    return nodeGroupIdOrName;
+  }
+  const list = await listK8sNodeGroups({ ownerId, clusterId }).then(sendToApi);
+  const matches = list.filter((ng) => ng.name === nodeGroupIdOrName);
+  if (matches.length === 0) {
+    throw new Error(`No node group found with name ${styleText('red', nodeGroupIdOrName)}`);
+  }
+  if (matches.length > 1) {
+    const listing = matches.map((ng) => `- ${ng.name} (${ng.id})`).join('\n');
+    throw new Error(
+      `Multiple node groups found with the name ${styleText('red', nodeGroupIdOrName)}, use the ID instead:\n${styleText('grey', listing)}`,
+    );
+  }
+  return matches[0].id;
+}
+
+/**
+ * Check a Kubernetes cluster version against available upgrades
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {string} format The output format
+ * @returns {Promise<void>}
+ */
+export async function k8sCheckVersion(orgIdOrName, clusterIdOrName, format) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const name = getClusterDisplayName(clusterIdOrName, clusterId);
+  const versions = await getK8sVersionCheck({ ownerId, clusterId }).then(sendToApi);
+
+  switch (format) {
+    case 'json':
+      Logger.printJson(versions);
+      break;
+    case 'human':
+    default:
+      if (!versions.needUpdate) {
+        Logger.printSuccess(`${styleText('green', name)} is up-to-date (${styleText('green', versions.installed)})`);
+      } else {
+        Logger.println(dedent`
+          🔄 ${styleText('red', name)} is outdated
+             • Installed version: ${styleText('red', versions.installed)}
+             • Latest version: ${styleText('green', versions.latest)}
+        `);
+        Logger.println();
+
+        await confirm(
+          `Do you want to update it to ${styleText('green', versions.latest)} now?`,
+          'No confirmation, aborting version update',
+        );
+
+        await updateK8sVersion({ ownerId, clusterId }, { targetVersion: versions.latest }).then(sendToApi);
+        Logger.printSuccess(`${styleText('green', name)} is upgrading to ${styleText('green', versions.latest)}…`);
+      }
+      break;
+  }
+}
+
+/**
+ * Update a Kubernetes cluster version
+ * @param {object} orgIdOrName The organisation ID or name
+ * @param {string|object} clusterIdOrName The cluster ID or name
+ * @param {string} [askedVersion] The target version; prompts from available versions when omitted
+ * @returns {Promise<void>}
+ */
+export async function k8sUpdateVersion(orgIdOrName, clusterIdOrName, askedVersion) {
+  const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
+  const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
+  const name = getClusterDisplayName(clusterIdOrName, clusterId);
+  const versions = await getK8sVersionCheck({ ownerId, clusterId }).then(sendToApi);
+
+  const targetVersion =
+    askedVersion ??
+    (await selectAnswer(
+      `Which version do you want to update ${styleText('blue', name)} to, current is ${styleText('blue', versions.installed)}?`,
+      [...versions.available].reverse(),
+    ));
+
+  if (!versions.available.includes(targetVersion)) {
+    throw new Error(`Version ${styleText('red', targetVersion)} is not available`);
+  }
+
+  if (versions.installed === targetVersion) {
+    Logger.printSuccess(`${styleText('green', name)} is already at version ${styleText('green', targetVersion)}`);
+    return;
+  }
+
+  await updateK8sVersion({ ownerId, clusterId }, { targetVersion }).then(sendToApi);
+  Logger.printSuccess(`${styleText('green', name)} is upgrading to ${styleText('green', targetVersion)}…`);
+}
+
+function getClusterDisplayName(clusterIdOrName, fallbackId) {
+  if (typeof clusterIdOrName === 'object') {
+    return clusterIdOrName.addon_name ?? clusterIdOrName.operator_id ?? fallbackId;
+  }
+  return clusterIdOrName ?? fallbackId;
 }

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -5,13 +5,17 @@ export function promptSecret(message) {
   return password({ message, mask: true }).catch(exitOnPromptError);
 }
 
-export async function confirm(message, rejectionMessage) {
-  const answer = await confirmPrompt({ message }).catch(exitOnPromptError);
+export async function confirm(message, rejectionMessage, defaultAnswer = true) {
+  const answer = await confirmPrompt({ message, default: defaultAnswer }).catch(exitOnPromptError);
   if (!answer) {
     throw new Error(rejectionMessage);
   }
 
   return answer;
+}
+
+export async function ask(message, defaultAnswer = true) {
+  return confirmPrompt({ message, default: defaultAnswer }).catch(exitOnPromptError);
 }
 
 export async function confirmAnswer(message, rejectionMessage, expectedAnswer) {

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -86,6 +86,16 @@ export function commaSeparated(string) {
   return string.split(',');
 }
 
+const flavorCountRegex = /^[^:]+:\d+$/;
+
+export function flavorCount(string) {
+  if (!flavorCountRegex.test(string)) {
+    throw new Error('Expected format: <flavor>:<count>');
+  }
+  const [flavor, count] = string.split(':');
+  return { flavor: flavor.toUpperCase(), targetNodeCount: Number(count) };
+}
+
 // /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/i;
 const tagRegex = /^[^,\s]+$/;
 


### PR DESCRIPTION
This pull request introduces significant enhancements to Kubernetes (k8s) support in the CLI, including new commands for managing node groups, cluster metadata, and versioning, as well as improvements to documentation and confirmation prompts. The changes add new API client functions, CLI commands, and update documentation to reflect the expanded Kubernetes management capabilities.

**Major Kubernetes (k8s) feature additions:**

* Added new CLI commands for managing Kubernetes node groups (`nodegroups create`, `nodegroups delete`, `nodegroups get`, `nodegroups list`, `nodegroups update`), updating clusters (`update`), checking and updating cluster versions (`version check`, `version update`), viewing deployment events (`activity`), and retrieving quotas (`quota`). [[1]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR65-R83) [[2]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR309-R334) [[3]](diffhunk://#diff-67f2b5dc0c4e561df9e7758d31cdca72436a87a80e5e4554ebf5fc8124a63a96R1-R53) [[4]](diffhunk://#diff-7c2aa9f52dce7544955e2d3ddba8f7cadb72998d841177535c362875a7c8a25eR10-R15)
* Introduced corresponding API client functions in `k8s.js` for all new endpoints, including node group CRUD operations, deployment events, cluster updates, version checks/updates, and quota/usage retrieval. [[1]](diffhunk://#diff-28a3279cd55e932a6ad843c8016021b7bbf4ae286adba2b020330839e16d0954R19-R35) [[2]](diffhunk://#diff-28a3279cd55e932a6ad843c8016021b7bbf4ae286adba2b020330839e16d0954R114-R293)

**Documentation updates:**

* Expanded the full documentation to cover all new k8s commands and options, including detailed usage, arguments, and options for node group and cluster management. [[1]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR1477-R1499) [[2]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR1539-R1550) [[3]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR1635-R1881)
* Updated confirmation prompt descriptions for deletion commands to clarify that the `--yes` flag skips confirmation prompts, not just deletion. [[1]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bL351-R351) [[2]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bL1539-R1572) [[3]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bL2573-R2853) [[4]](diffhunk://#diff-e161394bd32458497cc465afbf0e1a47b2e90c84529f153f0e8eb5a4029fd67cL65-R65) [[5]](diffhunk://#diff-f63a1cbfbce840262a7ff96fdf6a076605c4a4376561cbd1850bfc8bdada58d2L73-R73)

**Internal improvements:**

* Added new argument definition for node group IDs or names to support the new commands.

These changes provide comprehensive Kubernetes cluster and node group management directly from the CLI, making it easier for users to automate and control their Kubernetes resources.

**References:**  
[[1]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR65-R83) [[2]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR309-R334) [[3]](diffhunk://#diff-67f2b5dc0c4e561df9e7758d31cdca72436a87a80e5e4554ebf5fc8124a63a96R1-R53) [[4]](diffhunk://#diff-7c2aa9f52dce7544955e2d3ddba8f7cadb72998d841177535c362875a7c8a25eR10-R15) [[5]](diffhunk://#diff-28a3279cd55e932a6ad843c8016021b7bbf4ae286adba2b020330839e16d0954R19-R35) [[6]](diffhunk://#diff-28a3279cd55e932a6ad843c8016021b7bbf4ae286adba2b020330839e16d0954R114-R293) [[7]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR1477-R1499) [[8]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR1539-R1550) [[9]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bR1635-R1881) [[10]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bL351-R351) [[11]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bL1539-R1572) [[12]](diffhunk://#diff-00c66369dbe86c60d3ebb9bf89b8157b639f3eeb27931ffb3085168a0260c94bL2573-R2853) [[13]](diffhunk://#diff-e161394bd32458497cc465afbf0e1a47b2e90c84529f153f0e8eb5a4029fd67cL65-R65) [[14]](diffhunk://#diff-f63a1cbfbce840262a7ff96fdf6a076605c4a4376561cbd1850bfc8bdada58d2L73-R73)