### PR TITLE
fix(prompts): surface a clear error when prompts run without a TTY

### DIFF
--- a/src/commands/profile/profile.switch.command.js
+++ b/src/commands/profile/profile.switch.command.js
@@ -75,6 +75,10 @@ async function resolveTargetProfile(profiles, requestedAlias) {
     name: formatProfile(profile),
     value: profile.alias,
   }));
-  const selectedAlias = await selectAnswer('Select a profile:', choices);
+  const selectedAlias = await selectAnswer(
+    'Select a profile:',
+    choices,
+    'Use --alias <name> to select a profile directly.',
+  );
   return profiles.find((profile) => profile.alias === selectedAlias);
 }

--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -45,7 +45,7 @@ export const sshCommand = defineCommand({
     let sshTarget;
     if (instances.length === 1) {
       sshTarget = instances[0].id;
-    } else if (process.stdout.isTTY) {
+    } else if (process.stdin.isTTY) {
       const choices = instances
         .sort((a, b) => a.instanceNumber - b.instanceNumber)
         .map((inst) => ({

--- a/src/lib/k8s.js
+++ b/src/lib/k8s.js
@@ -503,6 +503,7 @@ export async function k8sUpdateVersion(orgIdOrName, clusterIdOrName, askedVersio
     (await selectAnswer(
       `Which version do you want to update ${styleText('blue', name)} to, current is ${styleText('blue', versions.installed)}?`,
       [...versions.available].reverse(),
+      'Use --target <version> to update directly.',
     ));
 
   if (!versions.available.includes(targetVersion)) {

--- a/src/lib/operator-commands.js
+++ b/src/lib/operator-commands.js
@@ -77,6 +77,7 @@ export async function operatorUpdateVersion(provider, askedVersion, addonIdOrNam
     (await selectAnswer(
       `Which version do you want to update ${styleText('blue', name)} to, current is ${styleText('blue', versions.installed)}?`,
       versions.available.reverse(),
+      'Use --target <version> to update directly.',
     ));
 
   if (!versions.available.includes(targetVersion)) {

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -26,10 +26,12 @@ export async function confirmAnswer(message, rejectionMessage, expectedAnswer) {
 }
 
 export function selectAnswer(message, choices) {
+  assertInteractiveTerminal();
   return select({ message, choices }).catch(exitOnPromptError);
 }
 
 export function promptCheckbox(message, choices) {
+  assertInteractiveTerminal();
   return checkbox({ message, choices }).catch(exitOnPromptError);
 }
 
@@ -48,6 +50,20 @@ export function promptTextOption(option, defaultValue) {
     return result.success || result.error.issues[0]?.message || 'Invalid value';
   };
   return input({ message, default: defaultValue, validate }).catch(exitOnPromptError);
+}
+
+/**
+ * Throw an explicit error when no interactive terminal is available.
+ *
+ * Raw-mode prompts (select, checkbox) need a TTY on stdin. Without one (CI, scripts,
+ * pipes, `< /dev/null`), Inquirer reads EOF and throws ExitPromptError, which
+ * exitOnPromptError turns into a silent `process.exit(1)` — indistinguishable from a
+ * user pressing Ctrl+C. Guarding up front lets us surface a clear message instead.
+ */
+function assertInteractiveTerminal() {
+  if (!process.stdin.isTTY) {
+    throw new Error('This command requires an interactive terminal.');
+  }
 }
 
 function exitOnPromptError(error) {

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -25,13 +25,23 @@ export async function confirmAnswer(message, rejectionMessage, expectedAnswer) {
   }
 }
 
-export function selectAnswer(message, choices) {
-  assertInteractiveTerminal();
+/**
+ * @param {string} message
+ * @param {Array<unknown>} choices
+ * @param {string} [nonInteractiveHint] How to achieve the same result without a prompt (e.g. an option to use)
+ */
+export function selectAnswer(message, choices, nonInteractiveHint) {
+  assertInteractiveTerminal(nonInteractiveHint);
   return select({ message, choices }).catch(exitOnPromptError);
 }
 
-export function promptCheckbox(message, choices) {
-  assertInteractiveTerminal();
+/**
+ * @param {string} message
+ * @param {Array<unknown>} choices
+ * @param {string} [nonInteractiveHint] How to achieve the same result without a prompt (e.g. an option to use)
+ */
+export function promptCheckbox(message, choices, nonInteractiveHint) {
+  assertInteractiveTerminal(nonInteractiveHint);
   return checkbox({ message, choices }).catch(exitOnPromptError);
 }
 
@@ -59,10 +69,12 @@ export function promptTextOption(option, defaultValue) {
  * pipes, `< /dev/null`), Inquirer reads EOF and throws ExitPromptError, which
  * exitOnPromptError turns into a silent `process.exit(1)` — indistinguishable from a
  * user pressing Ctrl+C. Guarding up front lets us surface a clear message instead.
+ * @param {string} [hint] How to achieve the same result without a prompt (e.g. an option to use)
  */
-function assertInteractiveTerminal() {
+function assertInteractiveTerminal(hint) {
   if (!process.stdin.isTTY) {
-    throw new Error('This command requires an interactive terminal.');
+    const suffix = hint != null ? ` ${hint}` : '';
+    throw new Error(`This command requires an interactive terminal.${suffix}`);
   }
 }
 

--- a/src/models/oauth-consumer.js
+++ b/src/models/oauth-consumer.js
@@ -47,7 +47,7 @@ export async function promptRights(existingRights) {
     checked: existingRights?.[apiName] ?? false,
   }));
 
-  const selected = await promptCheckbox('Select rights', choices);
+  const selected = await promptCheckbox('Select rights', choices, 'Use --rights <list> to set rights directly.');
 
   return rightsFromList(selected);
 }


### PR DESCRIPTION
Closes #1092

## Context

Commands that prompt via `selectAnswer` or `promptCheckbox` (raw-mode `@inquirer/prompts`) exited with code `1` and **no error message** when run without a controlling terminal (CI, scripts, `< /dev/null`).

- Inquirer reads EOF on a non-TTY stdin and throws `ExitPromptError`
- `exitOnPromptError` turns that into a silent `process.exit(1)` — bypassing the normal `Logger.error` path
- result: exit 1, empty stderr, a half-rendered prompt left on screen

## Proposal

Guard `selectAnswer` / `promptCheckbox` up front on `process.stdin.isTTY` and throw an explicit error instead of letting Inquirer fail silently.

- `This command requires an interactive terminal.`
- with an optional per-command remediation hint, e.g. `Use --alias <name> to select a profile directly.`

Hints are added only where a non-interactive option exists:

| command | hint |
|---|---|
| `profile switch` | `--alias <name>` |
| `oauth-consumers create/update` | `--rights <list>` |
| `k8s version update` | `--target <version>` |
| `operator version update` (keycloak/metabase/otoroshi) | `--target <version>` |

`ssh` keeps its specific message (multiple instances) and has no hint (no selection option).

### Design decisions

- **Ctrl+C stays silent.** Ctrl+C and non-TTY both produce the same `ExitPromptError`, so they can't be told apart *after* the fact. The guard runs *before* the prompt and only triggers when `stdin` is not a TTY — so an interactive Ctrl+C still flows through the unchanged `exitOnPromptError` (silent exit), no regression.
- **`ssh` guard fix.** It tested `process.stdout.isTTY`; the failing case (`clever ssh < /dev/null` in a terminal) has a TTY stdout but a non-TTY stdin, so it slipped through. Now tests `stdin`.

## Commits

Split for a clean changelog (1 fix + 4 features; the refactor is internal):

- `fix(prompts)` — the guard + ssh fix
- `refactor(prompts)` — optional `nonInteractiveHint` argument
- `feat(profile)` / `feat(oauth-consumers)` / `feat(k8s)` / `feat(operators)` — per-command hints

## How to test

```bash
# non-TTY: clear message + exit 1 (was: silent)
node bin/clever.js profile switch < /dev/null

# Ctrl+C in an interactive terminal: still exits silently (no stacktrace)
node bin/clever.js profile switch   # then press Ctrl+C

# nominal: arrows + Enter still switches profile
node bin/clever.js profile switch
```