### PR TITLE
feat(proxy): honor http_proxy/https_proxy environment variables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,33 @@ If you switch to the system git backend (`clever features enable system-git`), `
 > [!WARNING]
 > Disabling TLS verification entirely (for example with `NODE_TLS_REJECT_UNAUTHORIZED=0`) exposes you to man-in-the-middle attacks, including the theft of your Clever Cloud credentials. Always prefer trusting your CA with one of the methods above.
 
+## HTTP proxy
+
+On a network where outgoing traffic must go through an HTTP proxy, Clever Tools follows the same `http_proxy` / `https_proxy` environment variables as tools like `curl`, `kubectl` or `s3cmd`. Set them in your shell and every request the CLI makes (API calls, update checks…) is routed through the proxy:
+
+```bash
+# Linux / macOS
+export http_proxy=http://proxy.example.com:3128
+export https_proxy=http://proxy.example.com:3128
+clever profile
+```
+
+```powershell
+# Windows (PowerShell)
+$env:http_proxy = "http://proxy.example.com:3128"
+$env:https_proxy = "http://proxy.example.com:3128"
+clever profile
+```
+
+The uppercase variants (`HTTP_PROXY`, `HTTPS_PROXY`) are also recognized, and a proxy that requires authentication can be configured inline with `http://user:password@proxy.example.com:3128`. To bypass the proxy for some hosts, list them in the `no_proxy` (or `NO_PROXY`) variable:
+
+```bash
+export no_proxy=localhost,127.0.0.1,.internal.example.com
+```
+
+> [!NOTE]
+> Like the TLS variables above, proxy variables are read at startup: set them in your shell or inline before the command, not in a `.env` file. With the `system-git` feature enabled, `clever deploy` delegates to your system `git`, which follows its own proxy configuration (`git config --global http.proxy …` or the same `http_proxy`/`https_proxy` variables).
+
 ## features
 
 Some features are available as experimental, before they're completely ready for prime time. They usually work well, but this testing phase allows us to get feedbacks, refine some details, documentation, and break things between two releases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,33 @@ If you switch to the system git backend (`clever features enable system-git`), `
 > [!WARNING]
 > Disabling TLS verification entirely (for example with `NODE_TLS_REJECT_UNAUTHORIZED=0`) exposes you to man-in-the-middle attacks, including the theft of your Clever Cloud credentials. Always prefer trusting your CA with one of the methods above.
 
+## HTTP proxy
+
+On a network where outgoing traffic must go through an HTTP proxy, Clever Tools follows the same `http_proxy` / `https_proxy` environment variables. Set them in your shell and every request the CLI makes (API calls, update checks…) is routed through the proxy:
+
+```bash
+# Linux / macOS
+export http_proxy=http://proxy.example.com:3128
+export https_proxy=http://proxy.example.com:3128
+clever profile
+```
+
+```powershell
+# Windows (PowerShell)
+$env:http_proxy = "http://proxy.example.com:3128"
+$env:https_proxy = "http://proxy.example.com:3128"
+clever profile
+```
+
+The uppercase variants (`HTTP_PROXY`, `HTTPS_PROXY`) are also recognized, and a proxy that requires authentication can be configured inline with `http://user:password@proxy.example.com:3128`. To bypass the proxy for some hosts, list them in the `no_proxy` (or `NO_PROXY`) variable:
+
+```bash
+export no_proxy=localhost,127.0.0.1,.internal.example.com
+```
+
+> [!NOTE]
+> Like the TLS variables above, proxy variables are read at startup: set them in your shell or inline before the command, not in a `.env` file. With the `system-git` feature enabled, `clever deploy` delegates to your system `git`, which follows its own proxy configuration (`git config --global http.proxy …` or the same `http_proxy`/`https_proxy` variables).
+
 ## features
 
 Some features are available as experimental, before they're completely ready for prime time. They usually work well, but this testing phase allows us to get feedbacks, refine some details, documentation, and break things between two releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "simple-git": "3.30.0",
         "slugify": "1.6.6",
         "tldts": "7.0.19",
+        "undici": "7.24.4",
         "update-notifier": "7.3.1",
         "xdg": "0.1.1",
         "zod": "4.1.13"
@@ -4400,6 +4401,16 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/@yao-pkg/pkg-fetch/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@yao-pkg/pkg-fetch/node_modules/yargs": {
@@ -9394,10 +9405,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "simple-git": "3.30.0",
         "slugify": "1.6.6",
         "tldts": "7.0.19",
+        "undici": "7.24.4",
         "update-notifier": "7.3.1",
         "xdg": "0.1.1",
         "zod": "4.1.13"
@@ -4412,6 +4413,16 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/@yao-pkg/pkg-fetch/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@yao-pkg/pkg-fetch/node_modules/yargs": {
@@ -9396,10 +9407,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "dev": true,
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "simple-git": "3.30.0",
     "slugify": "1.6.6",
     "tldts": "7.0.19",
+    "undici": "7.24.4",
     "update-notifier": "7.3.1",
     "xdg": "0.1.1",
     "zod": "4.1.13"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "simple-git": "3.30.0",
     "slugify": "1.6.6",
     "tldts": "7.0.19",
+    "undici": "7.24.4",
     "update-notifier": "7.3.1",
     "xdg": "0.1.1",
     "zod": "4.1.13"

--- a/src/initial-setup.js
+++ b/src/initial-setup.js
@@ -1,4 +1,17 @@
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 import { hasParam } from './lib/has-param.js';
+
+// Node's global fetch() ignores the http_proxy/https_proxy environment variables,
+// unlike most CLI tools (curl, kubectl, s3cmd…). When such a variable is set, install
+// an EnvHttpProxyAgent as the global dispatcher so every fetch() (API calls, update
+// checks…) routes through the proxy and honors no_proxy for exclusions. We only swap
+// the dispatcher when a proxy is actually configured, leaving the default behavior
+// untouched for everyone else.
+const hasProxyConfig =
+  process.env.http_proxy || process.env.https_proxy || process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+if (hasProxyConfig) {
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+}
 
 // These need to be set before Logger and other stuffs
 if (hasParam('-v') || hasParam('--verbose')) {


### PR DESCRIPTION
Closes #1050

## Context

On corporate networks where all outgoing traffic must go through an authenticating HTTP proxy, `clever` failed with `ECONNREFUSED`. Unlike `curl`, `kubectl` or `s3cmd`, Node's global `fetch()` **ignores** the `http_proxy`/`https_proxy` environment variables by default — so the CLI never used the proxy.

The reporter found a workaround (`NODE_USE_ENV_PROXY=1`), but that requires users to know a magic variable, only works on recent Node, and emits an experimental warning on some of the versions where it does. We can do better: behave like the other CLI tools and pick up the proxy automatically.

## Proposal

Install an `EnvHttpProxyAgent` (from `undici`) as the global dispatcher at startup, so **every** request the CLI makes (API calls, update checks…) routes through the proxy:

- triggers on `http_proxy` / `https_proxy` (and the uppercase variants)
- honors `no_proxy` / `NO_PROXY` for exclusions
- supports authenticated proxies via `http://user:password@host:port`
- the dispatcher is **only** swapped when a proxy is actually configured → zero behavior change for users without a proxy

Done in `src/initial-setup.js` because it must run before the first `fetch()`.

### Design decisions

- **`undici` dependency + `setGlobalDispatcher`** rather than the native `NODE_USE_ENV_PROXY=1`: the native variable is read at boot only (can't be enabled from JS at runtime), is gated behind Node ≥ ~22.18, and prints an experimental warning. The `undici` route works at runtime on any supported Node, with no warning, and requires no action from the user.
- `undici` pinned to **7.24.4**, the same major bundled inside Node 24 → the global-dispatcher symbol is shared with the built-in `fetch`.

`undici@7.24.4` requires Node ≥ 20.18.1 and is the same major as the `undici` bundled in Node 24, so the global-dispatcher symbol is shared with the built-in `fetch`.

## Out of scope

- **`system-git` deploys**: with that feature enabled, `clever deploy` delegates to the system `git` binary, which follows its own proxy configuration (`git config http.proxy` / its own reading of `http_proxy`). Not covered here, documented in the README.
