### PR TITLE
Add organisation support to addon providers

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -420,12 +420,13 @@ clever addon providers show <addon-provider> [options]
 
 **Arguments**
 ```
-addon-provider           Add-on provider
+addon-provider                          Add-on provider
 ```
 
 **Options**
 ```
--F, --format <format>    Output format (human, json) (default: human)
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
 ### addon rename

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -403,7 +403,8 @@ clever addon providers [options]
 
 **Options**
 ```
--F, --format <format>    Output format (human, json) (default: human)
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
 #### addon providers show

--- a/src/commands/addon/addon.docs.md
+++ b/src/commands/addon/addon.docs.md
@@ -113,6 +113,7 @@ clever addon providers [options]
 |Name|Description|
 |---|---|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 
 ## ➡️ `clever addon providers show` <kbd>Since 0.2.3</kbd>
 

--- a/src/commands/addon/addon.docs.md
+++ b/src/commands/addon/addon.docs.md
@@ -134,6 +134,7 @@ clever addon providers show <addon-provider> [options]
 |Name|Description|
 |---|---|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 
 ## ➡️ `clever addon rename` <kbd>Since 0.3.0</kbd>
 

--- a/src/commands/addon/addon.providers.command.js
+++ b/src/commands/addon/addon.providers.command.js
@@ -3,19 +3,22 @@ import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import * as Addon from '../../models/addon.js';
-import { humanJsonOutputFormatOption } from '../global.options.js';
+import { getOwnerIdFromOrgIdOrName } from '../../models/ids-resolver.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
 
 export const addonProvidersCommand = defineCommand({
   description: 'List available add-on providers',
   since: '0.2.3',
   options: {
+    org: orgaIdOrNameOption,
     format: humanJsonOutputFormatOption,
   },
   args: [],
   async handler(options) {
-    const { format } = options;
+    const { org: orgaIdOrName, format } = options;
 
-    const providers = await Addon.listProviders();
+    const ownerId = await getOwnerIdFromOrgIdOrName(orgaIdOrName);
+    const providers = await Addon.listProviders(ownerId);
 
     switch (format) {
       case 'json': {

--- a/src/commands/addon/addon.providers.show.command.js
+++ b/src/commands/addon/addon.providers.show.command.js
@@ -2,20 +2,23 @@ import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import * as Addon from '../../models/addon.js';
-import { humanJsonOutputFormatOption } from '../global.options.js';
+import { getOwnerIdFromOrgIdOrName } from '../../models/ids-resolver.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
 import { addonProviderArg } from './addon.args.js';
 
 export const addonProvidersShowCommand = defineCommand({
   description: 'Show information about an add-on provider',
   since: '0.2.3',
   options: {
+    org: orgaIdOrNameOption,
     format: humanJsonOutputFormatOption,
   },
   args: [addonProviderArg],
   async handler(options, providerName) {
-    const { format } = options;
+    const { org: orgaIdOrName, format } = options;
 
-    const provider = await Addon.getProvider(providerName);
+    const ownerId = await getOwnerIdFromOrgIdOrName(orgaIdOrName);
+    const provider = await Addon.getProvider(providerName, ownerId);
     const providerInfos = await Addon.getProviderInfos(providerName);
 
     const formattedPlans = [...provider.plans]

--- a/src/models/addon.js
+++ b/src/models/addon.js
@@ -15,12 +15,12 @@ import { Logger } from '../logger.js';
 import { resolveOwnerId } from './ids-resolver.js';
 import { sendToApi } from './send-to-api.js';
 
-export function listProviders() {
-  return getAllAddonProviders({}).then(sendToApi);
+export function listProviders(orgaId) {
+  return getAllAddonProviders({ orgaId }).then(sendToApi);
 }
 
-export async function getProvider(providerName) {
-  const providers = await listProviders();
+export async function getProvider(providerName, orgaId) {
+  const providers = await listProviders(orgaId);
   const provider = providers.find((p) => p.id === providerName);
   if (provider == null) {
     throw new Error(`Invalid provider name. Available providers: ${providers.map((p) => p.id).join(', ')}`);
@@ -129,7 +129,7 @@ function validateAddonVersionAndOptions(region, version, addonOptions, providerI
 
 export async function create({ ownerId, name, providerName, planName, region, version, addonOptions }) {
   // TODO: We should be able to use it without {}
-  const provider = await getProvider(providerName);
+  const provider = await getProvider(providerName, ownerId);
 
   if (!provider.regions.includes(region)) {
     throw new Error(`Invalid region name. Available regions: ${provider.regions.join(', ')}`);


### PR DESCRIPTION
## Context

The addonproviders API supports an `orgaId` query param to filter available providers, regions and plans per organisation. During add-on creation, this param was never passed, preventing the API from checking zone availability for the specific organisation.

## Proposal

- **fix(addon)**: Update `listProviders()` and `getProvider()` to accept and propagate `orgaId`. During creation, pass the organisation's ID for org-aware zone validation.
- **feat(addon)**: Add `--org` option to `clever addon providers` command, allowing users to filter providers by organisation.
- **feat(addon)**: Add `--org` option to `clever addon providers show` command, allowing users to get org-specific provider details (plans, regions).

## How to test

```bash
# List all providers (global)
clever addon providers

# List providers available for specific org
clever addon providers --org <org-id>

# Show provider details for specific org
clever addon providers show <provider> --org <org-id>

# Create addon with org context (existing flow, now validated per-org)
clever addon create <provider> <name> --org <org-id>
```