### PR TITLE
fix(tls): surface TLS verification errors instead of masking them

### DIFF
--- a/src/lib/profile.js
+++ b/src/lib/profile.js
@@ -59,7 +59,14 @@ export async function getProfileDetails({ profile, isActive }) {
   const [user, token] = await Promise.all([
     getUser({}).then(sendWithCredentials),
     getCurrentTokenInfo().then(sendWithCredentials),
-  ]).catch(() => [null, null]);
+  ]).catch((error) => {
+    // An expired/invalid token surfaces as a 401: degrade gracefully so the command can report it.
+    // Any other failure (TLS, network…) must bubble up instead of being masked as "token invalid".
+    if (error?.cause?.response?.status === 401) {
+      return [null, null];
+    }
+    throw error;
+  });
 
   return {
     id: user?.id ?? profile.userId,

--- a/src/models/send-to-api.js
+++ b/src/models/send-to-api.js
@@ -75,6 +75,15 @@ async function executeRequest(requestParams, customConfig = {}) {
     .catch(processError);
 }
 
+// OpenSSL error codes raised when the server certificate chain isn't trusted
+// (corporate TLS-intercepting proxy, private or self-signed CA…).
+const TLS_ERROR_CODES = [
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+];
+
 export function processError(error) {
   const code = error.code ?? error?.cause?.code;
   if (code === 'EAI_AGAIN') {
@@ -86,6 +95,12 @@ export function processError(error) {
   if (error?.response?.status === 401) {
     throw new Error(
       `You're not logged in, use ${styleText('red', 'clever login')} command to connect to your Clever Cloud account`,
+      { cause: error },
+    );
+  }
+  if (TLS_ERROR_CODES.includes(code)) {
+    throw new Error(
+      `TLS certificate verification failed (${code}). If you're behind a corporate proxy or using a private/self-signed Certificate Authority, trust your CA and follow the "TLS certificates" section of the documentation.`,
       { cause: error },
     );
   }


### PR DESCRIPTION
## Context

Behind a TLS-intercepting proxy or with a private/self-signed CA, certificate verification fails. Two things made this needlessly confusing:

- Most commands surfaced the raw OpenSSL error, with no hint on how to fix it.
- `clever profile` went further: `getProfileDetails` catches *any* error and sets `isTokenValid = false`, so it reported `Your token is invalid or has expired, use clever login`. Misleading for the exact audience #1099 targets — it's a certificate-trust problem, and `clever login` can't fix it.

Follows up on #1099 (merged): the message points to the "TLS certificates" documentation it added.

## Changes

- **`send-to-api.js`** — `processError` maps TLS verification error codes (`SELF_SIGNED_CERT_IN_CHAIN`, `DEPTH_ZERO_SELF_SIGNED_CERT`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`) to an actionable message — same pattern as the existing `EAI_AGAIN` / `ECONNRESET` cases, so every API command benefits.
- **`profile.js`** — `getProfileDetails` only degrades to "no user" on a real `401`; transport/TLS errors now bubble up instead of being masked as "token invalid".

## Testing

`processError` checked in isolation: TLS codes → actionable message; `401` → login prompt; `ECONNRESET` → network message; anything else → rethrown untouched.

End-to-end against a public self-signed endpoint, no setup required:

```console
$ API_HOST=https://self-signed.badssl.com clever profile   # 4.10.0
[ERROR] Your token is invalid or has expired, use clever login command

$ API_HOST=https://self-signed.badssl.com clever profile   # this branch
[ERROR] TLS certificate verification failed (DEPTH_ZERO_SELF_SIGNED_CERT). If you're
behind a corporate proxy or using a private/self-signed Certificate Authority, trust
your CA and follow the "TLS certificates" section of the documentation.
```

Out of scope: `clever curl` (shells out to the system `curl`) and the system-git backend (native `git` TLS) keep their own behavior.
