### PR TITLE
ci(release): derive release PR branch from release-please output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Check out the release PR branch'
         if: ${{ steps.release.outputs.pr }}
         env:
-          RELEASE_BRANCH: release-please--branches--${{ github.ref_name }}
+          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
         run: |
           git fetch origin "$RELEASE_BRANCH"
           git checkout -B "$RELEASE_BRANCH" FETCH_HEAD


### PR DESCRIPTION
Closes #1105 follow-up.

## Context

PR #1105 added a step that resolves `since: null` markers on new commands to the upcoming version, on the open release PR. It never ran successfully.

- the step rebuilds the branch name from `github.ref_name` → `release-please--branches--master`
- the real release PR branch carries a component suffix → `release-please--branches--master--components--clever-tools`
- `git fetch origin release-please--branches--master` → `fatal: couldn't find remote ref` → exit 128

The failing run on the #1105 merge: [`28432947414`](https://github.com/CleverCloud/clever-tools/actions/runs/28432947414).

## Proposal

Read the branch name from the release-please `pr` output instead of reconstructing it:

```yaml
RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
```

`headBranchName` is the documented field on the PullRequest object exposed by the `pr` output. This stays correct regardless of the component suffix or any future change in release-please's branch naming.

The unrelated `concurrency.group: release-please-${{ github.ref }}` is a concurrency key, not a branch name, and is left untouched.

## How to test

Effective on the next push to master while a release PR is open (or by re-running the workflow). Expected: the release PR gains a second commit `docs(commands): resolve since to version X` whenever `since: null` markers are present.