### PR TITLE
fix(ssh): forbid password authentication fallback

### DIFF
--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -58,6 +58,9 @@ export const sshCommand = defineCommand({
     }
 
     const sshParams = [];
+    // Clever Cloud SSH only accepts key auth. Disable password fallback so a missing
+    // or unregistered key fails fast instead of prompting for a password that cannot work.
+    sshParams.push('-o', 'PreferredAuthentications=publickey', '-o', 'PasswordAuthentication=no');
     // -t: force PTY allocation (SSH skips it by default because appId is passed as a command for gateway routing)
     if (command == null) {
       sshParams.push('-t');


### PR DESCRIPTION
## Summary
Clever Cloud SSH only accepts key authentication. When a key is missing or not registered, `clever ssh` used to fall back to a password prompt that can never succeed.

This disables password authentication for the SSH session so the failure is immediate and clearer for users and support.

Fixes #574

## Change
Pass to the ssh client:
- `PreferredAuthentications=publickey`
- `PasswordAuthentication=no`

## Test plan
- [x] `clever ssh` with a valid key still connects
- [x] `clever ssh` with a missing/unregistered key fails without asking for a password

## E2E results (2026-08-13)
Tested against a real Clever Cloud Node app with the patched CLI (`clever-tools` PR checkout, linked as local `clever`).

1. Valid dedicated ed25519 key registered via `clever ssh-keys add`, then:
   `SSH_AUTH_SOCK= clever ssh -a <app> -i <good> -c 'echo SSH_OK'`
   → `SSH_OK`, exit 0
2. Unregistered key, same setup with agent disabled:
   `SSH_AUTH_SOCK= clever ssh -a <app> -i <bad> -c 'echo SSH_OK'`
   → exit 255 in under 1s, no password prompt

Note: without clearing the agent, OpenSSH may still offer other loaded keys, so a wrong `-i` can succeed if another registered key is available in the agent. That is normal OpenSSH behavior and unrelated to this change. For a clean negative test, use `SSH_AUTH_SOCK=` (or `IdentitiesOnly=yes` on a raw `ssh` call).

Test app and temporary SSH key were deleted after the run.
