### PR TITLE
feat(commands): automate since version field for new commands

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,13 +14,44 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          fetch-depth: 0
       - id: read-changelog-types
         # Transform JSON to a single line for GitHub Actions output
         run: echo "content=$(jq -c . .github/config/changelog-types.json)" >> $GITHUB_OUTPUT
       - uses: google-github-actions/release-please-action@v3
+        id: release
         with:
           token: ${{ secrets.CI_TOKEN }}
           release-type: node
           include-v-in-tag: false
           default-branch: ${{ github.ref_name }}
           changelog-types: ${{ steps.read-changelog-types.outputs.content }}
+      # When a release PR is open, resolve `since: null` markers on new commands to
+      # the upcoming version, regenerate the docs, and push it all back onto the PR.
+      # The version comes from the bumped package.json on the release branch.
+      - name: 'Check out the release PR branch'
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          RELEASE_BRANCH: release-please--branches--${{ github.ref_name }}
+        run: |
+          git fetch origin "$RELEASE_BRANCH"
+          git checkout -B "$RELEASE_BRANCH" FETCH_HEAD
+      - uses: ./.github/actions/setup-node
+        if: ${{ steps.release.outputs.pr }}
+      - name: 'Resolve `since` versions and regenerate docs'
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          VERSION=$(jq -r .version package.json)
+          node scripts/resolve-since.js "$VERSION"
+          npm run docs
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to resolve, working tree is clean."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "docs(commands): resolve \`since\` to version $VERSION"
+          git push origin HEAD

--- a/scripts/lib/docs-llm.js
+++ b/scripts/lib/docs-llm.js
@@ -268,7 +268,7 @@ function getCommandSection(heading, path, definition) {
 
   const parts = [heading];
   parts.push(`**Description:** ${definition.description}`);
-  parts.push(`**Since:** ${definition.since}`);
+  parts.push(`**Since:** ${definition.since ?? 'Unreleased'}`);
 
   parts.push(formatSection('Usage', [commandInfo.usage]));
   if (argumentsRows) {

--- a/scripts/lib/docs-reference.js
+++ b/scripts/lib/docs-reference.js
@@ -185,7 +185,8 @@ function getSubCommands(name, command, parentPath = []) {
  * @return {string}
  */
 export function getSubCommandHeading(commandPath, definition) {
-  return `## ➡️ \`clever ${commandPath.join(' ')}\` <kbd>Since ${definition.since}</kbd>`;
+  const since = definition.since == null ? 'Unreleased' : `Since ${definition.since}`;
+  return `## ➡️ \`clever ${commandPath.join(' ')}\` <kbd>${since}</kbd>`;
 }
 
 /**

--- a/scripts/resolve-since.js
+++ b/scripts/resolve-since.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+//
+// Resolve the `since` marker of every command definition to a concrete version.
+//
+// New commands are committed with `since: null` because the version they ship in
+// is only known at release time (release-please computes it from accumulated
+// commits). This script, run from the release workflow against the release PR
+// branch, rewrites those markers to the upcoming version.
+//
+// It parses each `*.command.js` file with the TypeScript compiler API (AST) rather
+// than regexes, locates the object literal passed to `defineCommand({ ... })`, and
+// resolves its `since` property in two cases:
+//   - `since: null`  -> rewrite the value to `since: '<version>'`.
+//   - `since` absent from the literal:
+//       * if the literal spreads another definition (`...x`), `since` is inherited:
+//         leave the file untouched and do not report it.
+//       * otherwise the property was simply forgotten on a new command: insert
+//         `since: '<version>'` into the literal.
+// An already-set `since: '<string>'` is left strictly intact. Any other value
+// (neither `null` nor a string literal) is a hard error citing the file.
+//
+// Rewrites are surgical: only the touched property changes (via AST node offsets),
+// the rest of the file is preserved byte for byte (no reformatting).
+//
+// USAGE: resolve-since.js <version>
+//
+// ARGUMENTS:
+//   version         The upcoming release version (semver, e.g. 3.14.0)
+//
+// EXAMPLES:
+//   resolve-since.js 3.14.0
+//
+import fs from 'node:fs/promises';
+import { globSync } from 'tinyglobby';
+import ts from 'typescript';
+import { runCommand } from './lib/command.js';
+
+const SEMVER_REGEX = /^\d+\.\d+\.\d+$/;
+
+/**
+ * @typedef {Object} SinceResult
+ * @property {'resolved'|'inserted'|'unchanged'|'skip'} action - what was done to the file.
+ * @property {string} content - the resulting file content (equal to the input when nothing changed).
+ * @property {string} [reason] - why the file was skipped (only set when action is 'skip').
+ */
+
+runCommand(async () => {
+  const version = process.argv[2];
+
+  if (version == null || version === '') {
+    throw new Error('Missing argument: version');
+  }
+  if (!SEMVER_REGEX.test(version)) {
+    throw new Error(`Invalid version "${version}", expected semver (e.g. 3.14.0)`);
+  }
+
+  const commandFiles = globSync('src/commands/**/*.command.js');
+  /** @type {string[]} */
+  const resolvedFiles = [];
+  /** @type {string[]} */
+  const insertedFiles = [];
+
+  for (const file of commandFiles) {
+    const content = await fs.readFile(file, 'utf-8');
+    const result = resolveSince(content, version, file);
+
+    switch (result.action) {
+      case 'skip':
+        console.warn(`Skipped ${file}: ${result.reason}`);
+        break;
+      case 'resolved':
+        await fs.writeFile(file, result.content);
+        resolvedFiles.push(file);
+        break;
+      case 'inserted':
+        await fs.writeFile(file, result.content);
+        insertedFiles.push(file);
+        break;
+      case 'unchanged':
+      default:
+        break;
+    }
+  }
+
+  if (resolvedFiles.length === 0 && insertedFiles.length === 0) {
+    console.log('No `since` to resolve.');
+    return;
+  }
+
+  if (resolvedFiles.length > 0) {
+    console.log(`Resolved ${resolvedFiles.length} \`since: null\` to ${version} in:`);
+    for (const file of resolvedFiles) {
+      console.log(`- ${file}`);
+    }
+  }
+  if (insertedFiles.length > 0) {
+    console.log(`Inserted missing \`since: '${version}'\` in:`);
+    for (const file of insertedFiles) {
+      console.log(`- ${file}`);
+    }
+  }
+});
+
+/**
+ * Resolves the `since` marker of a single command file.
+ * @param {string} content - the file source.
+ * @param {string} version - the upcoming release version.
+ * @param {string} file - the file path (used for error/skip messages).
+ * @returns {SinceResult}
+ */
+function resolveSince(content, version, file) {
+  const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const objectLiteral = findDefineCommandObject(sourceFile);
+
+  if (objectLiteral == null) {
+    return { action: 'skip', content, reason: 'no `defineCommand({ ... })` call found' };
+  }
+
+  /** @type {ts.PropertyAssignment | null} */
+  let sinceProp = null;
+  let hasSpread = false;
+  for (const prop of objectLiteral.properties) {
+    if (ts.isSpreadAssignment(prop)) {
+      hasSpread = true;
+    } else if (ts.isPropertyAssignment(prop) && getPropertyName(prop.name) === 'since') {
+      sinceProp = prop;
+    }
+  }
+
+  // Case 1: `since` is present in the literal.
+  if (sinceProp != null) {
+    const init = sinceProp.initializer;
+
+    if (init.kind === ts.SyntaxKind.NullKeyword) {
+      // `since: null` -> replace just the `null` value with the version string.
+      const start = init.getStart(sourceFile);
+      const end = init.getEnd();
+      const updated = content.slice(0, start) + `'${version}'` + content.slice(end);
+      return { action: 'resolved', content: updated };
+    }
+
+    if (ts.isStringLiteral(init)) {
+      // Already set to a concrete version: leave strictly intact.
+      return { action: 'unchanged', content };
+    }
+
+    throw new Error(
+      `Unexpected \`since\` value in ${file}: \`${init.getText(sourceFile)}\` (expected a string literal or null)`,
+    );
+  }
+
+  // Case 2: `since` is absent but inherited through a spread (`...x`): leave untouched.
+  if (hasSpread) {
+    return { action: 'unchanged', content };
+  }
+
+  // Case 3: `since` is absent and nothing is spread: it was forgotten, insert it.
+  // This safety net (and `insertSince` below) can be dropped once command files are
+  // typechecked, since a missing required `since` would then be caught by `tsc`.
+  const updated = insertSince(content, objectLiteral, sourceFile, version);
+  return { action: 'inserted', content: updated };
+}
+
+/**
+ * Finds the object literal passed as the first argument of the `defineCommand(...)` call.
+ * @param {ts.SourceFile} sourceFile
+ * @returns {ts.ObjectLiteralExpression | null}
+ */
+function findDefineCommandObject(sourceFile) {
+  /**
+   * @param {ts.Node} node
+   * @returns {ts.ObjectLiteralExpression | null}
+   */
+  function visit(node) {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === 'defineCommand') {
+      const arg = node.arguments[0];
+      if (arg != null && ts.isObjectLiteralExpression(arg)) {
+        return arg;
+      }
+    }
+    // `ts.forEachChild` stops and bubbles up the first truthy callback result.
+    return ts.forEachChild(node, visit) ?? null;
+  }
+
+  return visit(sourceFile);
+}
+
+/**
+ * Inserts a `since: '<version>'` property right after the first property of the literal,
+ * matching the indentation of the existing properties.
+ * @param {string} content - the file source.
+ * @param {ts.ObjectLiteralExpression} objectLiteral
+ * @param {ts.SourceFile} sourceFile
+ * @param {string} version
+ * @returns {string}
+ */
+function insertSince(content, objectLiteral, sourceFile, version) {
+  const property = `since: '${version}'`;
+
+  // Empty literal (`defineCommand({})`): insert right after the opening brace.
+  if (objectLiteral.properties.length === 0) {
+    const insertPos = objectLiteral.getStart(sourceFile) + 1; // just after `{`
+    return content.slice(0, insertPos) + `\n  ${property},\n` + content.slice(insertPos);
+  }
+
+  const firstProp = objectLiteral.properties[0];
+  const propStart = firstProp.getStart(sourceFile);
+  const lineStart = content.lastIndexOf('\n', propStart - 1) + 1;
+  const indent = content.slice(lineStart, propStart).match(/^[ \t]*/)?.[0] ?? '';
+
+  // Insert after the first property, skipping its trailing comma if there is one.
+  let insertPos = firstProp.getEnd();
+  let scan = insertPos;
+  while (scan < content.length && /\s/.test(content[scan])) {
+    scan += 1;
+  }
+  let prefix = '';
+  if (content[scan] === ',') {
+    insertPos = scan + 1;
+  } else {
+    // No trailing comma on the first property: add one before our insertion.
+    prefix = ',';
+  }
+
+  return content.slice(0, insertPos) + `${prefix}\n${indent}${property},` + content.slice(insertPos);
+}
+
+/**
+ * Reads the static name of an object property (identifier or string literal key).
+ * @param {ts.PropertyName} name
+ * @returns {string}
+ */
+function getPropertyName(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return name.getText();
+}

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1060,7 +1060,7 @@ clever drain [options]
 
 **Description:** Check that a drain's recipient is reachable and accepts deliveries
 
-**Since:** unreleased
+**Since:** Unreleased
 
 **Usage**
 ```

--- a/src/commands/drain/drain.check.command.js
+++ b/src/commands/drain/drain.check.command.js
@@ -14,7 +14,7 @@ import { drainIdArg } from './drain.args.js';
 
 export const drainCheckCommand = defineCommand({
   description: "Check that a drain's recipient is reachable and accepts deliveries",
-  since: 'unreleased',
+  since: null,
   options: {
     alias: aliasOption,
     appIdOrName: appIdOrNameOption,

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -17,7 +17,7 @@ clever drain [options]
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
 
-## ➡️ `clever drain check` <kbd>Since unreleased</kbd>
+## ➡️ `clever drain check` <kbd>Unreleased</kbd>
 
 Check that a drain's recipient is reachable and accepts deliveries
 

--- a/src/lib/define-command.types.d.ts
+++ b/src/lib/define-command.types.d.ts
@@ -41,8 +41,13 @@ export interface CommandDefinition<
    */
   featureFlag?: string;
 
-  /** Version when this command was introduced (semver format, e.g., '2.1.0'). */
-  since?: `${number}.${number}.${number}`;
+  /**
+   * Version when this command was introduced (semver format, e.g., '2.1.0').
+   * Use `null` for a command not yet released: the release workflow resolves it
+   * to the upcoming version (see `scripts/resolve-since.js`). Required on purpose,
+   * so a missing value is a type error rather than a silent omission.
+   */
+  since: `${number}.${number}.${number}` | null;
 
   /** Options (named options like --type, --region, --format). */
   options?: O;


### PR DESCRIPTION
Closes #1039

## Context

The `since` field records the version a command shipped in, but that version is unknown at commit time — release-please computes it later from accumulated commits (feat → minor, fix → patch). Contributors had to guess the number or leave an informal `since: 'unreleased'` string (which already crept into `drain check`).

## Proposal

Make `since` an explicit, type-checked contract and fill the real version automatically at release time.

- **Required, `version | null`** — `since` is no longer optional. `null` means "not yet released"; a missing value is now a TypeScript error rather than a silent omission. A real semver value is still type-checked via the template literal.
- **Doc generation** — `since === null` renders as `Unreleased` (clean badge) instead of the previous `Since undefined`.
- **Release automation** — when release-please opens its release PR, a workflow step reads the bumped version from `package.json`, rewrites every `since: null` to that version (`scripts/resolve-since.js`), regenerates the docs, and pushes it back onto the PR. After merge, `master` always has accurate version info.

### Design decisions

- **`null` over a `'unreleased'` placeholder** — the original idea (issue option C) was a magic string. `null` is unambiguous to detect (`=== null`), can't be confused with a real version, and being *required* prevents silent omission. This was the conclusion of the discussion on the issue.
- **Resolve in the release PR (option A)** over resolving at doc-gen time (option B) — keeps the source as the source of truth and avoids mis-dating a command if a `null` survives several releases.

## How to review

1. `src/lib/define-command.types.d.ts` — the contract change (`since: version | null`, required).
2. `scripts/lib/docs-reference.js` + `scripts/lib/docs-llm.js` — the `Unreleased` guard.
3. `scripts/resolve-since.js` — the rewrite script (validates semver, replaces `since: null`).
4. `.github/workflows/release-please.yml` — the release-time step.
5. `drain check` + regenerated docs — migration of the existing `'unreleased'` placeholder.

## Notes

- `npm run docs` hits the public CC API (zones/products) — already the case for `docs:check`, so the release job has the same dependency.
- `code-quality.yml` ignores `release-please--**`, so docs are regenerated in the release step to keep `master` consistent after merge.
- No infinite loop: pushing to the release branch doesn't trigger the workflow (trigger = push to `master`).