### PR TITLE
Otoroshi: add Swagger UI URL support

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -3066,6 +3066,22 @@ clever otoroshi open logs <addon-id|addon-name>
 addon-id|addon-name    Add-on ID (or name, if unambiguous)
 ```
 
+#### otoroshi open swaggerui
+
+**Description:** Open the Otoroshi Swagger UI in your browser
+
+**Since:** unreleased
+
+**Usage**
+```
+clever otoroshi open swaggerui <addon-id|addon-name>
+```
+
+**Arguments**
+```
+addon-id|addon-name    Add-on ID (or name, if unambiguous)
+```
+
 #### otoroshi open webui
 
 **Description:** Open the Otoroshi admin console in your browser

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -144,6 +144,7 @@ import { otoroshiGetConfigCommand } from './otoroshi/otoroshi.get-config.command
 import { otoroshiGetCommand } from './otoroshi/otoroshi.get.command.js';
 import { otoroshiOpenCommand } from './otoroshi/otoroshi.open.command.js';
 import { otoroshiOpenLogsCommand } from './otoroshi/otoroshi.open.logs.command.js';
+import { otoroshiOpenSwaggeruiCommand } from './otoroshi/otoroshi.open.swaggerui.command.js';
 import { otoroshiOpenWebuiCommand } from './otoroshi/otoroshi.open.webui.command.js';
 import { otoroshiRebuildCommand } from './otoroshi/otoroshi.rebuild.command.js';
 import { otoroshiRestartCommand } from './otoroshi/otoroshi.restart.command.js';
@@ -453,6 +454,7 @@ export const globalCommands = {
         otoroshiOpenCommand,
         {
           logs: otoroshiOpenLogsCommand,
+          swaggerui: otoroshiOpenSwaggeruiCommand,
           webui: otoroshiOpenWebuiCommand,
         },
       ],

--- a/src/commands/otoroshi/otoroshi.docs.md
+++ b/src/commands/otoroshi/otoroshi.docs.md
@@ -108,6 +108,20 @@ clever otoroshi open logs <addon-id|addon-name>
 |---|---|
 |`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
 
+## ➡️ `clever otoroshi open swaggerui` <kbd>Since unreleased</kbd>
+
+Open the Otoroshi Swagger UI in your browser
+
+```bash
+clever otoroshi open swaggerui <addon-id|addon-name>
+```
+
+### 📥 Arguments
+
+|Name|Description|
+|---|---|
+|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+
 ## ➡️ `clever otoroshi open webui` <kbd>Since 3.13.0</kbd>
 
 Open the Otoroshi admin console in your browser

--- a/src/commands/otoroshi/otoroshi.open.swaggerui.command.js
+++ b/src/commands/otoroshi/otoroshi.open.swaggerui.command.js
@@ -1,0 +1,13 @@
+import { defineCommand } from '../../lib/define-command.js';
+import { operatorOpenSwaggerUi } from '../../lib/operator-commands.js';
+import { addonIdOrNameArg } from '../global.args.js';
+
+export const otoroshiOpenSwaggeruiCommand = defineCommand({
+  description: 'Open the Otoroshi Swagger UI in your browser',
+  since: 'unreleased',
+  options: {},
+  args: [addonIdOrNameArg],
+  async handler(_options, addonIdOrName) {
+    await operatorOpenSwaggerUi(addonIdOrName);
+  },
+});

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -257,7 +257,8 @@ export async function operatorPrint(provider, addonIdOrName, format = 'human') {
   dataToPrint['Access URL'] = operator.accessUrl;
 
   if (provider === 'otoroshi') {
-    dataToPrint['API URL'] = operator.api.url;
+    dataToPrint['Swagger URL'] = operator.api.swaggerUrl;
+    dataToPrint['API endpoint'] = operator.api.url;
   }
 
   if (['otoroshi', 'keycloak'].includes(provider)) {

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -199,6 +199,19 @@ export async function operatorOpenWebUi(provider, addonIdOrName) {
 }
 
 /**
+ * Open an Otoroshi Swagger UI in the browser
+ * @param {{ addon_name?: string, operator_id?: string, addon_id?: string }} addonIdOrName The operator's name or ID
+ * @returns {Promise<void>}
+ */
+export async function operatorOpenSwaggerUi(addonIdOrName) {
+  const operator = await Operator.getDetails('otoroshi', addonIdOrName);
+  await openBrowser(
+    operator.api.swaggerUrl,
+    `Opening ${styleText('blue', operator.addonId)} Swagger UI in the browser…`,
+  );
+}
+
+/**
  * Reboot an operator
  * @param {object} params The command's parameters
  * @param {string} provider The operator's provider


### PR DESCRIPTION
This pull request adds a new command to open the Otoroshi Swagger UI directly from the CLI and updates related operator command logic and output. The main changes introduce the `otoroshiOpenSwaggeruiCommand`, implement its handler, and improve the information displayed for Otoroshi operators.

### New Otoroshi Swagger UI Command

* Added the `otoroshiOpenSwaggeruiCommand` to allow users to open the Otoroshi Swagger UI in their browser via the CLI. (`src/commands/otoroshi/otoroshi.open.swaggerui.command.js`)
* Registered the new command in the global Otoroshi commands group. (`src/commands/global.commands.js`) [[1]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR135) [[2]](diffhunk://#diff-b5d0a2bb7c1aee982ca7f9b0ae3e2b900863ac172a80ce8e0f73b11e3dd089ecR425)

### Operator Command Enhancements

* Implemented the `operatorOpenSwaggerUi` function to handle opening the Swagger UI using the operator's details. (`src/lib/operator-commands.js`)
* Updated the operator print output to show both the Swagger URL and the API endpoint for Otoroshi, improving clarity for users. (`src/lib/operator-commands.js`)