### PR TITLE
feat(aur): publish a Node.js flavored clever-tools package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,8 @@ jobs:
           CC_CLEVER_TOOLS_RELEASES_CELLAR_KEY_ID: ${{ secrets.CC_CLEVER_TOOLS_RELEASES_CELLAR_KEY_ID }}
           CC_CLEVER_TOOLS_RELEASES_CELLAR_SECRET_KEY: ${{ secrets.CC_CLEVER_TOOLS_RELEASES_CELLAR_SECRET_KEY }}
 
-  publish-aur:
-    name: 'Publish to AUR'
+  publish-aur-bin:
+    name: 'Publish to AUR (binary package)'
     needs: publish-cellar-archives
     runs-on: ubuntu-latest
     steps:
@@ -150,9 +150,29 @@ jobs:
       - uses: ./.github/actions/download-artifacts
         with: { pattern: build-linux-archive }
       - name: 'Publish to AUR'
-        run: ./scripts/publish-aur.js ${{ github.ref_name }}
+        run: ./scripts/publish-aur.js ${{ github.ref_name }} bin
         env:
-          AUR_GIT_URL: ${{ vars.AUR_GIT_URL }}
+          AUR_GIT_URL: ${{ vars.AUR_BIN_GIT_URL }}
+
+  publish-aur-nodejs:
+    name: 'Publish to AUR (Node.js package)'
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Setup SSH key'
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: 'Add AUR to known hosts'
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-node
+      - name: 'Publish to AUR'
+        run: ./scripts/publish-aur.js ${{ github.ref_name }} nodejs
+        env:
+          AUR_GIT_URL: ${{ vars.AUR_NODEJS_GIT_URL }}
 
   publish-homebrew:
     name: 'Publish to Homebrew'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .clever.json
 build/
+git-*/
 .idea/
 .s3cfg*
 *.gpg.key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,15 @@ We provide several utility scripts to streamline development (located in `/scrip
   node scripts/check-github-actions.js
   ```
 
+#### AUR Packages
+
+- **`scripts/publish-aur.js`**: Publish a package flavor to the Arch User Repository
+
+  Both flavors are published from templates in `scripts/templates/aur/<flavor>/`. The `.SRCINFO` is
+  templated alongside the `PKGBUILD`, so both files must be edited together and kept in sync
+  (`makepkg --printsrcinfo` regenerates it for comparison). On an Arch Linux machine, a template
+  change can be validated end to end against a local bare repository, without ever touching AUR.
+
 #### Preview Management
 
 - **`scripts/preview.js`**: Build and manage PR preview versions
@@ -123,6 +132,7 @@ clever-tools/
 ├── scripts/                             # Build and CI scripts (TypeScript with JSDoc enforced)
 │   ├── lib/                             # Shared utilities for scripts
 │   └── templates/                       # Templates for package managers (AUR, Homebrew, etc.)
+│       └── aur/{bin,nodejs}/            # One directory per AUR package flavor
 └── ...
 ```
 
@@ -694,7 +704,7 @@ Our CI/CD pipeline ensures quality and automates releases:
 - Conventional commits drive changelog generation
 - Release-please manages versioning
 - Automated publishing to multiple platforms:
-  - **AUR**: Arch Linux User Repository
+  - **AUR**: Arch Linux User Repository, two packages (`clever-tools`, the Node.js flavor, and `clever-tools-bin`, the self-contained binary)
   - **Cellar**: Clever Cloud's object storage for direct downloads
   - **Docker Hub**: Official Docker images
   - **Exherbo**: Linux distribution packages
@@ -742,6 +752,9 @@ graph LR
         BUNDLE2 --> BUILD_WIN2[build-windows]
     end
 
+    REL --> NPM[publish-npm]
+    NPM --> AUR_NODEJS[publish-aur-nodejs]
+
     BUILD_2 --> PACKAGE_RPM[package-rpm]
     BUILD_2 --> PACKAGE_DEB[package-deb]
     BUILD_2 --> CELLAR_ARC[publish-cellar-archives]
@@ -756,7 +769,7 @@ graph LR
     PACKAGE_DEB --> NEXUS_DEB[publish-nexus-deb]
 
     %% Package managers (depend on cellar archives)
-    CELLAR_ARC --> AUR[publish-aur]
+    CELLAR_ARC --> AUR_BIN[publish-aur-bin]
     CELLAR_ARC --> HOMEBREW[publish-homebrew]
     CELLAR_ARC --> DOCKER[publish-dockerhub]
     CELLAR_ARC --> EXHERBO[publish-exherbo]

--- a/docs/setup-systems.md
+++ b/docs/setup-systems.md
@@ -54,12 +54,21 @@ yarn global add clever-tools
 
 ### Arch Linux (AUR)
 
-If you use Arch Linux, install packages [from AUR](https://aur.archlinux.org/packages/clever-tools-bin/). If you don't know how to use this, run:
+If you use Arch Linux, install Clever Tools from AUR. Two packages are available, they provide the same `clever` command and cannot be installed side by side:
+
+- [`clever-tools`](https://aur.archlinux.org/packages/clever-tools/): the Node.js flavor, it runs on the `nodejs` package of your system
+- [`clever-tools-bin`](https://aur.archlinux.org/packages/clever-tools-bin/): a self-contained binary, with no runtime dependency
+
+If you use an AUR helper like `yay`, run:
 
 ```
-git clone https://aur.archlinux.org/clever-tools-bin.git clever-tools
-cd clever-tools
-makepkg -si
+yay -S clever-tools
+```
+
+Or, for the self-contained binary:
+
+```
+yay -S clever-tools-bin
 ```
 
 ### CentOS/Fedora (.rpm)

--- a/docs/update.md
+++ b/docs/update.md
@@ -52,12 +52,19 @@ yarn global add clever-tools
 
 ### Arch Linux (AUR)
 
-From the directory where you cloned the AUR package:
+With an AUR helper like `yay`, update the package you installed:
 
-```
-git -C clever-tools pull
-makepkg -si -C clever-tools
-```
+- [`clever-tools`](https://aur.archlinux.org/packages/clever-tools/), the Node.js flavor:
+
+  ```
+  yay -S clever-tools
+  ```
+
+- [`clever-tools-bin`](https://aur.archlinux.org/packages/clever-tools-bin/), the self-contained binary:
+
+  ```
+  yay -S clever-tools-bin
+  ```
 
 ### CentOS/Fedora (.rpm)
 

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -8,9 +8,27 @@ import path from 'node:path';
  * @returns {Promise<string>}
  */
 export async function getSha256(inputPath) {
+  return getFileHash(inputPath, 'sha256');
+}
+
+/**
+ * Calculates the SHA512 hash of a file.
+ * @param {string} inputPath - Path to the file to hash
+ * @returns {Promise<string>}
+ */
+export async function getSha512(inputPath) {
+  return getFileHash(inputPath, 'sha512');
+}
+
+/**
+ * Calculates the hash of a file with the given algorithm.
+ * @param {string} inputPath - Path to the file to hash
+ * @param {'sha256'|'sha512'} algorithm - Hash algorithm to use
+ * @returns {Promise<string>} The hash, hex encoded
+ */
+async function getFileHash(inputPath, algorithm) {
   const content = await fs.readFile(inputPath);
-  const hash = crypto.createHash('sha256').update(content).digest('hex');
-  return hash;
+  return crypto.createHash(algorithm).update(content).digest('hex');
 }
 
 /**

--- a/scripts/lib/npm-registry.js
+++ b/scripts/lib/npm-registry.js
@@ -1,0 +1,62 @@
+import { highlight } from './terminal.js';
+
+const REGISTRY_URL = 'https://registry.npmjs.org';
+const RETRY_COUNT = 3;
+const RETRY_DELAY = 5000;
+
+/**
+ * Gets the SHA512 hash of a package tarball published on the npm registry.
+ *
+ * The hash is derived from the "dist.integrity" field of the version document,
+ * so the tarball itself never needs to be downloaded.
+ *
+ * The registry is written to by "npm publish" but read through a CDN, so a version
+ * published seconds ago may still be answered with a 404: the read is retried a few times.
+ *
+ * @param {string} name - The package name
+ * @param {string} version - The package version
+ * @returns {Promise<string>} The tarball SHA512 hash, hex encoded
+ * @throws {Error} When the version cannot be read or has no SHA512 integrity field
+ */
+export async function getNpmTarballSha512(name, version) {
+  const url = `${REGISTRY_URL}/${name}/${version}`;
+
+  console.log(highlight`=> Getting tarball integrity of ${name} ${version} from ${REGISTRY_URL}`);
+  const versionDocument = await fetchJsonWithRetry(url);
+
+  const integrity = versionDocument?.dist?.integrity;
+  if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
+    throw new Error(`Could not read a SHA512 integrity for ${name}@${version}`);
+  }
+
+  const base64Hash = integrity.slice('sha512-'.length);
+  return Buffer.from(base64Hash, 'base64').toString('hex');
+}
+
+/**
+ * Fetches a JSON document, retrying a few times on failure.
+ * @param {string} url - The URL to fetch
+ * @returns {Promise<any>} The parsed JSON document
+ * @throws {Error} When all attempts failed
+ */
+async function fetchJsonWithRetry(url) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= RETRY_COUNT; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return await response.json();
+    } catch (error) {
+      lastError = error;
+      if (attempt < RETRY_COUNT) {
+        console.log(highlight`=> Could not fetch ${url}, retrying in ${RETRY_DELAY / 1000}s`);
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY));
+      }
+    }
+  }
+
+  throw new Error(`Could not fetch ${url}: ${lastError instanceof Error ? lastError.message : lastError}`);
+}

--- a/scripts/publish-aur.js
+++ b/scripts/publish-aur.js
@@ -2,60 +2,102 @@
 //
 // Publish a new version to Arch User Repository (AUR).
 //
-// This script updates the PKGBUILD file for the AUR package with new version
-// information, calculates the SHA256 hash of the Linux archive, and commits
-// the changes to the AUR repository.
+// This script updates the PKGBUILD and .SRCINFO files of an AUR package with new
+// version information and checksums, and commits the changes to the AUR repository.
 //
-// USAGE: publish-aur.js <version>
+// Two flavors are published, from two distinct AUR repositories:
+//   bin     "clever-tools-bin", the self contained binary, built from the Linux archive
+//   nodejs  "clever-tools", the Node.js flavor, built from the npm registry tarball
+//
+// USAGE: publish-aur.js <version> <flavor>
 //
 // ARGUMENTS:
 //   version         Version string (e.g., "1.2.3")
+//   flavor          Package flavor ('bin' or 'nodejs')
 //
 // ENVIRONMENT VARIABLES:
-//   AUR_GIT_URL     AUR repository URL
+//   AUR_GIT_URL     AUR repository URL of the given flavor
 //
 // REQUIRED SYSTEM BINARIES:
 //   git             For cloning, committing, and pushing to AUR repository
 //
 // EXAMPLES:
-//   publish-aur.js 1.2.3
+//   publish-aur.js 1.2.3 bin
+//   publish-aur.js 1.2.3 nodejs
 
 import { simpleGit } from 'simple-git';
 import pkg from '../package.json' with { type: 'json' };
 import { ArgumentError, readEnvVars, runCommand } from './lib/command.js';
-import { getSha256 } from './lib/fs.js';
+import { getSha256, getSha512 } from './lib/fs.js';
 import { commitAndPush } from './lib/git.js';
+import { getNpmTarballSha512 } from './lib/npm-registry.js';
 import { getAssetPath } from './lib/paths.js';
 import { applyTemplates } from './lib/templates.js';
 import { highlight } from './lib/terminal.js';
 
-const PKGBASE = 'clever-tools-bin';
+const VALID_FLAVORS = ['bin', 'nodejs'];
+/** @type {Record<string, string>} */
+const PKGBASES = { bin: 'clever-tools-bin', nodejs: 'clever-tools' };
+/** @type {Record<string, string>} */
+const FLAVOR_LABELS = { bin: 'standalone binary', nodejs: 'Node.js' };
+const LOCKFILE_PATH = './package-lock.json';
 const TEMPLATES_PATH = './scripts/templates/aur';
 const GIT_PATH = './git-aur';
 
 runCommand(async () => {
-  const [version] = process.argv.slice(2);
+  const [version, flavor] = process.argv.slice(2);
   if (version == null) {
     throw new ArgumentError('version');
+  }
+  if (flavor == null || !VALID_FLAVORS.includes(flavor)) {
+    throw new ArgumentError('flavor', VALID_FLAVORS);
   }
 
   const [gitUrl] = readEnvVars(['AUR_GIT_URL']);
 
-  const archivePath = getAssetPath('archive', version, 'build', 'linux');
-  const sha256 = await getSha256(archivePath);
+  const checksums = await getChecksums(version, flavor);
 
   console.log(highlight`=> Cloning AUR repository ${gitUrl} to ${GIT_PATH}`);
   await simpleGit().clone(gitUrl, GIT_PATH);
 
-  await applyTemplates(GIT_PATH, TEMPLATES_PATH, {
-    description: pkg.description,
+  await applyTemplates(GIT_PATH, `${TEMPLATES_PATH}/${flavor}`, {
+    description: `${pkg.description} (${FLAVOR_LABELS[flavor]})`,
     license: pkg.license,
     maintainer: pkg.author,
-    pkgbase: PKGBASE,
-    sha256,
+    pkgbase: PKGBASES[flavor],
     url: pkg.homepage,
     version,
+    ...checksums,
   });
 
   await commitAndPush(GIT_PATH, gitUrl, pkg.author, version);
 });
+
+/**
+ * Computes the source checksums required by the templates of the given flavor.
+ *
+ * The "bin" flavor hashes the Linux archive built by the pipeline, the "nodejs" flavor
+ * hashes the npm registry tarball and the lockfile that pins its dependency tree.
+ *
+ * @param {string} version - The version to publish
+ * @param {string} flavor - The package flavor ('bin' or 'nodejs')
+ * @returns {Promise<Record<string, string>>} The template variables holding the checksums
+ */
+async function getChecksums(version, flavor) {
+  switch (flavor) {
+    case 'bin': {
+      const archivePath = getAssetPath('archive', version, 'build', 'linux');
+      return { sha256: await getSha256(archivePath) };
+    }
+    case 'nodejs': {
+      // The lockfile is not part of the published npm tarball, the PKGBUILD downloads it
+      // from the matching git tag: the file we hash here is the one served by that tag.
+      return {
+        tarballSha512: await getNpmTarballSha512(pkg.name, version),
+        lockfileSha512: await getSha512(LOCKFILE_PATH),
+      };
+    }
+    default:
+      throw new ArgumentError('flavor', VALID_FLAVORS);
+  }
+}

--- a/scripts/templates/aur/bin/.SRCINFO
+++ b/scripts/templates/aur/bin/.SRCINFO
@@ -5,9 +5,12 @@ pkgbase = <%= pkgbase %>
 	url = <%= url %>
 	arch = x86_64
 	license = <%= license %>
+	depends = glibc
+	depends = gcc-libs
 	provides = clever-tools
 	conflicts = clever-tools
 	options = !strip
+	options = !debug
 	source = clever-tools-<%= version %>_linux.tar.gz::https://clever-tools.clever-cloud.com/releases/<%= version %>/clever-tools-<%= version %>_linux.tar.gz
 	sha256sums = <%= sha256 %>
 

--- a/scripts/templates/aur/bin/.SRCINFO
+++ b/scripts/templates/aur/bin/.SRCINFO
@@ -5,6 +5,8 @@ pkgbase = <%= pkgbase %>
 	url = <%= url %>
 	arch = x86_64
 	license = <%= license %>
+	provides = clever-tools
+	conflicts = clever-tools
 	options = !strip
 	source = clever-tools-<%= version %>_linux.tar.gz::https://clever-tools.clever-cloud.com/releases/<%= version %>/clever-tools-<%= version %>_linux.tar.gz
 	sha256sums = <%= sha256 %>

--- a/scripts/templates/aur/bin/PKGBUILD
+++ b/scripts/templates/aur/bin/PKGBUILD
@@ -7,10 +7,13 @@ pkgdesc="<%= description %>"
 arch=('x86_64')
 url="<%= url %>"
 license=('<%= license %>')
+# The binary embeds Node.js but is still dynamically linked against the C and C++ runtimes
+depends=('glibc' 'gcc-libs')
 provides=('clever-tools')
 conflicts=('clever-tools')
 
-options=(!strip)
+# Prebuilt binary: stripping it breaks it, and there are no debug symbols to extract
+options=(!strip !debug)
 
 source=("clever-tools-<%= version %>_linux.tar.gz::https://clever-tools.clever-cloud.com/releases/<%= version %>/clever-tools-<%= version %>_linux.tar.gz")
 sha256sums=('<%= sha256 %>')

--- a/scripts/templates/aur/bin/PKGBUILD
+++ b/scripts/templates/aur/bin/PKGBUILD
@@ -7,6 +7,8 @@ pkgdesc="<%= description %>"
 arch=('x86_64')
 url="<%= url %>"
 license=('<%= license %>')
+provides=('clever-tools')
+conflicts=('clever-tools')
 
 options=(!strip)
 

--- a/scripts/templates/aur/nodejs/.SRCINFO
+++ b/scripts/templates/aur/nodejs/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = <%= pkgbase %>
+	pkgdesc = <%= description %>
+	pkgver = <%= version %>
+	pkgrel = 1
+	url = <%= url %>
+	arch = any
+	license = <%= license %>
+	makedepends = npm
+	depends = nodejs>=22
+	conflicts = clever-tools-bin
+	options = !strip
+	options = !debug
+	source = clever-tools-<%= version %>.tgz::https://registry.npmjs.org/clever-tools/-/clever-tools-<%= version %>.tgz
+	source = clever-tools-<%= version %>-package-lock.json::https://raw.githubusercontent.com/CleverCloud/clever-tools/<%= version %>/package-lock.json
+	sha512sums = <%= tarballSha512 %>
+	sha512sums = <%= lockfileSha512 %>
+
+pkgname = <%= pkgbase %>

--- a/scripts/templates/aur/nodejs/PKGBUILD
+++ b/scripts/templates/aur/nodejs/PKGBUILD
@@ -1,0 +1,68 @@
+# Maintainer: <%= maintainer %>
+# Contributor: doclic <doclic@tutanota.com>
+
+pkgname=<%= pkgbase %>
+pkgver=<%= version %>
+pkgrel=1
+pkgdesc="<%= description %>"
+arch=('any')
+url="<%= url %>"
+license=('<%= license %>')
+depends=('nodejs>=22')
+makedepends=('npm')
+conflicts=('clever-tools-bin')
+
+# Pure JavaScript package: nothing to strip, no debug symbols to extract
+options=(!strip !debug)
+
+# The npm registry tarball is the reference artifact: it is exactly what
+# "npm install -g clever-tools" installs, published with provenance attestation.
+source=("clever-tools-$pkgver.tgz::https://registry.npmjs.org/clever-tools/-/clever-tools-$pkgver.tgz"
+        "clever-tools-$pkgver-package-lock.json::https://raw.githubusercontent.com/CleverCloud/clever-tools/$pkgver/package-lock.json")
+sha512sums=('<%= tarballSha512 %>'
+            '<%= lockfileSha512 %>')
+
+prepare() {
+  cd "${srcdir}/package"
+
+  # npm strips package-lock.json from published tarballs, so we fetch it from the
+  # matching git tag. It is not optional: without it, npm resolves the transitive
+  # dependency tree to whatever happens to be the latest matching version at build
+  # time, which is not what this release was tested against (52 transitive packages
+  # differed when measured on 4.11.0). With it, users get the exact dependency tree
+  # our CI builds and we test.
+  cp "${srcdir}/clever-tools-$pkgver-package-lock.json" package-lock.json
+
+  # --omit=dev       runtime dependencies only
+  # --ignore-scripts no dependency lifecycle script runs while packaging
+  # --cache          keep npm out of the packager's home directory
+  npm ci --omit=dev --ignore-scripts --no-audit --no-fund --cache "${srcdir}/npm-cache"
+}
+
+package() {
+  cd "${srcdir}/package"
+
+  install -d "${pkgdir}/usr/lib/clever-tools"
+  cp -r bin src node_modules package.json "${pkgdir}/usr/lib/clever-tools/"
+
+  # /usr/bin/clever is a thin wrapper around the Node.js entry point.
+  # NO_UPDATE_NOTIFIER disables the built-in update check: on Arch, updating is pacman's job.
+  install -Dm755 /dev/stdin "${pkgdir}/usr/bin/clever" <<'WRAPPER'
+#!/bin/sh
+export NO_UPDATE_NOTIFIER=1
+exec /usr/bin/node /usr/lib/clever-tools/bin/clever.js "$@"
+WRAPPER
+
+  NO_UPDATE_NOTIFIER=1 node bin/clever.js --bash-autocomplete-script /usr/bin/clever \
+    | install -Dm644 /dev/stdin "${pkgdir}/usr/share/bash-completion/completions/clever"
+  NO_UPDATE_NOTIFIER=1 node bin/clever.js --zsh-autocomplete-script /usr/bin/clever \
+    | install -Dm644 /dev/stdin "${pkgdir}/usr/share/zsh/site-functions/_clever"
+
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+  # Dependencies ship their own man pages, which namcap flags as non FHS and
+  # which are of no use here: the CLI documents itself through "clever help"
+  find "${pkgdir}/usr/lib/clever-tools/node_modules" -type d -name man -exec rm -rf {} +
+
+  chown -R root:root "${pkgdir}/usr/lib/clever-tools"
+}

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -58,12 +58,21 @@ yarn global add clever-tools
 
 #### Arch Linux (AUR)
 
-If you use Arch Linux, install packages [from AUR](https://aur.archlinux.org/packages/clever-tools-bin/). If you don't know how to use this, run:
+If you use Arch Linux, install Clever Tools from AUR. Two packages are available, they provide the same `clever` command and cannot be installed side by side:
+
+- [`clever-tools`](https://aur.archlinux.org/packages/clever-tools/): the Node.js flavor, it runs on the `nodejs` package of your system
+- [`clever-tools-bin`](https://aur.archlinux.org/packages/clever-tools-bin/): a self-contained binary, with no runtime dependency
+
+If you use an AUR helper like `yay`, run:
 
 ```
-git clone https://aur.archlinux.org/clever-tools-bin.git clever-tools
-cd clever-tools
-makepkg -si
+yay -S clever-tools
+```
+
+Or, for the self-contained binary:
+
+```
+yay -S clever-tools-bin
 ```
 
 #### CentOS/Fedora (.rpm)


### PR DESCRIPTION
Closes #1124

## Context

We now own the [`clever-tools`](https://aur.archlinux.org/packages/clever-tools) AUR package. It used to be maintained by a third party, and its inherited PKGBUILD rebuilt, from the GitHub sources, the very same `@yao-pkg/pkg` binary that we already publish as [`clever-tools-bin`](https://aur.archlinux.org/packages/clever-tools-bin): two AUR packages, one artifact, and a bump lag of days to weeks after each release.

It now ships the Node.js flavor of the CLI, running on the system `nodejs` package, and both packages are published by the release pipeline.

What Arch users get:

- `clever-tools-bin`: self-contained binary, no runtime dependency, frozen Node.js runtime
- `clever-tools`: Node.js flavor, `arch=any`, follows the system `nodejs`, so runtime security fixes are applied by pacman

## Proposal

`scripts/publish-aur.js` now takes a flavor argument (`bin` or `nodejs`) and templates live in `scripts/templates/aur/<flavor>/`. One script, two AUR repositories, two release jobs: `publish-aur-bin` (unchanged, `needs: publish-cellar-archives`) and `publish-aur-nodejs` (`needs: publish-npm`).

### Design decisions

**The npm registry tarball as source.** This is the URL template prescribed by the [Arch Node.js package guidelines](https://wiki.archlinux.org/title/Node.js_package_guidelines): immutable, versioned, and already attested by our `npm publish --provenance`. It is also what most Node.js CLIs packaged on the AUR use (`gemini-cli`, `netlify`, `firebase-tools`, `devcontainer-cli`, `repomix`).

**`npm ci` against the lockfile, not the wiki's `npm install -g --prefix`.** This is the one place where we knowingly deviate from the guidelines, and the reason is worth stating.

npm always strips `package-lock.json` from published tarballs, even when the file is explicitly listed in the `files` field, so the minimal recipe resolves the transitive dependency tree to whatever is latest at build time. Measured on 4.11.0: **52 transitive dependencies** resolve to versions this release was never tested against, including major bumps (`@pnpm/npm-conf` 2.3.1 → 3.0.3, `ansi-regex` 5.0.1 → 6.3.0, `@inquirer/core` 10.2.0 → 10.3.2). Our direct dependencies are pinned to exact versions, their own dependencies are not.

Three consequences we are not willing to ship:

- users would not install what we test and release: a regression introduced in a transitive dependency the week after a release lands on Arch users without any version of `clever-tools` moving
- the lockfile carries an integrity hash per package; without it nothing is verified, and a compromised transitive dependency published after our release goes straight into the package
- two people building the same `pkgver-pkgrel` two weeks apart get different packages

So the PKGBUILD fetches `package-lock.json` from the matching git tag as a second source, and runs `npm ci --omit=dev --ignore-scripts`. The rationale is also inlined in the PKGBUILD, since that file is read by AUR users and by whoever edits it next.

**`--ignore-scripts`**: no production dependency needs a lifecycle script, so none runs while packaging.

**`arch=any`**: verified, no native addon in the production tree.

**A thin `sh` wrapper for `/usr/bin/clever`**, exporting `NO_UPDATE_NOTIFIER=1`: a pacman-managed CLI must not advertise out-of-band updates. Same approach as `command-code`, `claude-code` and `sillytavern` on the AUR.

**No `jq` cleanup of the `_where` and `man` keys**: the recipe in the wiki dates back to npm 6, npm 11 no longer writes those references (verified on the built package).

**`.SRCINFO` stays templated**, and no containerized validation job was added. `makepkg --printsrcinfo` output is byte-identical to the templated file for both flavors, and what a build in CI would catch (a broken PKGBUILD) only happens when the template is edited, not on every tag. The local validation procedure is documented in `CONTRIBUTING.md` instead.

### Drive-by fix

`namcap` reports **3 errors** on the current `clever-tools-bin`: the PKGBUILD declares no dependency at all, while the binary is dynamically linked against glibc, libstdc++ and libgcc. Fixed with `depends=('glibc' 'gcc-libs')`, plus `!debug` to stop shipping an empty `/usr/src/debug`. Both packages now build with zero namcap error.

## How to review

- `scripts/templates/aur/nodejs/PKGBUILD` first, it carries the whole reasoning
- then `scripts/publish-aur.js` for the flavor dispatch, and `scripts/lib/npm-registry.js` which derives the tarball sha512 from `dist.integrity` without downloading anything
- `.github/workflows/release.yml` last, the new job is a twin of the existing one

## How to test

Requires an Arch machine, `makepkg` and `namcap`. Against a local bare repository, nothing reaches AUR:

```
git init --bare -b master /tmp/aur-clever-tools.git
git clone /tmp/aur-clever-tools.git /tmp/aur-seed
git -C /tmp/aur-seed commit --allow-empty -m init
git -C /tmp/aur-seed push origin HEAD:master

AUR_GIT_URL=/tmp/aur-clever-tools.git ./scripts/publish-aur.js 4.11.0 nodejs

mkdir -p /tmp/aur-build && cp git-aur/PKGBUILD /tmp/aur-build/ && cd /tmp/aur-build
makepkg -f
makepkg --printsrcinfo | diff - ~/clever-tools/git-aur/.SRCINFO
namcap PKGBUILD && namcap clever-tools-*.pkg.tar.zst
sudo pacman -U ./clever-tools-4.11.0-1-any.pkg.tar.zst
clever version
```

Results on 4.11.0: package builds as `any`, 5.4 MB compressed / 31 MB installed, zero namcap error, `clever version` and `clever help` work, bash and zsh completions installed, and installing it correctly prompts to remove `clever-tools-bin` thanks to the new `conflicts`.

Same sequence with the `bin` flavor to check the existing channel still builds.

## Out of scope

- no CI job validating PKGBUILD templates; if we want one later, the right trigger is a PR touching `scripts/templates/aur/**`, not every tag

## Before merging

The `AUR_NODEJS_GIT_URL` repository variable is already created (`ssh://aur@aur.archlinux.org/clever-tools.git`). Remaining check: confirm the CI SSH key has push rights on the transferred package, with `ssh aur@aur.archlinux.org list-repos`.
