### PR TITLE
fix: use update-notifier message template for non-npm installs

### DIFF
--- a/src/initial-update-notifier.js
+++ b/src/initial-update-notifier.js
@@ -5,14 +5,13 @@ import { hasParam } from './lib/has-param.js';
 // These need to be set before Logger and other stuffs
 const updateNotifierExplicitFalse = hasParam('--no-update-notifier') || hasParam('--update-notifier', 'false');
 if (!updateNotifierExplicitFalse) {
+  const docsUrl = 'https://github.com/CleverCloud/clever-tools/tree/master/docs#how-to-use-clever-tools';
+  // update-notifier ignores getDetails/tagsUrl. Use the supported message template instead
+  // so brew/apt/binary users are not told to run npm i -g.
   updateNotifierModule({
     pkg,
-    tagsUrl: 'https://api.github.com/repos/CleverCloud/clever-tools/tags',
   }).notify({
     isGlobal: true,
-    getDetails() {
-      const docsUrl = 'https://github.com/CleverCloud/clever-tools/tree/master/docs#how-to-use-clever-tools';
-      return `\nPlease follow this link to update your clever-tools:\n${docsUrl}`;
-    },
+    message: `Update available {currentVersion} -> {latestVersion}\nPlease follow this link to update your clever-tools:\n${docsUrl}`,
   });
 }


### PR DESCRIPTION
## Summary
update-notifier ignores getDetails and tagsUrl. This uses the supported message template and points to the clever-tools docs update section so brew/apt/binary users are not told to run a global npm install.

Fixes #1117

## Test plan
- Trigger the update notice and confirm the docs link appears
- Confirm the notice no longer recommends a global npm install
