### PR TITLE
feat(drain): support Splunk HEC as a drain target

### DIFF
--- a/docs/services-logs-drains.md
+++ b/docs/services-logs-drains.md
@@ -20,6 +20,7 @@ Where `DRAIN-TYPE` is one of:
 - `newrelic`: for NewRelic endpoint (note that this endpoint needs your NewRelic API Key)
 - `ovh-tcp`: for OVH TCP syslog endpoint (note that this endpoint has an optional sd-params parameter)
 - `raw-http`: for HTTP endpoint (note that this endpoint has optional username/password parameters as HTTP Basic Authentication)
+- `splunk`: for Splunk HTTP Event Collector endpoint (note that this endpoint needs an HEC token)
 - `syslog-tcp`: for TCP syslog endpoint
 - `syslog-udp`: for UDP syslog endpoint
 
@@ -31,6 +32,11 @@ Drain creation supports the following options:
 [--api-key, -k] API_KEY               API key (for newrelic)
 [--index-prefix, -i] INDEX_PREFIX     Optional index prefix (for elasticsearch), `logstash` value is used if not set
 [--sd-params, -s] SD_PARAMS           RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`
+[--source-token, -t] SOURCE_TOKEN     Source token (for betterstack)
+[--hec-token] HEC_TOKEN               HTTP Event Collector token (for splunk)
+[--index] INDEX                       Optional target index (for splunk), the HEC token's own index is used if not set
+[--sourcetype] SOURCETYPE             Optional sourcetype (for splunk), the HEC token's own sourcetype is used if not set
+[--tls-verification] MODE             TLS verification mode (for splunk), `default` or `trustful`
 ```
 
 ## ElasticSearch logs drains
@@ -51,6 +57,22 @@ clever drain create DatadogHTTP "https://http-intake.logs.datadoghq.com/v1/input
 ```
 
 The `host` query parameter is not mandatory: in the Datadog pipeline configuration, you can map `@source_host` which is the host provided by Clever Cloud in logs as `host` property.
+
+## Splunk logs drains
+
+Splunk drains send events to the [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) (HEC). The URL is the full collector endpoint, the token is the one bound to your HEC input:
+
+```
+clever drain create splunk "https://<HOST>:8088/services/collector/event" --hec-token <HEC_TOKEN>
+```
+
+`--index` and `--sourcetype` are optional: when they're not set, the values configured on the HEC token itself apply. When they are set, they override it for every forwarded event.
+
+A self-hosted Splunk ships a self-signed certificate on port 8088 by default. If you didn't replace it, add `--tls-verification trustful` so the drain doesn't fail on certificate verification:
+
+```
+clever drain create splunk "https://<HOST>:8088/services/collector/event" --hec-token <HEC_TOKEN> --tls-verification trustful
+```
 
 ## NewRelic logs drains
 

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1093,21 +1093,25 @@ clever drain create <drain-type> <drain-url> [options]
 
 **Arguments**
 ```
-drain-type                           Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)
-drain-url                            Drain URL
+drain-type                                   Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, splunk, syslog-tcp, syslog-udp)
+drain-url                                    Drain URL
 ```
 
 **Options**
 ```
-    --addon <addon-id>               Add-on ID or real ID
--a, --alias <alias>                  Short name for the application
--k, --api-key <api-key>              API key (for newrelic)
-    --app <app-id|app-name>          Application to manage by its ID (or name, if unambiguous)
--i, --index-prefix <index-prefix>    Optional index prefix (for elasticsearch), `logstash` value is used if not set
--p, --password <password>            Basic auth password (for elasticsearch or raw-http)
--s, --sd-params <sd-params>          RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`
--t, --source-token <source-token>    Source token (for betterstack)
--u, --username <username>            Basic auth username (for elasticsearch or raw-http)
+    --addon <addon-id>                       Add-on ID or real ID
+-a, --alias <alias>                          Short name for the application
+-k, --api-key <api-key>                      API key (for newrelic)
+    --app <app-id|app-name>                  Application to manage by its ID (or name, if unambiguous)
+    --hec-token <hec-token>                  HTTP Event Collector token (for splunk)
+    --index <index>                          Optional target index (for splunk), the HEC token's own index is used if not set
+-i, --index-prefix <index-prefix>            Optional index prefix (for elasticsearch), `logstash` value is used if not set
+-p, --password <password>                    Basic auth password (for elasticsearch or raw-http)
+-s, --sd-params <sd-params>                  RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`
+-t, --source-token <source-token>            Source token (for betterstack)
+    --sourcetype <sourcetype>                Optional sourcetype (for splunk), the HEC token's own sourcetype is used if not set
+    --tls-verification <tls-verification>    TLS verification mode (for splunk), use `trustful` to accept a self-signed certificate (default, trustful)
+-u, --username <username>                    Basic auth username (for elasticsearch or raw-http)
 ```
 
 ### drain disable

--- a/src/commands/drain/drain.create.command.js
+++ b/src/commands/drain/drain.create.command.js
@@ -97,8 +97,18 @@ export const drainCreateCommand = defineCommand({
   ],
   async handler(options, drainTypeCliCode, url) {
     const { alias, appIdOrName, addonIdOrRealId } = options;
-    const { username, password, apiKey, sourceToken, indexPrefix, rfc5424StructuredDataParameters } = options;
-    const { hecToken, index, sourcetype, tlsVerification } = options;
+    const {
+      username,
+      password,
+      apiKey,
+      sourceToken,
+      indexPrefix,
+      rfc5424StructuredDataParameters,
+      hecToken,
+      index,
+      sourcetype,
+      tlsVerification,
+    } = options;
 
     const drainType = Object.values(DRAIN_TYPES).find((drainType) => drainType.cliCode === drainTypeCliCode);
 

--- a/src/commands/drain/drain.create.command.js
+++ b/src/commands/drain/drain.create.command.js
@@ -41,6 +41,30 @@ export const drainCreateCommand = defineCommand({
       aliases: ['t'],
       placeholder: 'source-token',
     }),
+    hecToken: defineOption({
+      name: 'hec-token',
+      schema: z.string().optional(),
+      description: 'HTTP Event Collector token (for splunk)',
+      placeholder: 'hec-token',
+    }),
+    index: defineOption({
+      name: 'index',
+      schema: z.string().optional(),
+      description: "Optional target index (for splunk), the HEC token's own index is used if not set",
+      placeholder: 'index',
+    }),
+    sourcetype: defineOption({
+      name: 'sourcetype',
+      schema: z.string().optional(),
+      description: "Optional sourcetype (for splunk), the HEC token's own sourcetype is used if not set",
+      placeholder: 'sourcetype',
+    }),
+    tlsVerification: defineOption({
+      name: 'tls-verification',
+      schema: z.enum(['default', 'trustful']).optional(),
+      description: 'TLS verification mode (for splunk), use `trustful` to accept a self-signed certificate',
+      placeholder: 'tls-verification',
+    }),
     indexPrefix: defineOption({
       name: 'index-prefix',
       schema: z.string().optional(),
@@ -74,6 +98,7 @@ export const drainCreateCommand = defineCommand({
   async handler(options, drainTypeCliCode, url) {
     const { alias, appIdOrName, addonIdOrRealId } = options;
     const { username, password, apiKey, sourceToken, indexPrefix, rfc5424StructuredDataParameters } = options;
+    const { hecToken, index, sourcetype, tlsVerification } = options;
 
     const drainType = Object.values(DRAIN_TYPES).find((drainType) => drainType.cliCode === drainTypeCliCode);
 
@@ -120,6 +145,23 @@ export const drainCreateCommand = defineCommand({
         throw new Error(`${DRAIN_TYPES.BETTERSTACK.cliCode} drains require a source token (--source-token) to be set`);
       }
       body.recipient.sourceToken = sourceToken;
+    }
+
+    if (drainTypeCliCode === DRAIN_TYPES.SPLUNK.cliCode) {
+      if (!hecToken) {
+        throw new Error(`${DRAIN_TYPES.SPLUNK.cliCode} drains require an HEC token (--hec-token) to be set`);
+      }
+      body.recipient.token = hecToken;
+      // Both are omitted when unset: a field sent in the payload overrides the setting bound to the HEC token
+      if (index) {
+        body.recipient.index = index;
+      }
+      if (sourcetype) {
+        body.recipient.sourcetype = sourcetype;
+      }
+      if (tlsVerification) {
+        body.recipient.tlsVerification = tlsVerification.toUpperCase();
+      }
     }
 
     if (

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -52,7 +52,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 |Name|Description|
 |---|---|
-|`drain-type`|Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)|
+|`drain-type`|Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, splunk, syslog-tcp, syslog-udp)|
 |`drain-url`|Drain URL|
 
 ### ⚙️ Options
@@ -63,10 +63,14 @@ clever drain create <drain-type> <drain-url> [options]
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`-k`, `--api-key` `<api-key>`|API key (for newrelic)|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
+|`--hec-token` `<hec-token>`|HTTP Event Collector token (for splunk)|
+|`--index` `<index>`|Optional target index (for splunk), the HEC token's own index is used if not set|
 |`-i`, `--index-prefix` `<index-prefix>`|Optional index prefix (for elasticsearch), `logstash` value is used if not set|
 |`-p`, `--password` `<password>`|Basic auth password (for elasticsearch or raw-http)|
 |`-s`, `--sd-params` `<sd-params>`|RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`|
 |`-t`, `--source-token` `<source-token>`|Source token (for betterstack)|
+|`--sourcetype` `<sourcetype>`|Optional sourcetype (for splunk), the HEC token's own sourcetype is used if not set|
+|`--tls-verification` `<tls-verification>`|TLS verification mode (for splunk), use `trustful` to accept a self-signed certificate (default, trustful)|
 |`-u`, `--username` `<username>`|Basic auth username (for elasticsearch or raw-http)|
 
 ## ➡️ `clever drain disable` <kbd>Since 0.9.0</kbd>

--- a/src/models/drain.js
+++ b/src/models/drain.js
@@ -22,6 +22,7 @@ export const DRAIN_TYPES = {
   NEWRELIC: { apiCode: 'NEWRELIC', cliCode: 'newrelic', label: 'New Relic' },
   OVH_TCP: { apiCode: 'OVH_TCP', cliCode: 'ovh-tcp', label: 'OVH TCP' },
   RAW_HTTP: { apiCode: 'RAW_HTTP', cliCode: 'raw-http', label: 'Raw HTTP' },
+  SPLUNK: { apiCode: 'SPLUNK', cliCode: 'splunk', label: 'Splunk' },
   SYSLOG_TCP: { apiCode: 'SYSLOG_TCP', cliCode: 'syslog-tcp', label: 'Syslog TCP' },
   SYSLOG_UDP: { apiCode: 'SYSLOG_UDP', cliCode: 'syslog-udp', label: 'Syslog UDP' },
 };
@@ -57,6 +58,12 @@ export function formatDrain(rawDrain) {
     ['URL', rawDrain.recipient.url],
     ['Type', drainType.label],
     ['Custom index', rawDrain.recipient.index],
+    ['Sourcetype', rawDrain.recipient.sourcetype],
+    // DEFAULT is the implicit norm, only a relaxed verification is worth showing
+    [
+      'TLS verification',
+      rawDrain.recipient.tlsVerification === 'TRUSTFUL' ? 'Trustful (certificate not verified)' : null,
+    ],
     ['SD parameters', rawDrain.recipient.rfc5424StructuredDataParameters],
     ['Message output rate', formatRate(rawDrain.backlog.msgRateOut)],
     ['Message throughput', formatThroughput(rawDrain.backlog.msgThroughputOut)],


### PR DESCRIPTION
Adds the `splunk` drain type, following the `SPLUNK` recipient merged in OVD3.

```
clever drain create splunk "https://<host>:8088/services/collector/event" --hec-token <token>
clever drain create splunk "https://<host>:8088/services/collector/event" --hec-token <token> \
  --index my-index --sourcetype clevercloud --tls-verification trustful
```

### What's in it

- `SPLUNK` in `DRAIN_TYPES`, which drives the `<drain-type>` enum, its help text and shell completion.
- `--hec-token`, required for this type, sent as `recipient.token`.
- `--index` and `--sourcetype`, both optional and **omitted from the payload when unset**: a field present in the envelope overrides the setting bound to the customer's HEC token, so defaulting them would silently override the server-side configuration.
- `--tls-verification <default|trustful>`, mapped to the API's `TLSMode`. Splunk ships a self-signed certificate on `:8088` by default, so without it a self-hosted HEC is unreachable — for real deliveries *and* for `clever drain check`, since the probe honours the same setting.

### Everything else already works

`clever drain`, `drain get`, `drain check`, `drain enable|disable|remove` are keyed by drain ID and the recipient probe runs server-side, so they needed no change.

One exception worth flagging: `formatDrain()` resolved the type label through an unchecked `DRAIN_TYPES[recipient.type]` lookup, so `clever drain get` on a Splunk drain created from the Console or the API threw a `TypeError`. That's fixed by the registry entry. The same function now also shows `Sourcetype`, and a `TLS verification` line only when verification is relaxed — `DEFAULT` is the implicit norm and printing it on every Elasticsearch drain would be noise.

### Checks

`npm run validate` (lint, prettier, typecheck, docs check) passes. Verified by hand: the help output, the parse-time rejection of an invalid `--tls-verification`, `--index` and `--index-prefix` parsing independently of each other, and shell completion offering `splunk` and the two TLS modes.

Docs under `src/commands/` and `skills/` are regenerated; `docs/services-logs-drains.md` gets a Splunk section and the `--source-token` line that was missing from its option list.
