### PR TITLE
fix(git): hint at the system git backend when run from a git worktree

### DIFF
--- a/src/commands/create/create.command.js
+++ b/src/commands/create/create.command.js
@@ -9,6 +9,7 @@ import { Logger } from '../../logger.js';
 import * as AppConfig from '../../models/app_configuration.js';
 import * as Application from '../../models/application.js';
 import { AVAILABLE_ZONES, listAvailableTypes, listAvailableZones } from '../../models/application.js';
+import { LinkedWorktreeNotSupportedError } from '../../models/git-isomorphic.js';
 import { Git } from '../../models/git.js';
 import { aliasCreationOption, humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
 
@@ -54,7 +55,13 @@ async function displayAppCreation(app, alias, github, taskCommand) {
       Logger.println(`    ${shellCommand('git commit -m "Initial commit"')}`);
       Logger.println();
     } else {
-      const isClean = await git.isGitWorkingDirectoryClean();
+      // Best-effort hint: if we can't tell because of a linked worktree on the JS backend, don't nag
+      const isClean = await git.isGitWorkingDirectoryClean().catch((error) => {
+        if (error instanceof LinkedWorktreeNotSupportedError) {
+          return true;
+        }
+        throw error;
+      });
       if (!isClean) {
         Logger.println(`  ${styleText('yellow', '!')} Commit your changes first:`);
         Logger.println(`    ${shellCommand('git add .')}`);

--- a/src/commands/deploy/deploy.docs.md
+++ b/src/commands/deploy/deploy.docs.md
@@ -28,6 +28,7 @@ Clever Tools uses a current JS implementation for git operations. This works wit
 * **HTTP-only**: cannot use SSH-based git protocols
 * **Slow performance** on repositories with rewritten history (rebases, squashes)
 * **Connection timeouts** on large repositories or when pushing big files, due to HTTP-based transfers
+* **No git worktree support**: deploying from a linked git worktree (`git worktree add`) fails with `Could not find HEAD`. The system git backend deploys from worktrees just like from the main working tree
 
 If you experience any of these issues, you can enable the **system git backend** which uses the `git` command installed on your system (it must be in your `PATH` environment variable).
 

--- a/src/models/git-isomorphic.js
+++ b/src/models/git-isomorphic.js
@@ -13,6 +13,9 @@ export class GitIsomorphic extends Git {
 
   async #getRepo() {
     const dir = await this._getRepoDir();
+    if (await this._isLinkedWorktree(dir)) {
+      throw new LinkedWorktreeNotSupportedError();
+    }
     return { fs, dir, http };
   }
 
@@ -128,7 +131,8 @@ export class GitIsomorphic extends Git {
    */
   async isInsideGitRepo() {
     this._debug('isInsideGitRepo');
-    return this.#getRepo()
+    // Don't go through #getRepo: it rejects linked worktrees, which are still git repos
+    return this._getRepoDir()
       .then(() => true)
       .catch(() => false);
   }
@@ -149,5 +153,16 @@ export class GitIsomorphic extends Git {
         return (!isHidden || isCleverJson) && head !== workdir;
       }).length === 0;
     return isStatusEmpty;
+  }
+}
+
+export class LinkedWorktreeNotSupportedError extends Error {
+  constructor() {
+    super(
+      "Linked git worktrees aren't supported by the default JS git backend.\n" +
+        'Enable the system git backend (it uses your installed git):\n' +
+        '    clever features enable system-git',
+    );
+    this.name = 'LinkedWorktreeNotSupportedError';
   }
 }

--- a/src/models/git.js
+++ b/src/models/git.js
@@ -67,6 +67,24 @@ export class Git {
   }
 
   /**
+   * Check if the repository is a linked git worktree.
+   * In a linked worktree (created with `git worktree add`), the top-level `.git`
+   * is a file holding a `gitdir:` pointer instead of a directory.
+   * @protected
+   * @param {string} [dir] - Repository directory (resolved automatically when omitted)
+   * @returns {Promise<boolean>}
+   */
+  async _isLinkedWorktree(dir) {
+    const repoDir = dir ?? (await this._getRepoDir());
+    try {
+      const stats = await fs.promises.stat(path.join(repoDir, '.git'));
+      return stats.isFile();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Add a remote to the repository
    * @param {string} remoteName
    * @param {string} url


### PR DESCRIPTION
Closes #1096

## Context

`clever deploy` from a linked git worktree (`git worktree add`) fails with a cryptic `[ERROR] Could not find HEAD.`

The default JS git backend (isomorphic-git) resolves `.git` as a directory. In a linked worktree `.git` is a *file* holding a `gitdir:` pointer, and refs live in the shared `commondir` — isomorphic-git supports neither. A real fix would mean routing every operation between the worktree gitdir and the commondir, on a backend we plan to phase out. The system git backend already handles worktrees natively, since it shells out to the installed `git`.

## Proposal

Two commits:

1. **`fix(git)`** — detect linked worktrees in the shared repo accessor and raise an actionable error pointing to the system git backend. The guard covers every JS-backend git operation, so `deploy`, `restart` and `create` all surface the same hint instead of crashing with `Could not find HEAD` / `ENOTDIR`:

   ```
   [ERROR] Linked git worktrees aren't supported by the default JS git backend.
           Enable the system git backend (it uses your installed git):
               clever features enable system-git
   ```

2. **`docs(deploy)`** — list worktrees among the JS backend limitations in the `🧪 Experimental: System git backend` section.

### Design decisions

- `isInsideGitRepo()` keeps returning `true` in a worktree (it bypasses the guard), so `clever create` doesn't wrongly suggest `git init`.
- `clever create`'s working-tree-clean hint is best-effort: it now swallows the worktree error instead of aborting the command.

## How to test

```bash
git worktree add ../wt -b some-branch && cd ../wt
clever deploy                       # actionable hint instead of "Could not find HEAD"
clever features enable system-git
clever deploy                       # deploys from the worktree
```