### PR TITLE
feat(tls): trust system and custom CA certificates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,60 @@ For each of them, you can add these parameters:
 > [!TIP]
 > For commands returning a list of items, you can use `--format json` or `-F json` to get a JSON output.
 
+## TLS certificates (corporate proxy / custom CA)
+
+Clever Tools verifies the TLS certificate of every HTTPS connection it makes, both for API calls and for Git-based deployments. Behind a corporate proxy that intercepts HTTPS, or when your endpoint relies on a private or self-signed Certificate Authority (CA), this verification can fail with an error such as:
+
+```
+Error: self signed certificate in certificate chain
+```
+
+The right fix is to make Clever Tools trust your CA, not to disable verification. There are two ways to do it, depending on whether your CA is installed system-wide or only available as a file.
+
+### Trust your operating system's certificate store
+
+If your corporate or proxy root CA is installed at the OS level (Windows Certificate Store, macOS Keychain, Linux `/etc/ssl/certs`), Clever Tools can rely on it:
+
+- **Binary install**: nothing to do, the binary already trusts the OS certificate store.
+- **npm install**: the package runs on your own Node.js, so enable it explicitly (Node.js >= 22.15):
+
+```bash
+NODE_OPTIONS=--use-system-ca clever <command>
+```
+
+If the CA isn't in the OS store yet, ask your IT team to install it there: it's then trusted by every tool on the machine, not just Clever Tools.
+
+### Trust a specific certificate
+
+When the CA is only available as a file (not installed system-wide), set the `NODE_EXTRA_CA_CERTS` environment variable to its path. This works the same way for both the binary and npm installs. The file must be PEM-encoded and may contain several certificates:
+
+```bash
+# Linux / macOS
+export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
+clever <command>
+```
+
+```powershell
+# Windows (PowerShell)
+$env:NODE_EXTRA_CA_CERTS = "C:\path\to\corporate-ca.pem"
+clever <command>
+```
+
+> [!NOTE]
+> `NODE_EXTRA_CA_CERTS` and `NODE_OPTIONS` are read by Node.js at startup: set them in your shell, or inline before the command, not in a `.env` file.
+
+### Git-based deployments
+
+`clever deploy` pushes over HTTPS and verifies certificates too. By default it relies on its JS git implementation (running on Node.js), so it trusts the OS certificate store and `NODE_EXTRA_CA_CERTS` exactly like API calls — nothing more to do.
+
+If you switch to the system git backend (`clever features enable system-git`), `clever` delegates to your system `git` binary instead. That binary **ignores** `NODE_EXTRA_CA_CERTS` and follows its own TLS configuration: the OS certificate store (recommended), or an explicit CA file set with `git config --global http.sslCAInfo /path/to/corporate-ca.pem` (equivalent to the `GIT_SSL_CAINFO` environment variable).
+
+> [!TIP]
+> Installing your CA in the OS certificate store is the most reliable option: it covers both API calls and Git deployments, in every mode, for both binary and npm installs.
+
+> [!WARNING]
+> Disabling TLS verification entirely (for example with `NODE_TLS_REJECT_UNAUTHORIZED=0`) exposes you to man-in-the-middle attacks, including the theft of your Clever Cloud credentials. Always prefer trusting your CA with one of the methods above.
+
 ## features
 
 Some features are available as experimental, before they're completely ready for prime time. They usually work well, but this testing phase allows us to get feedbacks, refine some details, documentation, and break things between two releases.

--- a/scripts/lib/build-binary.js
+++ b/scripts/lib/build-binary.js
@@ -34,5 +34,5 @@ export async function buildBinary(version, os) {
     highlight`=> Build script ${input} into binary ${output} for ${platform}-${arch} with Node.js ${nodeMajorVersion}`,
   );
 
-  await pkg.exec([input, '--target', target, '--output', output]);
+  await pkg.exec([input, '--target', target, '--output', output, '--options', 'use-system-ca']);
 }


### PR DESCRIPTION
## Context

Enterprise users behind a TLS-intercepting proxy, or whose endpoint relies on a private/self-signed Certificate Authority, hit `Error: self signed certificate in certificate chain` and cannot use the CLI at all. The `pkg` binary bundles a Node.js that only trusts Mozilla's CA list, ignoring the certificates installed on the machine.

Supersedes #1046 (build-only change), and offers a secure alternative to the `--insecure` escape hatch proposed in #1097.

## Proposal

Make the CLI trust the user's CAs instead of disabling verification:

- **Build**: build the binary with `pkg --options use-system-ca` so it loads the OS certificate store (Windows Certificate Store, macOS Keychain, Linux `/etc/ssl/certs`). TLS verification stays **on** — corporate/proxy CAs trusted at the OS level just work, with no flag.
- **Docs**: new "TLS certificates" section in `docs/README.md`, split by strategy:
  - *Trust the OS store* — binary: nothing to do; npm: `NODE_OPTIONS=--use-system-ca`.
  - *Trust a specific certificate* — `NODE_EXTRA_CA_CERTS=/path/ca.pem` (binary & npm alike).
  - explicit `WARNING` against `NODE_TLS_REJECT_UNAUTHORIZED=0` (man-in-the-middle, credential theft).
  - *Git-based deployments* — the default JS implementation honors the same levers; the optional system git backend follows `git`'s own config (OS store / `GIT_SSL_CAINFO`).

### Design decisions

- Secure by default: extend the set of trusted CAs, never bypass verification — which is why this is preferred over a global `--insecure` flag (#1097).
- The code passes no explicit `ca` option (see `isomorphic-http-with-agent.js`), so `NODE_EXTRA_CA_CERTS` and `--use-system-ca` take effect for API calls and the **default JS git implementation**. The optional **system git backend** shells out to the native `git`, which follows its own TLS config instead (OS store / `http.sslCAInfo`) — see the "Git-based deployments" docs note.

## Testing

Tested locally against a reproduction of the corporate-proxy scenario:

- **nginx** (Docker) terminating TLS with a server cert signed by a throwaway self-signed root CA, served as a **full chain** so Node sees the private root → reproduces `self signed certificate in certificate chain`. It reverse-proxies to the real `api.clever-cloud.com`.
- Reached via `/etc/hosts` (`self-api.clever-cloud.com → 127.0.0.1`) + an `API_HOST` override.
- Probe: `clever profile` (real `GET /v2/self` with an authenticated profile) — a true end-to-end success, not just a TLS handshake.

### API calls

| build | no flag | `NODE_EXTRA_CA_CERTS=ca.pem` | CA in OS store (+ use-system-ca) |
|---|---|---|---|
| prod binary `4.10.0` | ❌ | ✅ | ❌ even with `NODE_OPTIONS=--use-system-ca` |
| **this branch** binary | ✅ trusts OS store, no flag | ✅ | ✅ |
| npm install | ❌ | ✅ | ✅ with `NODE_OPTIONS=--use-system-ca` |

The prod binary **not** honoring `NODE_OPTIONS=--use-system-ca` is precisely what the build-time `--options use-system-ca` fixes.

### Git-based deployments

Exercised on the real push network path (`isomorphic-http-with-agent.js`):

- **JS implementation (default)**: no flag → `SELF_SIGNED_CERT_IN_CHAIN`; with `NODE_EXTRA_CA_CERTS` or `--use-system-ca` → TLS OK. Deployments are covered by both levers, like API calls.
- **System git backend** (`clever features enable system-git`): the native `git` binary trusts the **OS store** (and `GIT_SSL_CAINFO`) but **ignores** `NODE_EXTRA_CA_CERTS`. Documented in the new "Git-based deployments" note.

### Other observations (out of scope)

- `clever profile` swallows TLS failures and reports `"token invalid"` (`profile.js`, `.catch(() => [null, null])`) — misleading for the exact audience this PR targets.
- `clever curl` shells out to the system `curl`, so it ignores `NODE_EXTRA_CA_CERTS` / `--use-system-ca`.
