### PR TITLE
feat(drain): list the drains of every application and add-on

### DIFF
--- a/docs/services-logs-drains.md
+++ b/docs/services-logs-drains.md
@@ -20,6 +20,8 @@ clever drain
 clever drain --org <ORG_ID_OR_NAME>
 ```
 
+A drain is reachable by the admins, managers and developers of an organisation: its recipient carries credentials in its URL, so reading one is as restricted as creating it. An organisation you belong to with another role is reported as unreachable and the listing goes on with the others.
+
 Where `DRAIN-TYPE` is one of:
 
 - `datadog`: for Datadog endpoint (note that this endpoint needs your Datadog API Key)

--- a/docs/services-logs-drains.md
+++ b/docs/services-logs-drains.md
@@ -13,6 +13,13 @@ clever drain enable <DRAIN-ID>
 clever drain disable <DRAIN-ID>
 ```
 
+When no application is linked or targeted, `clever drain` lists the drains of every application and add-on you have access to, grouped by organisation. You can restrict this listing to a single organisation with `--org` (`-o`, `--owner`):
+
+```
+clever drain
+clever drain --org <ORG_ID_OR_NAME>
+```
+
 Where `DRAIN-TYPE` is one of:
 
 - `datadog`: for Datadog endpoint (note that this endpoint needs your Datadog API Key)

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1050,10 +1050,11 @@ clever drain [options]
 
 **Options**
 ```
-    --addon <addon-id>         Add-on ID or real ID
--a, --alias <alias>            Short name for the application
-    --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
--F, --format <format>          Output format (human, json) (default: human)
+    --addon <addon-id>                  Add-on ID or real ID
+-a, --alias <alias>                     Short name for the application
+    --app <app-id|app-name>             Application to manage by its ID (or name, if unambiguous)
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
 ```
 
 ### drain check

--- a/src/clever-client/drains.js
+++ b/src/clever-client/drains.js
@@ -25,6 +25,29 @@ export function getDrains(params) {
 }
 
 /**
+ * GET /v4/drains/organisations/{ownerId}/drains?status={status}&executionStatus={executionStatus}&executionStatusNotIn={executionStatusNotIn}
+ * @param {Object} params
+ * @param {String} params.ownerId
+ * @param {String} params.status
+ * @param {String} params.executionStatus
+ * @param {String} params.executionStatusNotIn
+ */
+export function getOwnerDrains(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/drains/organisations/${params.ownerId}/drains`,
+    headers: { Accept: 'application/json' },
+    queryParams: {
+      status: params.status,
+      executionStatus: params.executionStatus,
+      executionStatusNotIn: params.executionStatusNotIn,
+    },
+    // no body
+  });
+}
+
+/**
  * POST /v4/drains/organisations/{ownerId}/resources/{resourceId}/drains
  * @param {Object} params
  * @param {String} params.ownerId

--- a/src/commands/drain/drain.command.js
+++ b/src/commands/drain/drain.command.js
@@ -1,13 +1,16 @@
 import { getDrains } from '../../clever-client/drains.js';
 import { defineCommand } from '../../lib/define-command.js';
+import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
-import { formatDrain, resolveDrainResource } from '../../models/drain.js';
+import * as AppConfig from '../../models/app_configuration.js';
+import { formatDrain, formatDrainRow, getAllDrains, resolveDrainResource } from '../../models/drain.js';
 import { sendToApi } from '../../models/send-to-api.js';
 import {
   addonIdOrRealIdOption,
   aliasOption,
   appIdOrNameOption,
   humanJsonOutputFormatOption,
+  orgaIdOrNameOption,
 } from '../global.options.js';
 
 export const drainCommand = defineCommand({
@@ -17,45 +20,128 @@ export const drainCommand = defineCommand({
     alias: aliasOption,
     appIdOrName: appIdOrNameOption,
     addonIdOrRealId: addonIdOrRealIdOption,
+    org: orgaIdOrNameOption,
     format: humanJsonOutputFormatOption,
   },
   args: [],
   async handler(options) {
     const { alias, appIdOrName, addonIdOrRealId, format } = options;
-    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
 
-    const drains = await getDrains({ ownerId, resourceId }).then(sendToApi);
+    // An empty `--org` value is the same as no organisation at all, as in `clever applications list`
+    const orgaIdOrName = options.org?.orga_name !== '' ? options.org : null;
+    const hasTargetedResource = alias != null || appIdOrName != null || addonIdOrRealId != null;
 
-    switch (format) {
-      case 'json': {
-        Logger.printJson(drains);
-        break;
-      }
-      case 'human':
-      default: {
-        if (drains.length === 0) {
-          const resourceLabel = addonIdOrRealId ?? appIdOrName ?? resourceId;
-          Logger.println(`There are no drains for ${resourceLabel}`);
-          return;
-        }
-
-        if (drains.length === 1) {
-          const formattedDrain = formatDrain(drains[0]);
-          console.table(formattedDrain);
-          return;
-        }
-
-        const formattedDrains = drains.map((drain) => {
-          return {
-            ID: drain.id,
-            Status: drain.status.status,
-            'Execution status': drain.execution.status,
-            URL: drain.recipient.url,
-          };
-        });
-
-        console.table(formattedDrains);
-      }
+    if (orgaIdOrName != null && hasTargetedResource) {
+      throw new Error('`--org` cannot be combined with `--app`, `--alias` or `--addon`');
     }
+
+    // Without a targeted resource and without a linked application, we list the drains of every resource
+    // of the targeted organisation, or of all the organisations the user belongs to
+    if (!hasTargetedResource) {
+      const appConfig = await AppConfig.loadApplicationConf();
+
+      if (orgaIdOrName != null || appConfig.apps.length === 0) {
+        printOwnersDrains(await getAllDrains(orgaIdOrName), format);
+        return;
+      }
+
+      // The linked application can come from a parent directory, so we name the one we resolved
+      const { appId, ownerId, name } = await AppConfig.getAppDetails({ appConfig });
+      if (format === 'human') {
+        Logger.printInfo(`Drains of the linked application '${name}' (${appId})`);
+      }
+      await printResourceDrains(ownerId, appId, name, format);
+      return;
+    }
+
+    const { ownerId, resourceId } = await resolveDrainResource(alias, appIdOrName, addonIdOrRealId);
+    const resourceLabel = addonIdOrRealId ?? appIdOrName?.app_id ?? appIdOrName?.app_name ?? resourceId;
+    await printResourceDrains(ownerId, resourceId, resourceLabel, format);
   },
 });
+
+/**
+ * @param {String} ownerId
+ * @param {String} resourceId
+ * @param {String} resourceLabel
+ * @param {'human'|'json'} format
+ */
+async function printResourceDrains(ownerId, resourceId, resourceLabel, format) {
+  const drains = await getDrains({ ownerId, resourceId }).then(sendToApi);
+
+  switch (format) {
+    case 'json': {
+      Logger.printJson(drains);
+      break;
+    }
+    case 'human':
+    default: {
+      if (drains.length === 0) {
+        Logger.println(`There are no drains for ${resourceLabel}`);
+        return;
+      }
+
+      if (drains.length === 1) {
+        console.table(formatDrain(drains[0]));
+        return;
+      }
+
+      console.table(drains.map((drain) => formatDrainRow(drain)));
+    }
+  }
+}
+
+/**
+ * @param {Array<{ id: String, name: String, drains: Array<Object>, error: Error|null }>} owners
+ * @param {'human'|'json'} format
+ */
+function printOwnersDrains(owners, format) {
+  const failedOwners = owners.filter((owner) => owner.error != null);
+
+  // Listing nothing at all is an error, not an empty result
+  if (owners.length > 0 && failedOwners.length === owners.length) {
+    throw failedOwners[0].error;
+  }
+
+  failedOwners.forEach((owner) => {
+    Logger.printErrorLine(
+      styleText('yellow', `Cannot list the drains of '${owner.name}' (${owner.id}): ${owner.error.message}`),
+    );
+  });
+
+  switch (format) {
+    case 'json': {
+      // Same shape as when a resource is targeted: a flat list of drains, each one knowing its owner
+      Logger.printJson(
+        owners.flatMap((owner) =>
+          owner.drains.map((drain) => ({ ...drain, ownerId: owner.id, ownerName: owner.name })),
+        ),
+      );
+      break;
+    }
+    case 'human':
+    default: {
+      const ownersWithDrains = owners.filter((owner) => owner.drains.length > 0);
+
+      if (ownersWithDrains.length === 0) {
+        const ownerLabel = owners.length === 1 ? owners[0].name : 'your organisations';
+        Logger.println(`There are no drains for ${ownerLabel}`);
+        return;
+      }
+
+      ownersWithDrains.forEach((owner) => {
+        const drainsPlural = owner.drains.length !== 1 ? 'drains' : 'drain';
+
+        Logger.println();
+        Logger.println(
+          styleText(
+            'blue',
+            `• Organisation '${owner.name}' (${owner.id}) with ${owner.drains.length} ${drainsPlural}:`,
+          ),
+        );
+
+        console.table(owner.drains.map((drain) => formatDrainRow(drain, drain.resourceName ?? drain.resourceId)));
+      });
+    }
+  }
+}

--- a/src/commands/drain/drain.command.js
+++ b/src/commands/drain/drain.command.js
@@ -140,7 +140,10 @@ function printOwnersDrains(owners, format) {
           ),
         );
 
-        console.table(owner.drains.map((drain) => formatDrainRow(drain, drain.resourceName ?? drain.resourceId)));
+        // A tenant-scoped drain (audit logs) has no resource, it belongs to the organisation itself
+        console.table(
+          owner.drains.map((drain) => formatDrainRow(drain, drain.resourceName ?? drain.resourceId ?? owner.name)),
+        );
       });
     }
   }

--- a/src/commands/drain/drain.docs.md
+++ b/src/commands/drain/drain.docs.md
@@ -16,6 +16,7 @@ clever drain [options]
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 
 ## ➡️ `clever drain check` <kbd>Since 4.11.0</kbd>
 

--- a/src/models/app_configuration.js
+++ b/src/models/app_configuration.js
@@ -139,9 +139,13 @@ function findDefaultApp(appConfig) {
   );
 }
 
-export async function getAppDetails({ alias }) {
-  const appConfig = await loadApplicationConf();
-  const app = findApp(appConfig, alias);
+/**
+ * @param {Object} params
+ * @param {String} [params.alias]
+ * @param {Object} [params.appConfig] an already loaded application configuration, to avoid reading it again
+ */
+export async function getAppDetails({ alias, appConfig }) {
+  const app = findApp(appConfig ?? (await loadApplicationConf()), alias);
   const ownerId = app.org_id != null ? app.org_id : await User.getCurrentId();
   return {
     appId: app.app_id,

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -129,21 +129,17 @@ export async function deleteApp(app, skipConfirmation) {
 }
 
 export async function getAllApps(ownerId) {
-  const summary = await getSummary().then(sendToApi);
+  const owners = await Organisation.listOwners(ownerId == null ? null : { orga_id: ownerId });
 
   const orgaWithApps = await Promise.all(
-    summary.organisations
-      // If owner ID is present, only keep the matching org
-      .filter((org) => ownerId == null || org.id === ownerId)
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(async (org) => {
-        const applications = await getApplicationsForOwner(org.id);
-        return {
-          id: org.id,
-          name: org.name,
-          applications: applications.sort((a, b) => a.name.localeCompare(b.name)),
-        };
-      }),
+    owners.map(async (org) => {
+      const applications = await getApplicationsForOwner(org.id);
+      return {
+        id: org.id,
+        name: org.name,
+        applications: applications.sort((a, b) => a.name.localeCompare(b.name)),
+      };
+    }),
   );
 
   return orgaWithApps;

--- a/src/models/drain.js
+++ b/src/models/drain.js
@@ -1,5 +1,8 @@
+import { getOwnerDrains } from '../clever-client/drains.js';
 import * as Application from './application.js';
 import { resolveAddon } from './ids-resolver.js';
+import * as Organisation from './organisation.js';
+import { sendToApi } from './send-to-api.js';
 
 export async function resolveDrainResource(alias, appIdOrName, addonIdOrRealId) {
   if (addonIdOrRealId != null && (appIdOrName != null || alias != null)) {
@@ -13,6 +16,47 @@ export async function resolveDrainResource(alias, appIdOrName, addonIdOrRealId) 
 
   const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
   return { ownerId, resourceId: appId };
+}
+
+/**
+ * List the drains of every resource an owner has, grouped by owner.
+ * When `orgaIdOrName` is null, all the owners the current user belongs to are listed.
+ * An owner whose drains cannot be listed is returned with its `error`, so that one
+ * unreachable organisation doesn't hide the drains of all the others.
+ * @param {{ orga_id: String }|{ orga_name: String }|null} orgaIdOrName
+ * @returns {Promise<Array<{ id: String, name: String, drains: Array<Object>, error: Error|null }>>}
+ */
+export async function getAllDrains(orgaIdOrName) {
+  const owners = await Organisation.listOwners(orgaIdOrName);
+
+  // `listOwners` only filters on an ID, an organisation ID matching nothing is not an empty result
+  if (orgaIdOrName != null && owners.length === 0) {
+    throw new Error('Organisation not found');
+  }
+
+  return Promise.all(
+    owners.map(async (org) => {
+      // Drains are attached to applications by their ID and to add-ons by their real ID
+      const resourceNames = new Map([
+        ...org.applications.map((app) => [app.id, app.name]),
+        ...org.addons.map((addon) => [addon.realId, addon.name]),
+      ]);
+
+      try {
+        const drains = await getOwnerDrains({ ownerId: org.id }).then(sendToApi);
+        return {
+          id: org.id,
+          name: org.name,
+          drains: drains
+            .map((drain) => ({ ...drain, resourceName: resourceNames.get(drain.resourceId) }))
+            .sort((a, b) => (a.resourceName ?? '').localeCompare(b.resourceName ?? '')),
+          error: null,
+        };
+      } catch (error) {
+        return { id: org.id, name: org.name, drains: [], error };
+      }
+    }),
+  );
 }
 
 export const DRAIN_TYPES = {
@@ -46,6 +90,21 @@ function formatThroughput(bytesPerSecond) {
     return (bytesPerSecond / 1024).toFixed(2) + ' KiB/second';
   }
   return (bytesPerSecond / (1024 * 1024)).toFixed(2) + ' MiB/second';
+}
+
+/**
+ * Format a drain as a row of the table listing several drains.
+ * @param {Object} rawDrain
+ * @param {String} [resourceLabel] the resource the drain belongs to, when the table mixes several of them
+ */
+export function formatDrainRow(rawDrain, resourceLabel) {
+  return {
+    ID: rawDrain.id,
+    ...(resourceLabel != null ? { Resource: resourceLabel } : {}),
+    Status: rawDrain.status.status,
+    'Execution status': rawDrain.execution.status,
+    URL: rawDrain.recipient.url,
+  };
 }
 
 export function formatDrain(rawDrain) {

--- a/src/models/organisation.js
+++ b/src/models/organisation.js
@@ -27,3 +27,35 @@ async function getByName(name) {
 
   return filteredOrgs[0];
 }
+
+/**
+ * List the owners the current user belongs to, sorted by name.
+ * The personal space is one of them, `/v2/summary` returns it among the organisations.
+ * When an ID or a name is given, only the matching owner is returned.
+ * @param {{ orga_id: String }|{ orga_name: String }|null} orgaIdOrName
+ * @returns {Promise<Array<Object>>} the raw summary owners, with their applications and add-ons
+ */
+export async function listOwners(orgaIdOrName) {
+  const summary = await getSummary({}).then(sendToApi);
+
+  // A name has to be resolved against the summary we just fetched, an ID is only filtered on
+  if (orgaIdOrName?.orga_name != null) {
+    const matchingOwners = _.filter(summary.organisations, { name: orgaIdOrName.orga_name });
+
+    if (matchingOwners.length === 0) {
+      throw new Error('Organisation not found');
+    }
+    if (matchingOwners.length > 1) {
+      throw new Error('Ambiguous organisation name');
+    }
+
+    return matchingOwners;
+  }
+
+  return (
+    summary.organisations
+      // If owner ID is present, only keep the matching org
+      .filter((org) => orgaIdOrName == null || org.id === orgaIdOrName.orga_id)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  );
+}


### PR DESCRIPTION
Closes #1118.

## Why

`clever drain` always required a linked or targeted application:

```
[ERROR] There is no linked or targeted application. Use `--app` option or `clever link` command.
```

There was no way to get an overview of the drains one has set up.

## What

`clever drain` now falls back to listing the drains of every resource of every organisation, the personal space included, grouped by organisation and naming the application or add-on each drain belongs to:

```
• Organisation 'LambdaDevs' (orga_5f42efc9-…) with 2 drains:
│ ID           │ Resource          │ Status     │ Execution status │ URL
│ 'drain_1111' │ 'biscuit-haskell' │ 'ENABLED'  │ 'RUNNING'        │ 'https://logs.example.com/in'
│ 'drain_2222' │ 'faas-test'       │ 'DISABLED' │ 'FAILED'         │ 'syslog+tcp://logs.example.com:514'
```

- `--org` (`-o`, `--owner`) restricts the listing to one organisation, and cannot be combined with `--app`, `--alias` or `--addon`
- targeting a resource is unchanged, and a linked application still takes precedence over the listing — since it can come from a parent directory, it is now named in the output
- `--format json` keeps printing a flat list of drains in both cases, each one carrying its `ownerId`/`ownerName`, so a script doesn't have to care how the command was targeted
- a drain that belongs to the organisation itself, audit logs for instance, has no resource: it is named after the organisation
- an organisation whose drains cannot be listed is reported on stderr without hiding the others, unless none can be listed at all
- resource names come from the `/v2/summary` call the listing already makes, so naming them costs no extra request

Also fixes `clever drain --app <name>` printing `[object Object]` instead of the application name when it has no drain.

## API

The listing relies on `GET /v4/drains/organisations/{ownerId}/drains`, **which is now live in production** — it is served to OAuth1 callers since ovd!2147, and reading a drain asks for ADMIN, MANAGER or DEVELOPER in the organisation since ovd!2150. An organisation held with another role answers 403 and is reported as unreachable without hiding the others, which is what the per-organisation failure handling above is for. The roles are now documented in `docs/services-logs-drains.md`.

Side note, out of scope here: `src/models/send-to-api.js` maps *any* 401 to "You're not logged in, use clever login command". It is misleading whenever the API means "authenticated fine, not allowed here".

## Testing

`npm run validate` passes.

Verified against production, no longer against stubs:

```bash
clever drain                                    # every organisation, grouped, resources named
clever drain --org "Clever Support"             # by name
clever drain --org orga_858600a8-…              # by id
clever drain --format json                      # flat list, every drain carrying ownerId/ownerName
clever drain --app app_5cd7548d-…               # single drain, detailed view
clever drain --app "test to delete"             # There are no drains for test to delete
clever drain --addon postgresql_66ab5c65-…      # add-on by real id
clever drain --addon addon_c743cde0-…           # add-on by add-on id
```

The add-on `realId` → name resolution is confirmed by the listing naming a PostgreSQL add-on next to its three drains, and the linked-application path by running from a directory whose `.clever.json` sits in a parent: `ℹ Drains of the linked application 'billing-api' (app_5cd7548d-…)`, with `--org` still taking over when given.

The error paths behave as intended:

```bash
clever drain --org orga_11111111-1111-4111-8111-111111111111  # [ERROR] Organisation not found
clever drain --org definitely-not-an-org                      # [ERROR] Organisation not found
clever drain --org ""                                         # same as no --org
clever drain --org "Clever Cloud" --app foo                   # [ERROR] `--org` cannot be combined with …
```

