### PR TITLE
fix(ci): skip release-please PRs via head_ref check

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-    branches-ignore:
-      - 'release-please--**'
 
 concurrency:
   group: code-quality-${{ github.event.pull_request.number }}
@@ -15,6 +13,7 @@ concurrency:
 
 jobs:
   code-quality:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: 'Code quality'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types:
       - closed
-    branches-ignore:
-      - 'release-please--**'
 
 env:
   CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET: ${{ vars.CC_CLEVER_TOOLS_PREVIEWS_CELLAR_BUCKET }}
@@ -14,6 +12,7 @@ env:
 
 jobs:
   cleanup:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: 'Cleanup preview'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -10,8 +10,6 @@ on:
       - unlabeled
     paths-ignore:
       - '**/*.md'
-    branches-ignore:
-      - 'release-please--**'
 
 concurrency:
   group: preview-${{ github.event.pull_request.number }}
@@ -24,6 +22,7 @@ env:
 
 jobs:
   build:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary
Three `pull_request` workflows used `branches-ignore: ['release-please--**']` to skip release-please PRs. On `pull_request`, that filter matches the **base** branch (the PR target), not the **head** branch, so release-please PRs targeting `master` still triggered these workflows.

Fixes #1110

## Change
In `code-quality.yml`, `preview-cleanup.yml`, and `preview-publish.yml`:
- remove the no-op `branches-ignore`
- skip jobs with `if: ${{ !startsWith(github.head_ref, 'release-please--') }}`

For `preview-publish.yml`, the condition is only on the `build` job. The `publish` job depends on it and is skipped automatically when `build` is skipped.

## Test plan
- [ ] On a normal PR to `master`, Code quality / Publish preview still run
- [ ] On a release-please PR (`head_ref` starting with `release-please--`), those jobs are skipped
- [ ] Preview cleanup on close behaves the same for normal PRs and is skipped for release-please heads