### PR TITLE
ci(release): resolve since against the open release PR, not the action output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,7 +67,7 @@ jobs:
             echo "Nothing to resolve, working tree is clean."
             exit 0
           fi
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'clevercloud-ci'
+          git config user.email '43004578+clevercloud-ci@users.noreply.github.com'
           git commit -m "docs(commands): resolve \`since\` to version $VERSION"
           git push origin HEAD

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,21 +30,37 @@ jobs:
           changelog-types: ${{ steps.read-changelog-types.outputs.content }}
       # When a release PR is open, resolve `since: null` markers on new commands to
       # the upcoming version, regenerate the docs, and push it all back onto the PR.
-      # The version comes from the bumped package.json on the release branch.
-      - name: 'Check out the release PR branch'
-        if: ${{ steps.release.outputs.pr }}
+      # The open PR is looked up directly (rather than via the action's `pr` output,
+      # which is empty whenever the PR didn't change this run) so the resolution also
+      # runs on pushes that leave the release PR untouched.
+      - name: 'Find the open release PR branch'
+        id: release-pr
         env:
-          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+          PREFIX: release-please--branches--${{ github.ref_name }}
+        run: |
+          BRANCH=$(gh pr list --state open --json headRefName \
+            --jq "[.[] | select(.headRefName | startswith(\"$PREFIX\"))][0].headRefName // empty")
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+      - name: 'Check out the release PR branch'
+        if: ${{ steps.release-pr.outputs.branch }}
+        env:
+          RELEASE_BRANCH: ${{ steps.release-pr.outputs.branch }}
         run: |
           git fetch origin "$RELEASE_BRANCH"
           git checkout -B "$RELEASE_BRANCH" FETCH_HEAD
       - uses: ./.github/actions/setup-node
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.branch }}
       - name: 'Resolve `since` versions and regenerate docs'
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.branch }}
         run: |
           VERSION=$(jq -r .version package.json)
           node scripts/resolve-since.js "$VERSION"
+          # Safety net: no `since: null` may survive on the release branch.
+          if grep -rEn "since:[[:space:]]*null" src/commands --include="*.command.js"; then
+            echo "::error::Unresolved \`since: null\` remains on the release branch"
+            exit 1
+          fi
           npm run docs
           git add -A
           if git diff --cached --quiet; then


### PR DESCRIPTION
Supersedes #1108. Fixes the `since` auto-resolution introduced in #1105, which never actually ran successfully on a release PR.

## Background

#1105 added a step to `release-please.yml` that, while a release PR is open:
- reads the bumped version from `package.json` on the release branch,
- runs `scripts/resolve-since.js` to rewrite every `since: null` command marker to that version,
- regenerates the docs and pushes it all back onto the release PR.

The intent: contributors ship new commands with `since: null` (the version is unknown at commit time), and the release workflow fills in the real version once release-please knows it. In practice the step failed on every run, for three distinct reasons.

## What was broken

**1. Wrong branch name (the original #1105 run)**

The step rebuilt the branch from `github.ref_name`:

```
release-please--branches--master
```

But the real release PR branch carries a component suffix:

```
release-please--branches--master--components--clever-tools
```

So `git fetch origin release-please--branches--master` → `fatal: couldn't find remote ref` → exit 128. Failing run: [`28432947414`](https://github.com/CleverCloud/clever-tools/actions/runs/28432947414).

**2. `fromJSON('')` template crash (the #1108 attempt)**

#1108 switched to reading the branch from the action output:

```yaml
RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
```

`steps.release.outputs.pr` is empty whenever a push leaves the release PR unchanged — release-please logs `✔ PR #1098 remained the same` and sets no `pr` output. `fromJSON('')` is a hard template error, and crucially the step's `if: steps.release.outputs.pr` guard does **not** protect it, because `env` expressions are evaluated as part of the same template, not gated by `if`. Failing run: [`28436109628`](https://github.com/CleverCloud/clever-tools/actions/runs/28436109628):

```
The template is not valid ... (Line: 37, Col: 27):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

**3. Gating on `outputs.pr` can drop a `since` resolution entirely**

Even fixed, `outputs.pr` answers *"did the PR change this run?"*, not *"is a release PR open?"* — the question we actually need. So resolution would be skipped on any push that doesn't touch the release PR:
- a hidden-type commit (`ci` / `docs` / `chore` / `refactor`), which leaves the PR "remained the same";
- a run killed by `cancel-in-progress` *after* release-please force-pushed the branch but *before* our resolution commit was pushed — the next run then sees "remained the same" and skips.

In both cases `since: null` stays on the release branch, and merging the release PR in that window would ship `since: null` to `master`.

## The fix

**Look the open release PR up directly**, instead of relying on `outputs.pr`:

```yaml
- name: 'Find the open release PR branch'
  id: release-pr
  env:
    GH_TOKEN: ${{ secrets.CI_TOKEN }}
    PREFIX: release-please--branches--${{ github.ref_name }}
  run: |
    BRANCH=$(gh pr list --state open --json headRefName \
      --jq "[.[] | select(.headRefName | startswith(\"$PREFIX\"))][0].headRefName // empty")
    echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
```

- matches the `release-please--branches--<branch>` prefix, so the `--components--clever-tools` suffix (or any future suffix) is picked up automatically;
- emits a plain string output → no `fromJSON` in any template, so the downstream `if: steps.release-pr.outputs.branch` guard cleanly skips when there is no open release PR;
- runs on **every** push to master while a release PR is open, independent of whether release-please touched it this run. The resolution is idempotent (commit only on diff), so re-running is a no-op when nothing changed.

This closes problems 1, 2 and 3. The intra-job ordering is safe: steps run sequentially, so by the time `gh pr list` runs, the preceding release-please step has already created/updated the PR via its synchronous API calls — the PR (and its branch) exist.

**Safety net.** After resolution, fail the run if any `since: null` survives:

```bash
if grep -rEn "since:[[:space:]]*null" src/commands --include="*.command.js"; then
  echo "::error::Unresolved \`since: null\` remains on the release branch"
  exit 1
fi
```

**Commit identity.** The resolution commit is now authored as `clevercloud-ci` (`43004578+clevercloud-ci@users.noreply.github.com`), matching release-please's own release commits, instead of `github-actions[bot]`.

## How it behaves now

- push that opens/updates the release PR (e.g. a `feat`) → branch found → `since` resolved, docs regenerated, commit pushed onto the PR;
- push that leaves the release PR unchanged (e.g. this `ci` merge) → branch still found → resolution re-runs idempotently; if nothing to resolve, the step exits clean (green);
- no open release PR → lookup returns empty → all steps skipped, job green.

## Known limitation

The grep safety net runs on the push-to-master workflow, so it guards the release branch continuously but is not a hard merge-block. The only remaining (narrow) window is merging the release PR mid-burst, before a resolution run lands. A fully blocking guard would be a separate `on: pull_request` required check that fails when a release PR still contains `since: null`; left as a possible follow-up.

## How to test

Effective on the next push to master. Watch the `release-please` workflow:
- `ci`/`docs` push (PR unchanged) → previously **failed** at template parsing, now the resolution step runs (or exits clean) and the job is **green**;
- next `feat`/`fix` → release PR gains a `docs(commands): resolve since to version X` commit authored by `clevercloud-ci`, with all `since: null` replaced.
