### PR TITLE
feat(global): add --insecure option to skip TLS certificate verification

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -10,6 +10,7 @@ import { globalCommands } from '../src/commands/global.commands.js';
 import {
   colorOption,
   helpOption,
+  insecureOption,
   updateNotifierOption,
   verboseOption,
   versionOption,
@@ -68,6 +69,7 @@ async function run() {
       verbose: verboseOption,
       color: colorOption,
       'update-notifier': updateNotifierOption,
+      insecure: insecureOption,
     },
   };
 
@@ -78,7 +80,12 @@ async function run() {
     name: 'clever',
     description: rootCommandDefinition.description,
     version: pkg.version,
-    options: [convertOption(colorOption), convertOption(updateNotifierOption), convertOption(verboseOption)],
+    options: [
+      convertOption(colorOption),
+      convertOption(updateNotifierOption),
+      convertOption(verboseOption),
+      convertOption(insecureOption),
+    ],
     helpCommand: false,
     commands: sortedCommands,
   });

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,11 @@ For each of them, you can add these parameters:
 [--color]               Choose whether to print colors or not. You can also use --no-color (default: true)
 [--update-notifier]     Choose whether to use update notifier or not. You can also use --no-update-notifier (default: true)
 [--verbose, -v]         Verbose output (default: false)
+[--insecure]            Skip TLS certificate verification. You can also set CLEVER_INSECURE=1 (default: false)
 ```
+
+> [!WARNING]
+> `--insecure` (or `CLEVER_INSECURE=1`) disables TLS certificate verification for API calls, Git operations, and `clever curl`. Use it only behind a trusted corporate proxy that intercepts TLS with its own certificates. It exposes you to man-in-the-middle attacks.
 
 > [!TIP]
 > For commands returning a list of items, you can use `--format json` or `-F json` to get a JSON output.

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -21,7 +21,7 @@ import { ListZoneCommand } from '@clevercloud/client/cc-api-commands/zone/list-z
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { globalCommands } from '../src/commands/global.commands.js';
-import { colorOption, updateNotifierOption, verboseOption } from '../src/commands/global.options.js';
+import { colorOption, insecureOption, updateNotifierOption, verboseOption } from '../src/commands/global.options.js';
 import { baseConfig } from '../src/config/config.js';
 import { styleText } from '../src/lib/style-text.js';
 import { runCommand } from './lib/command.js';
@@ -66,7 +66,11 @@ async function generateCommandsReadme(commands, checkMode) {
   const existingReadme = await fs.readFile(readmePath, 'utf-8').catch(() => null);
 
   const newMarkdown =
-    getReadmeMarkdown(commands, { colorOption, verboseOption, updateNotifierOption }, getDocRelativePath) + '\n';
+    getReadmeMarkdown(
+      commands,
+      { colorOption, verboseOption, updateNotifierOption, insecureOption },
+      getDocRelativePath,
+    ) + '\n';
 
   return processFile(readmePath, existingReadme, newMarkdown, checkMode);
 }

--- a/scripts/lib/docs-reference.js
+++ b/scripts/lib/docs-reference.js
@@ -22,12 +22,12 @@ export function getDocRelativePath(rootName) {
 /**
  * Generates the main README with the list of commands.
  * @param {Array<[string, unknown]>} commands
- * @param {{ colorOption: OptionDefinition, verboseOption: OptionDefinition, updateNotifierOption: OptionDefinition }} globalOptions
+ * @param {{ colorOption: OptionDefinition, verboseOption: OptionDefinition, updateNotifierOption: OptionDefinition, insecureOption: OptionDefinition }} globalOptions
  * @param {(rootName: string) => string} getDocRelativePath
  * @return {string}
  */
 export function getReadmeMarkdown(commands, globalOptions, getDocRelativePath) {
-  const { colorOption, verboseOption, updateNotifierOption } = globalOptions;
+  const { colorOption, verboseOption, updateNotifierOption, insecureOption } = globalOptions;
 
   const commandRows = commands.map(([rootName, command]) => {
     const definition = Array.isArray(command) ? command[0] : command;
@@ -50,6 +50,7 @@ export function getReadmeMarkdown(commands, globalOptions, getDocRelativePath) {
     |${getOptionAliases('color', colorOption)}|${escapeTableCell(colorOption.description)}|
     |${getOptionAliases('verbose', verboseOption)}|${escapeTableCell(verboseOption.description)}|
     |${getOptionAliases('update-notifier', updateNotifierOption)}|${escapeTableCell(updateNotifierOption.description)}|
+    |${getOptionAliases('insecure', insecureOption)}|${escapeTableCell(insecureOption.description)}|
 
     ## ➡️ Commands
 

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -11,6 +11,7 @@ These options are available for all commands:
 |`--color`|Choose whether to print colors or not. You can also use --no-color|
 |`-v`, `--verbose`|Verbose output|
 |`--update-notifier`|Choose whether to use update notifier or not. You can also use --no-update-notifier|
+|`--insecure`|Skip TLS certificate verification (you can also set CLEVER_INSECURE=1). Use only behind a trusted proxy|
 
 ## ➡️ Commands
 

--- a/src/commands/curl/curl.command.js
+++ b/src/commands/curl/curl.command.js
@@ -67,6 +67,12 @@ export async function curl() {
     curlArgs.push('-H', `authorization: ${oauthHeader}`);
   }
 
+  // NODE_TLS_REJECT_UNAUTHORIZED has no effect on the spawned curl process, so we forward the intent explicitly
+  const alreadyInsecure = curlArgs.includes('-k') || curlArgs.includes('--insecure');
+  if (process.env.CLEVER_INSECURE === '1' && !alreadyInsecure) {
+    curlArgs.push('--insecure');
+  }
+
   spawn('curl', curlArgs, { stdio: 'inherit' });
 }
 

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -184,3 +184,10 @@ export const verboseOption = defineOption({
   description: 'Verbose output',
   aliases: ['v'],
 });
+
+export const insecureOption = defineOption({
+  name: 'insecure',
+  schema: z.boolean().default(false),
+  description:
+    'Skip TLS certificate verification (you can also set CLEVER_INSECURE=1). Use only behind a trusted proxy',
+});

--- a/src/initial-setup.js
+++ b/src/initial-setup.js
@@ -5,6 +5,13 @@ if (hasParam('-v') || hasParam('--verbose')) {
   process.env.CLEVER_VERBOSE = '1';
 }
 
+// This needs to be set before any TLS connection is opened (fetch, isomorphic-git, ...)
+// Useful behind corporate proxies that intercept TLS with their own certificates
+if (hasParam('--insecure') || process.env.CLEVER_INSECURE != null) {
+  process.env.CLEVER_INSECURE = '1';
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+}
+
 // These need to be set before Logger and other stuffs
 // Don't log anything in autocomplete mode
 if (hasParam('--autocomplete-index')) {


### PR DESCRIPTION
## What

Add an opt-in `--insecure` global flag and `CLEVER_INSECURE` environment variable to skip TLS certificate verification.

## Why

Some users are behind corporate proxies that intercept TLS with their own certificates. Certificate verification then fails on every request and the CLI is unusable for them. This gives them an explicit, documented escape hatch.

## How

- `src/initial-setup.js`: when `--insecure` is passed or `CLEVER_INSECURE` is set, it runs before any TLS module loads and sets `NODE_TLS_REJECT_UNAUTHORIZED=0`. That single switch covers API calls (`fetch`/undici) and Git operations (the `https.Agent` used by isomorphic-git).
- `src/commands/curl/curl.command.js`: the spawned `curl` process ignores that env var, so `--insecure` is appended to its args when `CLEVER_INSECURE=1` (skipped if `-k`/`--insecure` is already there).
- `src/commands/global.options.js` + `bin/clever.js`: register the new global option so it parses and shows in help.
- Docs regenerated.

## Notes

- Default behavior stays fully secure. Node still prints its own insecure-TLS warning when enabled.
- Due to existing `clever curl` special-casing, with curl the flag must follow the subcommand (`clever curl --insecure <url>`); `CLEVER_INSECURE=1` works in any position.
- `npm run validate` passes (lint, prettier, typecheck, docs:check).
