### PR TITLE
feat(tokens): add a metrics gen command to create Warp 10 read tokens

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -3761,6 +3761,36 @@ api-token-name                   API token name
 -F, --format <format>            Output format (human, json) (default: human)
 ```
 
+### tokens metrics
+
+**Description:** Manage the Warp 10 tokens used to query your metrics
+
+**Since:** Unreleased
+
+**Usage**
+```
+clever tokens metrics
+```
+
+#### tokens metrics gen
+
+**Description:** Generate a Warp 10 read token to query your metrics
+
+**Since:** Unreleased
+
+**Usage**
+```
+clever tokens metrics gen [options]
+```
+
+**Options**
+```
+-a, --apps <applications>               Comma separated list of platform applications the token grants read access to
+-F, --format <format>                   Output format (human, json) (default: human)
+-o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
+-t, --ttl <ttl>                         Token lifespan, as an ISO 8601 duration (e.g.: P5D, PT12H) or a "1h, 4d, 2w" like duration
+```
+
 ### tokens revoke
 
 **Description:** Revoke an API token

--- a/src/clever-client/stats.js
+++ b/src/clever-client/stats.js
@@ -1,0 +1,20 @@
+/**
+ * Create a Warp 10 READ token scoped to an owner and a set of platform applications.
+ *
+ * The owner may be an organisation (`orga_…`) or a personal space (`user_…`); the route is named
+ * `organisations` but accepts both.
+ *
+ * @param {object} params
+ * @param {string} params.ownerId Organisation or personal space ID
+ * @param {string[]} params.applications Platform applications the token grants read access to
+ * @param {string} params.ttl Token lifespan, as an ISO 8601 duration
+ * @returns {Promise<object>} the request params, to be sent with `sendToApi`
+ */
+export function createMetricsReadToken({ ownerId, applications, ttl }) {
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/stats/organisations/${ownerId}/tokens/read`,
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: { applications, ttl },
+  });
+}

--- a/src/commands/global.commands.js
+++ b/src/commands/global.commands.js
@@ -181,6 +181,8 @@ import { tcpRedirsListNamespacesCommand } from './tcp-redirs/tcp-redirs.list-nam
 import { tcpRedirsRemoveCommand } from './tcp-redirs/tcp-redirs.remove.command.js';
 import { tokensCommand } from './tokens/tokens.command.js';
 import { tokensCreateCommand } from './tokens/tokens.create.command.js';
+import { tokensMetricsCommand } from './tokens/tokens.metrics.command.js';
+import { tokensMetricsGenCommand } from './tokens/tokens.metrics.gen.command.js';
 import { tokensRevokeCommand } from './tokens/tokens.revoke.command.js';
 import { unlinkCommand } from './unlink/unlink.command.js';
 import { versionCommand } from './version/version.command.js';
@@ -522,6 +524,12 @@ export const globalCommands = {
     tokensCommand,
     {
       create: tokensCreateCommand,
+      metrics: [
+        tokensMetricsCommand,
+        {
+          gen: tokensMetricsGenCommand,
+        },
+      ],
       revoke: tokensRevokeCommand,
     },
   ],

--- a/src/commands/tokens/tokens.docs.md
+++ b/src/commands/tokens/tokens.docs.md
@@ -35,6 +35,31 @@ clever tokens create <api-token-name> [options]
 |`-e`, `--expiration` `<expiration>`|Duration until API token expiration (e.g.: 1h, 4d, 2w, 6M) (default: 1y)|
 |`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
 
+## ➡️ `clever tokens metrics` <kbd>Unreleased</kbd>
+
+Manage the Warp 10 tokens used to query your metrics
+
+```bash
+clever tokens metrics
+```
+
+## ➡️ `clever tokens metrics gen` <kbd>Unreleased</kbd>
+
+Generate a Warp 10 read token to query your metrics
+
+```bash
+clever tokens metrics gen [options]
+```
+
+### ⚙️ Options
+
+|Name|Description|
+|---|---|
+|`-a`, `--apps` `<applications>`|Comma separated list of platform applications the token grants read access to|
+|`-F`, `--format` `<format>`|Output format (human, json) (default: human)|
+|`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
+|`-t`, `--ttl` `<ttl>`|Token lifespan, as an ISO 8601 duration (e.g.: P5D, PT12H) or a "1h, 4d, 2w" like duration|
+
 ## ➡️ `clever tokens revoke` <kbd>Since 3.12.0</kbd>
 
 Revoke an API token

--- a/src/commands/tokens/tokens.metrics.command.js
+++ b/src/commands/tokens/tokens.metrics.command.js
@@ -1,0 +1,9 @@
+import { defineCommand } from '../../lib/define-command.js';
+
+export const tokensMetricsCommand = defineCommand({
+  description: 'Manage the Warp 10 tokens used to query your metrics',
+  since: null,
+  options: {},
+  args: [],
+  handler: null,
+});

--- a/src/commands/tokens/tokens.metrics.gen.command.js
+++ b/src/commands/tokens/tokens.metrics.gen.command.js
@@ -1,0 +1,175 @@
+import { getSummary } from '@clevercloud/client/esm/api/v2/user.js';
+import dedent from 'dedent';
+import { z } from 'zod';
+import { createMetricsReadToken } from '../../clever-client/stats.js';
+import { formatDate } from '../../lib/date-utils.js';
+import { defineCommand } from '../../lib/define-command.js';
+import { defineOption } from '../../lib/define-option.js';
+import { promptCheckbox, promptTextOption, selectAnswer } from '../../lib/prompts.js';
+import { styleText } from '../../lib/style-text.js';
+import { Logger } from '../../logger.js';
+import * as Organisation from '../../models/organisation.js';
+import { sendToApi } from '../../models/send-to-api.js';
+import { commaSeparated, iso8601Duration } from '../../parsers.js';
+import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
+
+/**
+ * The Warp 10 platform applications a READ token can be scoped to, as offered by the prompt.
+ *
+ * Whether a given owner may actually ask for one of them is a server-side decision that varies
+ * per deployment, so this list drives the prompt only — it is never used to validate `--apps`.
+ * An unknown or disallowed value goes to the API, whose error names exactly what it accepts;
+ * that keeps a stale list here from rejecting an application the platform has since opened up.
+ */
+const PLATFORM_APPLICATIONS = [
+  { value: 'metrics', description: 'Runtime metrics of your applications and add-ons (CPU, memory, disk…)' },
+  { value: 'metrics.accesslogs', description: 'HTTP access logs' },
+  { value: 'addon-api-cellar', description: 'Cellar storage usage' },
+  { value: 'addon-api-fsbucket', description: 'FS Bucket storage usage' },
+];
+
+/** The applications a token covers when the request omits them. */
+const DEFAULT_APPLICATIONS = ['metrics', 'metrics.accesslogs'];
+
+/**
+ * A token lifespan, before normalisation.
+ *
+ * The rule lives in a `refine` rather than only in the `transform` below because
+ * `promptTextOption` validates against the *input* schema: put it here and a typo re-asks, put it
+ * in the transform and it throws the prompt away. `iso8601Duration` stays the single source of
+ * truth for the grammar — a throw from it is what "invalid" means.
+ */
+const ttlSchema = z.string().superRefine((value, ctx) => {
+  try {
+    iso8601Duration(value);
+  } catch (error) {
+    // Forward the parser's own message: it distinguishes an unparseable duration from a
+    // well-formed but non-positive one, which a boolean refine would flatten into one wording.
+    ctx.addIssue({ code: 'custom', message: error.message });
+  }
+});
+
+const ttlOption = defineOption({
+  name: 'ttl',
+  schema: ttlSchema.transform(iso8601Duration).optional(),
+  description: 'Token lifespan, as an ISO 8601 duration (e.g.: P5D, PT12H) or a "1h, 4d, 2w" like duration',
+  aliases: ['t'],
+  placeholder: 'ttl',
+});
+
+const applicationsOption = defineOption({
+  name: 'apps',
+  schema: z.string().transform(commaSeparated).optional(),
+  description: 'Comma separated list of platform applications the token grants read access to',
+  aliases: ['a'],
+  placeholder: 'applications',
+});
+
+export const tokensMetricsGenCommand = defineCommand({
+  description: 'Generate a Warp 10 read token to query your metrics',
+  since: null,
+  options: {
+    org: orgaIdOrNameOption,
+    apps: applicationsOption,
+    ttl: ttlOption,
+    format: humanJsonOutputFormatOption,
+  },
+  args: [],
+  async handler(options) {
+    const { org, apps, ttl, format } = options;
+
+    const owner = org != null ? { id: await Organisation.getId(org) } : await promptOwner();
+    const lifespan = ttl ?? (await promptTtl());
+
+    // `--apps ''` and a trailing comma both yield empty entries; drop them here rather than let
+    // the API answer `"" not in expected values […]`, which reads like a bug in the CLI.
+    const applications = (apps ?? (await promptApplications())).map((app) => app.trim()).filter((app) => app !== '');
+
+    if (applications.length === 0) {
+      throw new Error('You must pick at least one application');
+    }
+
+    const token = await createMetricsReadToken({
+      ownerId: owner.id,
+      applications,
+      ttl: lifespan,
+    }).then(sendToApi);
+
+    switch (format) {
+      case 'json':
+        Logger.printJson(token);
+        break;
+      case 'human':
+      default:
+        Logger.println(dedent`
+          ${styleText('green', '✔')} Metrics read token successfully created! Store it securely, you won't be able to print it again.
+
+            - Owner        : ${styleText('grey', owner.name ?? owner.id)}
+            - Applications : ${styleText('grey', token.applications.join(', '))}
+            - Expiration   : ${styleText('grey', formatDate(token.expiresAt))}
+            - Token        : ${styleText('grey', token.token)}
+
+          Use it as the read token of your Warp 10 queries, for instance:
+
+            [ '${token.token}' '~.*' {} NOW 1 h ] FETCH
+        `);
+    }
+  },
+});
+
+/**
+ * Ask which owner the token should be scoped to, personal space included.
+ * @returns {Promise<{ id: string, name: string }>}
+ */
+async function promptOwner() {
+  const { user, organisations } = await getSummary({}).then(sendToApi);
+
+  // The summary already lists the personal space among `organisations`, so a bare
+  // `[user, ...organisations]` shows it twice. Deduplicating on the first occurrence keeps it at
+  // the top of the list, where it is the friendliest default to land on.
+  const owners = [user, ...organisations].filter(
+    (owner, index, all) => all.findIndex((other) => other.id === owner.id) === index,
+  );
+
+  const choices = owners.map((owner) => ({
+    name: owner.id === user.id ? `${owner.name} (personal space)` : owner.name,
+    value: { id: owner.id, name: owner.name },
+  }));
+
+  return selectAnswer(
+    'Which organisation do you want a token for?',
+    choices,
+    'Use --org <org-id|org-name> to skip this prompt.',
+  );
+}
+
+/**
+ * Ask which platform applications the token should grant read access to.
+ * @returns {Promise<string[]>}
+ */
+function promptApplications() {
+  const choices = PLATFORM_APPLICATIONS.map(({ value, description }) => ({
+    name: value,
+    value,
+    description,
+    checked: DEFAULT_APPLICATIONS.includes(value),
+  }));
+
+  return promptCheckbox(
+    'Which applications do you want to read?',
+    choices,
+    'Use --apps <applications> to skip this prompt.',
+  );
+}
+
+/**
+ * Ask how long the token should live.
+ *
+ * The prompt validates but does not transform, so the answer still goes through
+ * `iso8601Duration` to normalise `4d` into `P4D`.
+ * @returns {Promise<string>}
+ */
+async function promptTtl() {
+  const answer = await promptTextOption(ttlOption, 'P5D');
+  return iso8601Duration(answer);
+}

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -158,13 +158,53 @@ const SHORT_UNITS_TO_ISO = {
 };
 
 function parseSimpleDuration(durationStr) {
-  const { rawValue, unit } = durationStr.match(/^(?<rawValue>\d+)(?<unit>.*)$/)?.groups ?? {};
-  if (unit in SHORT_UNITS_TO_ISO) {
-    const value = Number(rawValue);
-    const isoDuration = SHORT_UNITS_TO_ISO[unit](value);
-    const d = ISO8601.parse(isoDuration);
-    return ISO8601.toSeconds(d);
+  const isoDuration = shortDurationToIso(durationStr);
+  if (isoDuration != null) {
+    return ISO8601.toSeconds(ISO8601.parse(isoDuration));
   }
+}
+
+/**
+ * Convert a `1h`/`4d`/`2w` like duration to its ISO 8601 form, or `null` if the unit is unknown.
+ * @param {string} durationStr
+ * @returns {string|null} an ISO 8601 duration
+ */
+function shortDurationToIso(durationStr) {
+  const { rawValue, unit } = durationStr.match(/^(?<rawValue>\d+)(?<unit>.*)$/)?.groups ?? {};
+  return unit in SHORT_UNITS_TO_ISO ? SHORT_UNITS_TO_ISO[unit](Number(rawValue)) : null;
+}
+
+/**
+ * Parse a duration into the ISO 8601 string an API expects.
+ *
+ * Accepts the same grammar as {@link durationInSeconds} minus the bare number of seconds, which
+ * would be ambiguous here, and returns a duration rather than a count of seconds: `P5D` stays
+ * `P5D` instead of becoming `432000`, so what the user typed is what gets sent and echoed back.
+ * A zero or negative duration is rejected — every caller so far wants a lifespan.
+ *
+ * @param {string} durationStr an ISO 8601 duration or a `1h, 4d, 2w` like duration
+ * @returns {string} an ISO 8601 duration
+ */
+export function iso8601Duration(durationStr = '') {
+  const errorMessage = `Invalid duration: "${durationStr}", expect an ISO 8601 duration (e.g.: P5D, PT12H) or a "1h, 4d, 2w" like duration`;
+
+  const isoDuration = durationStr.startsWith('P') ? durationStr : shortDurationToIso(durationStr);
+  if (isoDuration == null) {
+    throw new Error(errorMessage);
+  }
+
+  let seconds;
+  try {
+    seconds = ISO8601.toSeconds(ISO8601.parse(isoDuration));
+  } catch {
+    throw new Error(errorMessage);
+  }
+
+  if (seconds <= 0) {
+    throw new Error(`Invalid duration: "${durationStr}", it must be strictly positive`);
+  }
+
+  return isoDuration;
 }
 
 // Network Groups parsers


### PR DESCRIPTION
## What

Adds `clever tokens metrics gen`, which mints a Warp 10 READ token through `POST /v4/stats/organisations/{ownerId}/tokens/read`.

```
$ clever tokens metrics gen
? Which organisation do you want a token for? › Rémi Collignon (personal space)
? Which applications do you want to read? › ◉ metrics  ◉ metrics.accesslogs  ◯ addon-api-cellar  ◯ addon-api-fsbucket
? Token lifespan, as an ISO 8601 duration (e.g.: P5D, PT12H) or a "1h, 4d, 2w" like duration: › P5D

✔ Metrics read token successfully created! Store it securely, you won't be able to print it again.

  - Owner        : Rémi Collignon
  - Applications : metrics, metrics.accesslogs
  - Expiration   : 2026-08-31 09:12
  - Token        : …
```

## Why

Getting a Warp 10 token today means either the Console's **Metrics** tab — which only ever hands out one fixed scope — or a hand-rolled `clever curl` with a JSON body most people have to be told about. Neither lets you ask for, say, FS Bucket storage metrics, which is what prompted this.

## Design notes

**Prompts are skipped when the option is given.** `--org`, `--apps` and `--ttl` each bypass their prompt, so the command is scriptable and CI-safe. Without a TTY the existing `assertInteractiveTerminal` guard fires with the option to use, rather than the silent `exit(1)` a raw Inquirer EOF would produce.

**The application list is not validation.** Which applications an owner may request is a server-side allow-list that varies per deployment, so `PLATFORM_APPLICATIONS` drives the checkbox and nothing else — `--apps` is passed through untouched. A stale list here would otherwise reject an application the platform has since opened up, and the API's own error already names what it accepts:

```
$ clever tokens metrics gen -o … -a bogus-app -t P1D
[ERROR] bogus-app not in expected values [metrics, addon-api-cellar, metrics.accesslogs, addon-api-fsbucket]
```

**`since: null`** on both definitions, per `scripts/resolve-since.js` — the release resolves it.

**Two things worth a reviewer's eye:**

- The personal space is listed *twice* by `/v2/summary`: it appears in `organisations` with the same id as `user`. A bare `[user, ...organisations]` (the shape `models/addon.js` uses, where it only costs a wasted loop iteration) renders a visible duplicate in a picker, so the choices are deduplicated on first occurrence — which also keeps the personal space at the top.
- The TTL rule lives in a `superRefine` on the *input* schema rather than only in the `transform`. `promptTextOption` validates against the unwrapped input schema, so this is what makes a typo re-ask instead of throwing the prompt away. `iso8601Duration` stays the single source of truth for the grammar and its message is forwarded verbatim, which is why `PT0S` says something useful:

```
$ clever tokens metrics gen … -t nope
ttl: Invalid duration: "nope", expect an ISO 8601 duration (e.g.: P5D, PT12H) or a "1h, 4d, 2w" like duration
$ clever tokens metrics gen … -t PT0S
ttl: Invalid duration: "PT0S", it must be strictly positive
```

## `src/parsers.js`

New `iso8601Duration`: same grammar as `durationInSeconds` minus the bare number of seconds (ambiguous here), but returns a duration instead of a count, so `P5D` is sent as `P5D` rather than `432000` and the API echoes back something the user recognises. `parseSimpleDuration` now shares the short-unit conversion with it — same behaviour, one copy.

## Open question for the reviewer

`clever tokens`' own description still reads *"Manage API tokens to query Clever Cloud API from https://api-bridge.clever-cloud.com"*. That stays true of the bare command, which lists API tokens, but the group now also holds Warp 10 metrics tokens. I left the string alone rather than reword a released command's help as a side effect of this PR — say the word and I'll broaden it.

## Verification

`npm run validate` clean (eslint, prettier, tsc, docs:check).

Run against the production API, not mocked:

- non-interactive with `-t 5d` → token expiring exactly 5 days later, so the short form normalises correctly
- non-interactive with `-t 2h` → 2 hours
- `--org` by name resolves through `Organisation.getId`
- full interactive flow driven over a real pty → token with the default applications
- `--apps ''` and `--apps ' metrics , '` → the first errors client-side, the second yields `['metrics']`
- no TTY and no `--org` → `This command requires an interactive terminal. Use --org <org-id|org-name> to skip this prompt.`

No unit tests: the repo has no test suite for commands, so this follows the existing convention.

> [!NOTE]
> The branch is still named `feat/metrics-gen-token`, from the first naming of this command (`clever metrics gen-token`). GitHub can't retarget a PR's head branch, so it stays — the commit and the command are the ones that matter.

## Follow-up

The FS Bucket storage metric this unblocks is documented in CleverCloud/documentation#998.