### PR TITLE
feat(accesslogs): fetch access logs of add-ons

### DIFF
--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -24,19 +24,74 @@ const THROTTLE_PER_IN_MILLISECONDS = 100;
 
 const CITY_MAX_LENGTH = 20;
 
+function formatLocation(endpoint) {
+  const country = endpoint.countryCode ?? '(unknown)';
+  const hasCity = endpoint.city ?? '';
+
+  return `${country}${hasCity ? '/' + truncateWithEllipsis(CITY_MAX_LENGTH, endpoint.city) : ''}`;
+}
+
 function formatHuman(log) {
   const { date, http, source } = log;
-  const country = source.countryCode ?? '(unknown)';
-  const hasSourceCity = source.city ?? '';
 
   return formatTable(
     [
       [
         styleText('grey', date.toISOString(date)),
         source.ip,
-        `${country}${hasSourceCity ? '/' + truncateWithEllipsis(CITY_MAX_LENGTH, source.city) : ''}`,
+        formatLocation(source),
         colorStatusCode(http.response.statusCode),
         http.request.method.toString().padEnd(4, ' ') + ' ' + http.request.path,
+      ],
+    ],
+
+    ACCESSLOG_COLUMN_WIDTHS,
+  );
+}
+
+/** An access log carries this instance ID when the platform did not attach the event to a VM */
+const NIL_INSTANCE_ID = '00000000-0000-0000-0000-000000000000';
+
+const INSTANCE_ID_SHORT_LENGTH = 8;
+
+function formatBytes(bytes) {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(2)}KiB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(2)}MiB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GiB`;
+}
+
+/**
+ * Format an access log without an HTTP section, as emitted for TCP redirections and for add-ons
+ * exposed over raw TCP (Redis, PostgreSQL…). The columns are kept identical to the HTTP ones so both
+ * kinds of lines stay aligned in a single stream: `TCP` sits where the status code would be, and the
+ * connection details replace the request line.
+ *
+ * The destination is the load balancer, not the add-on, so it's dropped. The target VM is only
+ * printed when the platform actually filled it: add-ons exposed over raw TCP leave it at the nil
+ * UUID, printing that on every line would be pure noise.
+ */
+function formatHumanTcp(log) {
+  const { date, source, bytesIn, bytesOut, instanceId } = log;
+  const target =
+    instanceId != null && instanceId !== NIL_INSTANCE_ID ? instanceId.slice(0, INSTANCE_ID_SHORT_LENGTH) : null;
+
+  return formatTable(
+    [
+      [
+        styleText('grey', date.toISOString(date)),
+        source.ip,
+        formatLocation(source),
+        styleText('cyan', 'TCP'),
+        [`:${source.port}`, `${formatBytes(bytesIn)}↑ ${formatBytes(bytesOut)}↓`, target && styleText('grey', target)]
+          .filter((part) => part != null)
+          .join('  '),
       ],
     ],
 
@@ -140,7 +195,8 @@ export const accesslogsCommand = defineCommand({
             Logger.printJson(log);
             break;
           case 'clf':
-            // when the connection is cut too early, or for TCP redirections, we don't have HTTP section
+            // when the connection is cut too early, or for TCP redirections, we don't have HTTP
+            // section. CLF describes an HTTP request, there is nothing meaningful to emit here
             if (log.http == null) {
               break;
             }
@@ -149,12 +205,10 @@ export const accesslogsCommand = defineCommand({
             break;
           case 'human':
           default:
-            // when the connection is cut too early, or for TCP redirections, we don't have HTTP section
-            if (log.http == null) {
-              break;
-            }
-
-            Logger.println(formatHuman(log));
+            // when the connection is cut too early, or for TCP redirections, we don't have HTTP
+            // section. That's the only thing add-ons exposed over raw TCP ever emit, so these logs
+            // get their own line instead of being dropped
+            Logger.println(log.http == null ? formatHumanTcp(log) : formatHuman(log));
             break;
         }
       });

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -165,10 +165,6 @@ export const accesslogsCommand = defineCommand({
       throttlePerInMilliseconds: THROTTLE_PER_IN_MILLISECONDS,
     });
 
-    if (format === 'human') {
-      Logger.println(styleText('yellow', '/!\\ This feature is in Beta testing phase'));
-    }
-
     if (format === 'json' && !until) {
       throw new Error('JSON format only works with a limiting parameter such as `before`');
     }

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -5,6 +5,7 @@ import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import * as Application from '../../models/application.js';
+import { resolveAddon } from '../../models/ids-resolver.js';
 import { JsonArray } from '../../models/json-array.js';
 import { getHostAndTokens } from '../../models/send-to-api.js';
 import { truncateWithEllipsis } from '../../models/utils.js';
@@ -84,20 +85,25 @@ export const accesslogsCommand = defineCommand({
   },
   args: [],
   async handler(options) {
-    // TODO: drop when add-ons are supported in API
-    if (options.addon) {
-      throw new Error('Access Logs are not available for add-ons yet');
-    }
-
     const { apiHost, tokens } = await getHostAndTokens();
-    const { alias, app: appIdOrName, format, before: until, after: since } = options;
-    const { ownerId, appId } = await Application.resolveId(appIdOrName, alias);
+    const { alias, app: appIdOrName, addon: addonIdOrRealId, format, before: until, after: since } = options;
+
+    // Add-ons are served by the very same endpoint as applications: the `applications` path segment
+    // is a misnomer, the API accepts any loggable ID. The access logs topic is named after the
+    // add-on real ID, an `addon_` ID resolves to no topic at all, hence the `realId` here.
+    const { ownerId, resourceId } =
+      addonIdOrRealId != null
+        ? await resolveAddon(addonIdOrRealId).then(({ ownerId, realId }) => ({ ownerId, resourceId: realId }))
+        : await Application.resolveId(appIdOrName, alias).then(({ ownerId, appId }) => ({
+            ownerId,
+            resourceId: appId,
+          }));
 
     const stream = new ApplicationAccessLogStream({
       apiHost,
       tokens,
       ownerId,
-      appId,
+      appId: resourceId,
       since,
       until,
       throttleElements: THROTTLE_ELEMENTS,
@@ -117,7 +123,7 @@ export const accesslogsCommand = defineCommand({
 
     stream
       .on('open', () => {
-        Logger.debug(styleText('blue', `Logs stream (open) ${JSON.stringify({ appId })}`));
+        Logger.debug(styleText('blue', `Logs stream (open) ${JSON.stringify({ resourceId })}`));
         if (format === 'json') {
           jsonArray.open();
         }

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -74,8 +74,9 @@ function formatBytes(bytes) {
  * connection details replace the request line.
  *
  * The destination is the load balancer, not the add-on, so it's dropped. The target VM is only
- * printed when the platform actually filled it: add-ons exposed over raw TCP leave it at the nil
- * UUID, printing that on every line would be pure noise.
+ * printed when the API resolved it: it carries the load balancer server name, which is a bare UUID
+ * for some providers but not for others, and the API falls back to the nil UUID when it cannot
+ * parse it. Printing `00000000` on every line of those would be pure noise.
  */
 function formatHumanTcp(log) {
   const { date, source, bytesIn, bytesOut, instanceId } = log;


### PR DESCRIPTION
Closes #1126

## What

`clever accesslogs --addon <id>` now works. The option was already declared and documented, but the handler threw `Access Logs are not available for add-ons yet` behind a `// TODO: drop when add-ons are supported in API`.

## Why the TODO was stale

The v4 endpoint reads `/v4/accesslogs/organisations/{ownerId}/applications/{id}/accesslogs`, and that `applications` segment is a misnomer. Server side it is parsed as a `LoggableId`, a union accepting every add-on prefix (`redis_`, `postgresql_`, `cellar_`, `pulsar_`, `keycloak_`, `otoroshi_`…), and the handler then reads the Pulsar topic named after that ID. Nothing along that path is application specific — the API has been able to serve add-on access logs all along.

The **real ID** is what matters: it is the topic name. An `addon_` ID matches no topic and would silently stream nothing, so add-ons go through `resolveAddon` first, exactly like `clever logs --addon` already does. Both ID forms work for the user.

## TCP access logs were being dropped

Add-ons exposed over raw TCP emit access logs with no `http` section (so do TCP redirections on applications, and connections cut before the request line is parsed). Both the `human` and `clf` formatters skipped any log where `log.http == null` — meaning that without this second fix, the command would have connected, received events, and printed nothing.

The human format now renders them, keeping the exact same columns as HTTP lines so a mixed stream stays aligned: `TCP` where the status code sits, connection details where the request line sits.

```
2026-08-13T05:31:10.793Z  91.231.89.104    FR/Gravelines            TCP  :53171  0B↑ 0B↓
2026-08-13T05:31:20.979Z  91.231.89.107    FR/Gravelines            TCP  :53749  0B↑ 0B↓
2026-08-13T11:50:09.802Z  185.177.72.22    (unknown)                TCP  :49700  0B↑ 0B↓
2026-08-13T05:31:44.201Z  54.36.148.12     FR/Roubaix               200  GET  /api/v1/items?page=2
```

The destination is dropped, it is the load balancer rather than the resource. The target VM is printed only when the API resolved it. `clf` keeps skipping these on purpose: it describes an HTTP request, and a line with neither request line nor status is not parsable by grok or GoAccess.

## Two platform-side gaps, not addressed here

Observed in production across four add-ons: `bytesIn`/`bytesOut` are always `0`, and `instanceId` is the nil UUID on Redis/PostgreSQL — but a **real VM UUID on Elasticsearch**. The CLI renders both correctly whenever the platform provides them; nothing more can be done client side.

- **Target VM.** The value does reach the API. It carries HAProxy's `server_name`, which is a bare UUID for some providers (`c958d0a5-…`) and `<real_id>_<index>` for others (`postgresql_bde3942f-…_0`) — see the access-logs-forwarder parser fixtures. The API parses that string as a UUID-typed `InstanceID` and silently substitutes the nil UUID when it fails, so the information is dropped for a whole class of providers. Fix belongs in the API's `AccessLogView` (or in a uniform load balancer server naming).
- **Byte counters.** Every other field of the record survives, so the loss is confined to the metrics envelope rather than the record. The v2→v3 conversion in the common SDK only builds the TCP metrics envelope when `protocol` equals the literal string `"TCP"`, and the v3→customer-avro conversion then defaults the counters to `0` when that envelope is absent. Needs confirmation by reading the raw customer topic (the `source` and `proxy_hostname` fields, which the API drops, identify the emitter).

Also for the record: the API hardcodes `region`/`zone` to `""` and `tls` to `null` in its mapping — dead fields in the payload.

## Also

Drops the `/!\ This feature is in Beta testing phase` banner: the command shipped in 2.1.0 and the endpoint is stable.

## Testing

`npm run validate` passes (lint, prettier, tsc, docs). Manually verified against production on Redis, PostgreSQL and Elasticsearch add-ons, with both `addon_` and real ID forms, across `human`, `json`, `json-stream` and `clf` formats.