### PR TITLE
feat(accesslogs): restore CLF output format

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -260,7 +260,7 @@ clever accesslogs [options]
 -a, --alias <alias>               Short name for the application
     --app <app-id|app-name>       Application to manage by its ID (or name, if unambiguous)
     --before, --until <before>    Fetch logs before this date/time (ISO8601 date, positive number in seconds or duration, e.g.: 1h)
--F, --format <format>             Output format (human, json, json-stream) (default: human)
+-F, --format <format>             Output format (human, json, json-stream, clf) (default: human)
 ```
 
 ## activity

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -1,5 +1,6 @@
 import { ApplicationAccessLogStream } from '@clevercloud/client/esm/streams/access-logs.js';
 import { formatTable } from '../../format-table.js';
+import { formatClf } from '../../lib/access-logs-clf.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
@@ -8,12 +9,12 @@ import { JsonArray } from '../../models/json-array.js';
 import { getHostAndTokens } from '../../models/send-to-api.js';
 import { truncateWithEllipsis } from '../../models/utils.js';
 import {
+  accessLogsFormatOption,
   addonIdOrRealIdOption,
   afterOption,
   aliasOption,
   appIdOrNameOption,
   beforeOption,
-  logsFormatOption,
 } from '../global.options.js';
 
 const THROTTLE_ELEMENTS = 2000;
@@ -76,7 +77,7 @@ export const accesslogsCommand = defineCommand({
   options: {
     alias: aliasOption,
     app: appIdOrNameOption,
-    format: logsFormatOption,
+    format: accessLogsFormatOption,
     before: beforeOption,
     after: afterOption,
     addon: addonIdOrRealIdOption,
@@ -131,6 +132,14 @@ export const accesslogsCommand = defineCommand({
             break;
           case 'json-stream':
             Logger.printJson(log);
+            break;
+          case 'clf':
+            // when the connection is cut too early, or for TCP redirections, we don't have HTTP section
+            if (log.http == null) {
+              break;
+            }
+
+            Logger.println(formatClf(log));
             break;
           case 'human':
           default:

--- a/src/commands/accesslogs/accesslogs.docs.md
+++ b/src/commands/accesslogs/accesslogs.docs.md
@@ -17,4 +17,4 @@ clever accesslogs [options]
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`--before`, `--until` `<before>`|Fetch logs before this date/time (ISO8601 date, positive number in seconds or duration, e.g.: 1h)|
-|`-F`, `--format` `<format>`|Output format (human, json, json-stream) (default: human)|
+|`-F`, `--format` `<format>`|Output format (human, json, json-stream, clf) (default: human)|

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -28,6 +28,14 @@ export const logsFormatOption = defineOption({
   placeholder: 'format',
 });
 
+export const accessLogsFormatOption = defineOption({
+  name: 'format',
+  schema: z.enum(['human', 'json', 'json-stream', 'clf']).default('human'),
+  description: 'Output format',
+  aliases: ['F'],
+  placeholder: 'format',
+});
+
 export const beforeOption = defineOption({
   name: 'before',
   schema: z.string().transform(date).optional(),

--- a/src/lib/access-logs-clf.js
+++ b/src/lib/access-logs-clf.js
@@ -1,0 +1,52 @@
+const CLF_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * Format a `Date` as a Common Log Format timestamp in UTC, e.g. `10/Oct/2000:13:55:36 +0000`.
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatClfDate(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  const day = pad(date.getUTCDate());
+  const month = CLF_MONTHS[date.getUTCMonth()];
+  const year = date.getUTCFullYear();
+  const hours = pad(date.getUTCHours());
+  const minutes = pad(date.getUTCMinutes());
+  const seconds = pad(date.getUTCSeconds());
+  return `${day}/${month}/${year}:${hours}:${minutes}:${seconds} +0000`;
+}
+
+/**
+ * Escape a value so it can be safely embedded inside a double-quoted CLF field.
+ * Backslashes are escaped first, then double-quotes, otherwise a `"` would be escaped
+ * twice. Without this, a `"` in the value would close the quoted field early and shift
+ * every subsequent column.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeClfQuoted(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Format an HTTP access log as a Common Log Format line.
+ *
+ * The HTTP protocol version is absent from the v4 access log payload, so the request line is
+ * limited to `method path` (no `HTTP/x.y` token). The protocol token is optional in CLF parsers
+ * (grok, GoAccess), and emitting a `-` placeholder would actually break their structured parsing.
+ *
+ * @see https://en.wikipedia.org/wiki/Common_Log_Format
+ * @param {object} log an HTTP access log (the `http` section must be present)
+ * @returns {string}
+ */
+export function formatClf(log) {
+  const host = log.source.ip;
+  const ident = '-';
+  const authuser = '-';
+  const date = formatClfDate(log.date);
+  const request = `${log.http.request.method} ${escapeClfQuoted(log.http.request.path)}`;
+  const status = log.http.response.statusCode;
+  const bytes = log.bytesOut;
+
+  return `${host} ${ident} ${authuser} [${date}] "${request}" ${status} ${bytes}`;
+}


### PR DESCRIPTION
Closes #909

## Context

The Common Log Format was dropped during the Warp10 → v4 API migration (commit `619095d9`, early 2024), which reduced the available formats to `human`, `json` and `json-stream`. CLF was supported by the previous CLI and is still advertised in the public docs, so this is a regression (reopened via #909).

## Proposal

Re-add `--format clf` on `clever accesslogs`, backed by a dedicated formatter (`src/lib/access-logs-clf.js`) mapping the v4 access log shape to a CLF line:

```
203.0.113.7 - - [24/Jun/2026:08:05:43 +0000] "GET /apache_pb.gif" 200 2326
```

### Design decisions

- **Dedicated `accessLogsFormatOption`** instead of extending the shared `logsFormatOption` — that option is also used by `clever logs` (runtime logs), where an HTTP-only format is meaningless.
- **Request line is `method path` (no `HTTP/x.y`)** — the protocol version is absent from the v4 payload. The protocol token is optional in CLF parsers, and a `-` placeholder would actually break structured parsing (verified against the grok `COMMONAPACHELOG` pattern and GoAccess, both fall back to an unparsed request with `-`).
- **UTC `+0000`** for the timestamp — deterministic, no `clf-date` dependency re-added (custom helper instead, in line with the project trend of dropping small deps).
- **`clf` streams line by line** like `human`/`json-stream` → not subject to the `--before` requirement that `json` has (the latter buffers a JSON array that must be closed).
- TCP redirections / early-cut connections have no `http` section → skipped (same guard as `human`).

## How to test

```bash
clever accesslogs --format clf            # live tail, CLF lines
clever accesslogs --format clf --before 1h  # bounded fetch
```

Out of scope: the `extended` format (also removed in 2024) is not reintroduced — #909 only asks for CLF.