### PR TITLE
feat(drain): filter the drain list by recipient type

### DIFF
--- a/docs/services-logs-drains.md
+++ b/docs/services-logs-drains.md
@@ -5,6 +5,7 @@ You can use Clever Tools to control logs drains, through following commands. Eac
 ```
 clever drain
 clever drain -F json
+clever drain --type <DRAIN-TYPE>
 clever drain create <DRAIN-TYPE> <DRAIN-URL>
 clever drain get <DRAIN-ID>
 clever drain get <DRAIN-ID> --format json

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1054,6 +1054,7 @@ clever drain [options]
 -a, --alias <alias>            Short name for the application
     --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
 -F, --format <format>          Output format (human, json) (default: human)
+    --type <drain-type>        Only list drains of this type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, splunk, syslog-tcp, syslog-udp)
 ```
 
 ### drain check

--- a/src/commands/drain/drain.command.js
+++ b/src/commands/drain/drain.command.js
@@ -1,7 +1,9 @@
+import { z } from 'zod';
 import { getDrains } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
 import { Logger } from '../../logger.js';
-import { formatDrain, resolveDrainResource } from '../../models/drain.js';
+import { DRAIN_TYPE_CLI_CODES, DRAIN_TYPES, formatDrain, resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import {
   addonIdOrRealIdOption,
@@ -17,14 +19,25 @@ export const drainCommand = defineCommand({
     alias: aliasOption,
     appIdOrName: appIdOrNameOption,
     addonIdOrRealId: addonIdOrRealIdOption,
+    type: defineOption({
+      name: 'type',
+      schema: z.enum(DRAIN_TYPE_CLI_CODES).optional(),
+      description: 'Only list drains of this type',
+      placeholder: 'drain-type',
+    }),
     format: humanJsonOutputFormatOption,
   },
   args: [],
   async handler(options) {
-    const { alias, appIdOrName, addonIdOrRealId, format } = options;
+    const { alias, appIdOrName, addonIdOrRealId, type, format } = options;
     const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const drains = await getDrains({ ownerId, resourceId }).then(sendToApi);
+    const allDrains = await getDrains({ ownerId, resourceId }).then(sendToApi);
+
+    // The resource scoped endpoint only filters on status, so the type filter is applied here.
+    // The list is bounded by the number of drains of a single resource, it never paginates.
+    const drainType = Object.values(DRAIN_TYPES).find((drainType) => drainType.cliCode === type);
+    const drains = drainType == null ? allDrains : allDrains.filter((d) => d.recipient.type === drainType.apiCode);
 
     switch (format) {
       case 'json': {
@@ -35,7 +48,8 @@ export const drainCommand = defineCommand({
       default: {
         if (drains.length === 0) {
           const resourceLabel = addonIdOrRealId ?? appIdOrName ?? resourceId;
-          Logger.println(`There are no drains for ${resourceLabel}`);
+          const drainsLabel = drainType == null ? 'drains' : `${drainType.label} drains`;
+          Logger.println(`There are no ${drainsLabel} for ${resourceLabel}`);
           return;
         }
 

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -16,6 +16,7 @@ clever drain [options]
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`--type` `<drain-type>`|Only list drains of this type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, splunk, syslog-tcp, syslog-udp)|
 
 ## ➡️ `clever drain check` <kbd>Since 4.11.0</kbd>
 


### PR DESCRIPTION
Follow-up to #1112, independent of it (branched from `master`, no shared files beyond the generated docs).

`clever drain` listed every drain of a resource with no way to narrow it down. This adds `--type`:

```
clever drain --type elasticsearch
clever drain --type datadog -F json
```

The option reuses `DRAIN_TYPE_CLI_CODES`, so it is validated at parse time, shell-completed, and stays in sync with whatever `drain create` accepts — including new types as they ship.

### Why the filter is client side

The endpoint the CLI calls, `GET /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains`, only takes `status`, `executionStatus` and `executionStatusNotIn`. `recipientType` exists, but on the admin `GET /v4/drains` endpoint, which isn't reachable from here. The response is bounded by the drains of a single resource and never paginates, so filtering after the call can't miss anything. If `recipientType` is ever added to the resource-scoped endpoint, moving the filter server-side is a one-line change in `src/clever-client/drains.js`.

The filter applies to both output formats, and the empty-list message names the type when one is set, so an empty result reads as an empty filter rather than a resource with no drains at all.

### Checks

`npm run validate` passes. Verified by hand that an unknown `--type` is rejected at parse time with the list of valid values, and that shell completion offers the drain types after `--type`.

Not included, still open if you want it: the multi-drain table shows ID / Status / Execution status / URL but no Type column, so an unfiltered list still doesn't tell you what to filter on.
