### PR TITLE
fix: activate update notifier for every install channel

### DIFF
--- a/docs/setup-systems.md
+++ b/docs/setup-systems.md
@@ -1,7 +1,12 @@
 # How to install Clever Tools
 
-Clever Cloud CLI is based on Node.js. We thought it to be easily available on any platform. Thus, you can download Clever Tools as [a npm package](https://www.npmjs.com/package/clever-tools), but also through package managers or as a binary on many systems:
+Clever Tools is available as a npm package, through package managers, or as a standalone binary on many systems:
 
+- [Node.js](/docs/setup-systems.md#nodejs)
+  - [npm](/docs/setup-systems.md#npm)
+  - [pnpm](/docs/setup-systems.md#pnpm)
+  - [Bun](/docs/setup-systems.md#bun)
+  - [Yarn](/docs/setup-systems.md#yarn)
 - [GNU/Linux](/docs/setup-systems.md#gnulinux)
   - [Arch Linux (AUR)](/docs/setup-systems.md#arch-linux-aur)
   - [CentOS/Fedora (.rpm)](/docs/setup-systems.md#centosfedora-rpm)
@@ -16,6 +21,34 @@ Clever Cloud CLI is based on Node.js. We thought it to be easily available on an
   - [Binary (.zip)](/docs/setup-systems.md#binary-zip)
 - [Docker](/docs/setup-systems.md#docker)
 - [Nix package manager](/docs/setup-systems.md#nix-package-manager)
+
+## Node.js
+
+Clever Tools is available as [a npm package](https://www.npmjs.com/package/clever-tools):
+
+### npm
+
+```
+npm install -g clever-tools
+```
+
+### pnpm
+
+```
+pnpm add -g clever-tools
+```
+
+### Bun
+
+```
+bun add -g clever-tools
+```
+
+### Yarn
+
+```
+yarn global add clever-tools
+```
 
 ## GNU/Linux
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,137 @@
+# How to update Clever Tools
+
+The command to update Clever Tools depends on how you installed it. If you're not sure, see [how to install Clever Tools](/docs/setup-systems.md).
+
+- [Node.js](#nodejs)
+  - [npm](#npm)
+  - [pnpm](#pnpm)
+  - [Bun](#bun)
+  - [Yarn](#yarn)
+- [GNU/Linux](#gnulinux)
+  - [Arch Linux (AUR)](#arch-linux-aur)
+  - [CentOS/Fedora (.rpm)](#centosfedora-rpm)
+  - [Debian/Ubuntu (.deb)](#debianubuntu-deb)
+  - [Exherbo](#exherbo)
+  - [Binary (.tar.gz)](#other-distributions-targz)
+- [macOS](#macos)
+  - [Homebrew](#homebrew)
+  - [Binary (.tar.gz)](#binary-targz)
+- [Windows](#windows)
+  - [WinGet](#winget)
+  - [Binary (.zip)](#binary-zip)
+- [Docker](#docker)
+- [Nix package manager](#nix-package-manager)
+
+## Node.js
+
+### npm
+
+```
+npm install -g clever-tools
+```
+
+### pnpm
+
+```
+pnpm add -g clever-tools
+```
+
+### Bun
+
+```
+bun add -g clever-tools
+```
+
+### Yarn
+
+```
+yarn global add clever-tools
+```
+
+## GNU/Linux
+
+### Arch Linux (AUR)
+
+From the directory where you cloned the AUR package:
+
+```
+git -C clever-tools pull
+makepkg -si -C clever-tools
+```
+
+### CentOS/Fedora (.rpm)
+
+```
+yum update clever-tools
+```
+
+### Debian/Ubuntu (.deb)
+
+```
+apt update
+apt install --only-upgrade clever-tools
+```
+
+### Exherbo
+
+```
+cave sync
+cave resolve clever-tools-bin -zx
+```
+
+### Other distributions (.tar.gz)
+
+Download the latest archive again and replace the binary in your `PATH`:
+
+```
+curl -O https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_linux.tar.gz
+tar xvzf clever-tools-latest_linux.tar.gz
+cp clever-tools-latest_linux/clever ~/.local/bin/
+```
+
+## macOS
+
+### Homebrew
+
+```
+brew upgrade CleverCloud/homebrew-tap/clever-tools
+```
+
+### Binary (.tar.gz)
+
+Download the latest archive again and replace the binary in your `PATH`:
+
+```
+curl -O https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_macos.tar.gz
+tar xvzf clever-tools-latest_macos.tar.gz
+cp clever-tools-latest_macos/clever ~/.local/bin/
+```
+
+## Windows
+
+### WinGet
+
+```
+winget upgrade CleverTools
+```
+
+### Binary (.zip)
+
+Download the latest archive again and replace the binary in your `PATH`:
+
+```PowerShell
+Invoke-WebRequest https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_win.zip -OutFile clever-tools-latest_win.zip
+Expand-Archive .\clever-tools-latest_win.zip -DestinationPath .
+```
+
+## Docker
+
+Pull the image again to get the latest tag:
+
+```
+docker pull clevercloud/clever-tools
+```
+
+## Nix package manager
+
+Update your channel or flake input, then upgrade the package as usual for your setup. See [these instructions](https://search.nixos.org/packages?channel=unstable&show=clever-tools&from=0&size=50&sort=relevance&type=packages&query=clever-tools).

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,14 +35,6 @@ export default defineConfig({
         }
       },
     },
-    // When building the CJS for the binary builds, we don't want to include "update-notifier"
-    {
-      transform(code, id) {
-        if (id.endsWith('/bin/clever.js')) {
-          return code.replace("import '../src/initial-update-notifier.js';", '');
-        }
-      },
-    },
     commonjs(),
     nodeResolve({
       preferBuiltins: true,

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -22,9 +22,37 @@ To control an application with Clever Tools, it must be linked to a local direct
 
 ## How to install Clever Tools
 
-Clever Cloud CLI is based on Node.js. We thought it to be easily available on any platform. Thus, you can download Clever Tools as [a npm package](https://www.npmjs.com/package/clever-tools), but also through package managers or as a binary on many systems:
+Clever Tools is available as a npm package, through package managers, or as a standalone binary on many systems:
 
 
+
+### Node.js
+
+Clever Tools is available as [a npm package](https://www.npmjs.com/package/clever-tools):
+
+#### npm
+
+```
+npm install -g clever-tools
+```
+
+#### pnpm
+
+```
+pnpm add -g clever-tools
+```
+
+#### Bun
+
+```
+bun add -g clever-tools
+```
+
+#### Yarn
+
+```
+yarn global add clever-tools
+```
 
 ### GNU/Linux
 

--- a/src/initial-update-notifier.js
+++ b/src/initial-update-notifier.js
@@ -5,14 +5,11 @@ import { hasParam } from './lib/has-param.js';
 // These need to be set before Logger and other stuffs
 const updateNotifierExplicitFalse = hasParam('--no-update-notifier') || hasParam('--update-notifier', 'false');
 if (!updateNotifierExplicitFalse) {
+  const docsUrl = 'https://github.com/CleverCloud/clever-tools/blob/master/docs/update.md';
   updateNotifierModule({
     pkg,
-    tagsUrl: 'https://api.github.com/repos/CleverCloud/clever-tools/tags',
   }).notify({
     isGlobal: true,
-    getDetails() {
-      const docsUrl = 'https://github.com/CleverCloud/clever-tools/tree/master/docs#how-to-use-clever-tools';
-      return `\nPlease follow this link to update your clever-tools:\n${docsUrl}`;
-    },
+    message: `Update available {currentVersion} -> {latestVersion}\nPlease follow this link to update your clever-tools:\n${docsUrl}`,
   });
 }


### PR DESCRIPTION
## Context

- The `update-notifier` message relied on an API that was removed in version 7.3.1, silently falling back to the default "npm i -g" message.
- The Rollup config strips `initial-update-notifier.js` from the bundle used for pkg binary builds, so the notifier is only available to users who install via Node.js/npm.

## Problem

- Users who install via Homebrew, WinGet, apt/yum, AUR, Exherbo or the standalone binary are never notified an update is available, even though nudging them to update is valuable.
- Users who install via pnpm, Bun or Yarn get a "npm i -g" message that doesn't match how they actually installed.

## Proposal

- Use the correct API of the latest `update-notifier` version to display a message pointing to a doc page.
- Introduce a dedicated update guide, since the install page didn't make sense once the tool is already installed.
- Promote Node.js to a top-level section in `docs/setup-systems.md`, broken into npm/pnpm/Bun/Yarn items, same treatment in the update guide.
- Remove the Rollup transform excluding the notifier from binary builds, so every install channel gets the notice.

Builds on top of #1121.

## How to test

1. Bump the local `version` in `package.json` below the latest published version (or just run against an older clone)
2. Remove the notifier cache: `rm ~/.config/configstore/update-notifier-clever-tools.json`
3. Force the check to run now: edit `~/.config/configstore/update-notifier-clever-tools.json` and set `lastUpdateCheck` to `0`, then run any `clever` command (triggers the async check)
4. Run a second `clever` command a few seconds later to display the message
5. Confirm the message and doc link, then repeat with the Rollup-built binary to confirm it also notifies