### PR TITLE
feat(drain): support Better Stack as a drain target

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1069,7 +1069,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 **Arguments**
 ```
-drain-type                           Drain type (datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)
+drain-type                           Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)
 drain-url                            Drain URL
 ```
 
@@ -1082,6 +1082,7 @@ drain-url                            Drain URL
 -i, --index-prefix <index-prefix>    Optional index prefix (for elasticsearch), `logstash` value is used if not set
 -p, --password <password>            Basic auth password (for elasticsearch or raw-http)
 -s, --sd-params <sd-params>          RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`
+-t, --source-token <source-token>    Source token (for betterstack)
 -u, --username <username>            Basic auth username (for elasticsearch or raw-http)
 ```
 

--- a/src/commands/drain/drain.create.command.js
+++ b/src/commands/drain/drain.create.command.js
@@ -34,6 +34,13 @@ export const drainCreateCommand = defineCommand({
       aliases: ['k'],
       placeholder: 'api-key',
     }),
+    sourceToken: defineOption({
+      name: 'source-token',
+      schema: z.string().optional(),
+      description: 'Source token (for betterstack)',
+      aliases: ['t'],
+      placeholder: 'source-token',
+    }),
     indexPrefix: defineOption({
       name: 'index-prefix',
       schema: z.string().optional(),
@@ -66,7 +73,7 @@ export const drainCreateCommand = defineCommand({
   ],
   async handler(options, drainTypeCliCode, url) {
     const { alias, appIdOrName, addonIdOrRealId } = options;
-    const { username, password, apiKey, indexPrefix, rfc5424StructuredDataParameters } = options;
+    const { username, password, apiKey, sourceToken, indexPrefix, rfc5424StructuredDataParameters } = options;
 
     const drainType = Object.values(DRAIN_TYPES).find((drainType) => drainType.cliCode === drainTypeCliCode);
 
@@ -106,6 +113,13 @@ export const drainCreateCommand = defineCommand({
         throw new Error(`${DRAIN_TYPES.NEWRELIC.cliCode} drains require an API key (--api-key) to be set`);
       }
       body.recipient.apiKey = apiKey;
+    }
+
+    if (drainTypeCliCode === DRAIN_TYPES.BETTERSTACK.cliCode) {
+      if (!sourceToken) {
+        throw new Error(`${DRAIN_TYPES.BETTERSTACK.cliCode} drains require a source token (--source-token) to be set`);
+      }
+      body.recipient.sourceToken = sourceToken;
     }
 
     if (

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -29,7 +29,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 |Name|Description|
 |---|---|
-|`drain-type`|Drain type (datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)|
+|`drain-type`|Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)|
 |`drain-url`|Drain URL|
 
 ### ⚙️ Options
@@ -43,6 +43,7 @@ clever drain create <drain-type> <drain-url> [options]
 |`-i`, `--index-prefix` `<index-prefix>`|Optional index prefix (for elasticsearch), `logstash` value is used if not set|
 |`-p`, `--password` `<password>`|Basic auth password (for elasticsearch or raw-http)|
 |`-s`, `--sd-params` `<sd-params>`|RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`|
+|`-t`, `--source-token` `<source-token>`|Source token (for betterstack)|
 |`-u`, `--username` `<username>`|Basic auth username (for elasticsearch or raw-http)|
 
 ## ➡️ `clever drain disable` <kbd>Since 0.9.0</kbd>

--- a/src/models/drain.js
+++ b/src/models/drain.js
@@ -16,6 +16,7 @@ export async function resolveDrainResource(alias, appIdOrName, addonIdOrRealId) 
 }
 
 export const DRAIN_TYPES = {
+  BETTERSTACK: { apiCode: 'BETTERSTACK', cliCode: 'betterstack', label: 'Better Stack' },
   DATADOG: { apiCode: 'DATADOG', cliCode: 'datadog', label: 'Datadog' },
   ELASTICSEARCH: { apiCode: 'ELASTICSEARCH', cliCode: 'elasticsearch', label: 'Elasticsearch' },
   NEWRELIC: { apiCode: 'NEWRELIC', cliCode: 'newrelic', label: 'New Relic' },


### PR DESCRIPTION
## Summary

Adds the `betterstack` drain type so users can forward application logs to [Better Stack](https://betterstack.com/docs/logs/http-rest-api/) from the CLI.

```bash
clever drain create betterstack https://in.logs.betterstack.com \
  --source-token <token> --app my-app
```

The source token is sent as `Authorization: Bearer <token>` (matches Better Stack's HTTP REST API). The `--source-token` (`-t`) flag mirrors Better Stack's own terminology and is required for this drain type.

## Changes

- `src/models/drain.js`: register `BETTERSTACK` in `DRAIN_TYPES` (cliCode `betterstack`, label `Better Stack`).
- `src/commands/drain/drain.create.command.js`: new `--source-token` / `-t` option; `betterstack` branch in the handler that requires the token and sets `body.recipient.sourceToken`.
- `src/commands/drain/drain.docs.md` + `skills/clever-tools/references/full-documentation.md`: regenerated via `npm run docs`.

## Backend

The corresponding API support is being added in OVD ([clever-cloud/ovd!1994](https://gitlab.corp.clever-cloud.com/clever-cloud/ovd/-/merge_requests/1994)). This PR should land alongside or after that MR.

## Test plan

- [x] `npm run validate` passes locally (lint + format + typecheck + docs:check) ✅
- [x] `clever drain create betterstack https://in.logs.betterstack.com --source-token TOKEN --app <app>` creates a drain and the recipient comes back with `type: "BETTERSTACK"`
- [x] `clever drain create betterstack <url> --app <app>` (no `--source-token`) errors with a clear message
- [x] `clever drain test-command <drain-id>` (existing command) returns a curl with `Authorization: Bearer $DRAIN_SOURCE_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)