### PR TITLE
fix(cli): stop printing valid positional args as undefined errors

### DIFF
--- a/src/lib/cliparse-patched.js
+++ b/src/lib/cliparse-patched.js
@@ -1,4 +1,5 @@
 import cliparseOriginal from 'cliparse';
+import cliparseArgumentModule from 'cliparse/src/argument.js';
 import cliparseCommandModule from 'cliparse/src/command.js';
 import semver from 'semver';
 import pkg from '../../package.json' with { type: 'json' };
@@ -31,6 +32,23 @@ cliparseOriginal.command = function (name, options, commandFunction) {
     });
   });
   return command;
+};
+
+// Patch cliparse.argument.parseList to drop the parse results that succeeded
+// from its error payload. When several positional args are given and only one
+// fails its parser, parseList returns the *whole* result list (successes
+// included) as the error. Downstream, displayErrors prints the valid siblings
+// as `<arg-name>: undefined` (they carry an `.argument` but no `.error`).
+// We keep only the entries that actually failed, fixing the issue at its root.
+// The success path is untouched (we only rewrite the error array), and
+// missing-value errors carry an `.error` ("missing value") so they are kept.
+const originalParseList = cliparseArgumentModule.parseList;
+cliparseArgumentModule.parseList = function (args, providedArguments) {
+  const result = originalParseList(args, providedArguments);
+  if (Array.isArray(result.error)) {
+    return cliparseOriginal.parsers.error(result.error.filter((entry) => entry.error != null));
+  }
+  return result;
 };
 
 /**


### PR DESCRIPTION
Closes #1087

## Context
When a command takes several positional args and only one fails its parser, `cliparse@0.5.0` keeps the **whole** result list as the error payload (`argument.parseList`, `src/argument.js:53`). `cli.displayErrors` then prints the valid siblings as `<arg-name>: undefined`, so the user reads several errors when only one is real.

```
$ clever k8s nodegroups create kubernetes_01XXX nope BadFormat
cluster-id|cluster-name: undefined
nodegroup-name: undefined
flavor:count: Expected format: <flavor>:<count>
```

## Proposal
Patch `argument.parseList` in `src/lib/cliparse-patched.js` (the existing dedicated patch module) to keep only the entries that actually failed in its error payload.

### Design decisions
- Fixed at the **root** (`parseList`) rather than at the display layer: the error payload no longer carries successful results, instead of cleaning them up just before printing. The error array has a single consumer (`displayErrors`), so the effect is identical, but the fix sits where the wrong data is produced.
- Wrapper only rewrites the **error** branch — the success path (args passed to the handler) is untouched.
- Missing-value errors carry an `.error` (`"missing value"`), so a fully empty arg list still reports each arg.
- Kept local rather than patching `cliparse` upstream, consistent with the other patches in this module.

## How to test
`k8s` commands are behind a feature flag. With it enabled:

```
clever k8s nodegroups create kubernetes_01XXX nope BadFormat
# => flavor:count: Expected format: <flavor>:<count>   (single error)
```

Cases verified:
- 1 invalid arg out of 3 → only the invalid one is shown
- middle arg invalid → only that one
- all args missing → each reported as `missing value`
- option error (e.g. `--min notanumber`) → preserved
- all valid → handler runs normally with the parsed args