### PR TITLE
feat(k8s): autoscale nodes with Karpenter node auto-provisioning

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -41,5 +41,7 @@ jobs:
         run: npm run format:check
       - name: 'Check for type issues with TypeScript and JSDoc'
         run: npm run typecheck
+      - name: 'Run unit tests'
+        run: npm test
       - name: 'Check generated docs are up to date'
         run: npm run docs:check

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -65,6 +65,35 @@ Classic response is a table:
 └─────────┴─────────────────────────────────────────┘
 ```
 
+## Enable node auto-provisioning
+
+Instead of sizing node groups yourself, you can let the cluster autoscale its nodes: node auto-provisioning creates and deletes nodes to fit the pods waiting to be scheduled. It's powered by [Karpenter](https://karpenter.sh), installed in the cluster by Clever Cloud. Enable it at creation time, or later on an `ACTIVE` cluster:
+
+```
+clever k8s create myKubeCluster --node-autoprovisioning
+clever k8s update myKubeCluster --node-autoprovisioning
+```
+
+Karpenter provisions nothing until you create your own `NodePool` and `CleverNodeClass` resources in the cluster.
+
+A cluster is reported with the features it has installed, not with the ones it was asked for. Right after an activation, `clever k8s get` shows `disabled (cluster reconciling)` while the cluster is `RECONCILING`, then `enabled` once Karpenter is in place. A deactivation reads the same way in reverse: `enabled (cluster reconciling)`, then `disabled`.
+
+To disable it, which really uninstalls Karpenter:
+
+```
+clever k8s update myKubeCluster --disable-node-autoprovisioning
+```
+
+Delete your `NodePool`, `NodeOverlay` and `CleverNodeClass` resources and let Karpenter drain the nodes first, otherwise the command is refused.
+
+Node auto-provisioning can't run alongside the node group autoscaler. If it is enabled on an existing cluster, disable it before enabling node auto-provisioning:
+
+```
+clever k8s update myKubeCluster --disable-autoscaling
+```
+
+The existing `--autoscaling`, `--disable-autoscaling`, `--min` and `--max` options remain available for managing the node group autoscaler. `--autoscaling` and `--node-autoprovisioning` cannot be enabled together.
+
 ## Add persistent storage to a Cluster
 
 You can add persistent storage to an `ACTIVE` cluster with:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ export default [
   {
     name: 'global config',
     ...cleverCloud.configs.node,
-    files: ['bin/*.js', 'src/**/*.js', 'scripts/**/*.js'],
+    files: ['bin/*.js', 'src/**/*.js', 'scripts/**/*.js', 'test/**/*.js'],
     languageOptions: {
       ecmaVersion: 2025,
       sourceType: 'module',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "install-local:cliparse": "(cd ../cliparse-node && npm pack) && mv ../cliparse-node/cliparse-*.tgz . && npm i -f ./cliparse-*.tgz",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check",
+    "test": "node --test test/*.test.js",
+    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run test && npm run docs:check",
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {

--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -1769,6 +1769,7 @@ cluster-name                                     Kubernetes cluster name
     --cluster-version <cluster-version>          Kubernetes version to deploy (e.g.: 1.36)
     --description <description>                  Free-form cluster description
     --flavor <flavor>                            Control plane flavor
+    --node-autoprovisioning                      Enable node autoscaling via node auto-provisioning, powered by Karpenter
     --nodegroup <flavor:count>                   Initial node group (format: <flavor>:<count>, e.g.: XS:3)
 -o, --org, --owner <org-id|org-name>             Organisation to target by its ID (or name, if unambiguous)
     --persistent-storage                         Enable persistent storage (Ceph CSI)
@@ -2035,7 +2036,9 @@ cluster-id|cluster-name                 Kubernetes cluster ID or name
     --autoscaling                       Enable the cluster autoscaler
     --description <description>         Free-form cluster description
     --disable-autoscaling               Disable the cluster autoscaler
+    --disable-node-autoprovisioning     Disable node autoscaling via node auto-provisioning, uninstalls Karpenter
     --name <name>                       Rename the cluster
+    --node-autoprovisioning             Enable node autoscaling via node auto-provisioning, powered by Karpenter
 -o, --org, --owner <org-id|org-name>    Organisation to target by its ID (or name, if unambiguous)
     --tag <tag[,tag...]>                Replace tags (comma-separated, e.g.: env:prod,team:platform)
 ```

--- a/src/commands/k8s/k8s.create.command.js
+++ b/src/commands/k8s/k8s.create.command.js
@@ -3,7 +3,7 @@ import { typewriterLogo } from '../../lib/ascii.js';
 import { defineArgument } from '../../lib/define-argument.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { defineOption } from '../../lib/define-option.js';
-import { getK8sCluster, k8sCreate, k8sGetProduct } from '../../lib/k8s.js';
+import { NODE_AUTOPROVISIONING_HINT, getK8sCluster, k8sCreate, k8sGetProduct } from '../../lib/k8s.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import { flavorCount, tags } from '../../parsers.js';
@@ -41,6 +41,11 @@ export const k8sCreateCommand = defineCommand({
       name: 'autoscaling',
       schema: z.boolean().default(false),
       description: 'Enable the cluster autoscaler',
+    }),
+    nodeAutoprovisioning: defineOption({
+      name: 'node-autoprovisioning',
+      schema: z.boolean().default(false),
+      description: 'Enable node autoscaling via node auto-provisioning, powered by Karpenter',
     }),
     persistentStorage: defineOption({
       name: 'persistent-storage',
@@ -112,6 +117,7 @@ export const k8sCreateCommand = defineCommand({
         description: options.description,
         tags: options.tag,
         autoscaling: options.autoscaling,
+        nodeAutoprovisioning: options.nodeAutoprovisioning,
         persistentStorage: options.persistentStorage,
         topology: options.topology,
         flavor: options.flavor,
@@ -154,6 +160,9 @@ export const k8sCreateCommand = defineCommand({
       const orgMessageComplement = orgIdOrName ? `--org "${orgIdOrName.orga_id || orgIdOrName.orga_name}"` : '';
 
       Logger.println('');
+      if (options.nodeAutoprovisioning) {
+        Logger.printInfo(NODE_AUTOPROVISIONING_HINT);
+      }
       Logger.println(
         `You can get its information with ${styleText('blue', `clever k8s get ${cluster.id} ${orgMessageComplement}`)}`,
       );

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -76,6 +76,7 @@ clever k8s create <cluster-name> [options]
 |`--cluster-version` `<cluster-version>`|Kubernetes version to deploy (e.g.: 1.36)|
 |`--description` `<description>`|Free-form cluster description|
 |`--flavor` `<flavor>`|Control plane flavor|
+|`--node-autoprovisioning`|Enable node autoscaling via node auto-provisioning, powered by Karpenter|
 |`--nodegroup` `<flavor:count>`|Initial node group (format: <flavor>:<count>, e.g.: XS:3)|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 |`--persistent-storage`|Enable persistent storage (Ceph CSI)|
@@ -326,7 +327,9 @@ clever k8s update <cluster-id|cluster-name> [options]
 |`--autoscaling`|Enable the cluster autoscaler|
 |`--description` `<description>`|Free-form cluster description|
 |`--disable-autoscaling`|Disable the cluster autoscaler|
+|`--disable-node-autoprovisioning`|Disable node autoscaling via node auto-provisioning, uninstalls Karpenter|
 |`--name` `<name>`|Rename the cluster|
+|`--node-autoprovisioning`|Enable node autoscaling via node auto-provisioning, powered by Karpenter|
 |`-o`, `--org`, `--owner` `<org-id\|org-name>`|Organisation to target by its ID (or name, if unambiguous)|
 |`--tag` `<tag[,tag...]>`|Replace tags (comma-separated, e.g.: env:prod,team:platform)|
 

--- a/src/commands/k8s/k8s.get.command.js
+++ b/src/commands/k8s/k8s.get.command.js
@@ -1,5 +1,5 @@
 import { defineCommand } from '../../lib/define-command.js';
-import { getK8sCluster } from '../../lib/k8s.js';
+import { formatFeatureState, getK8sCluster } from '../../lib/k8s.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import { humanJsonOutputFormatOption, orgaIdOrNameOption } from '../global.options.js';
@@ -32,6 +32,7 @@ export const k8sGetCommand = defineCommand({
           Version: k8sInfo.version,
           Topology: formatTopology(topo),
           Autoscaling: k8sInfo.features?.autoscalingEnabled ? 'enabled' : 'disabled',
+          'Node auto-provisioning': formatFeatureState(k8sInfo.features?.nodeAutoprovisioning, k8sInfo.status),
           'Persistent storage': k8sInfo.features?.csi != null ? 'enabled' : 'disabled',
         };
         if (k8sInfo.tags?.length) overview.Tags = k8sInfo.tags.join(', ');

--- a/src/commands/k8s/k8s.update.command.js
+++ b/src/commands/k8s/k8s.update.command.js
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import { defineCommand } from '../../lib/define-command.js';
 import { defineOption } from '../../lib/define-option.js';
-import { k8sUpdate } from '../../lib/k8s.js';
+import {
+  NODE_AUTOPROVISIONING_HINT,
+  buildClusterFeaturesPatch,
+  k8sUpdate,
+  processFeaturesError,
+} from '../../lib/k8s.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
 import { tags } from '../../parsers.js';
@@ -40,33 +45,48 @@ export const k8sUpdateCommand = defineCommand({
       schema: z.boolean().default(false),
       description: 'Disable the cluster autoscaler',
     }),
+    nodeAutoprovisioning: defineOption({
+      name: 'node-autoprovisioning',
+      schema: z.boolean().default(false),
+      description: 'Enable node autoscaling via node auto-provisioning, powered by Karpenter',
+    }),
+    disableNodeAutoprovisioning: defineOption({
+      name: 'disable-node-autoprovisioning',
+      schema: z.boolean().default(false),
+      description: 'Disable node autoscaling via node auto-provisioning, uninstalls Karpenter',
+    }),
     org: orgaIdOrNameOption,
   },
   args: [k8sIdOrNameArg],
   async handler(options, clusterIdOrName) {
     const { org: orgIdOrName } = options;
 
-    if (options.autoscaling && options.disableAutoscaling) {
-      throw new Error('--autoscaling and --disable-autoscaling are mutually exclusive');
-    }
-
     const updates = {};
     if (options.name != null) updates.name = options.name;
     if (options.description != null) updates.description = options.description;
     if (options.tag != null) updates.tags = options.tag;
 
-    const features = {};
-    if (options.autoscaling) features.autoscalingEnabled = true;
-    if (options.disableAutoscaling) features.autoscalingEnabled = false;
+    const features = buildClusterFeaturesPatch(options);
     if (Object.keys(features).length > 0) updates.features = features;
 
     if (Object.keys(updates).length === 0) {
       throw new Error(
-        'No update specified. Provide at least one of --name, --description, --tag, --autoscaling, --disable-autoscaling',
+        'No update specified. Provide at least one of --name, --description, --tag, --autoscaling, --disable-autoscaling, --node-autoprovisioning, --disable-node-autoprovisioning',
       );
     }
 
-    const cluster = await k8sUpdate(orgIdOrName, clusterIdOrName, updates);
+    const cluster = await k8sUpdate(orgIdOrName, clusterIdOrName, updates).catch((error) => {
+      // Preserve API errors for metadata and existing autoscaler updates.
+      if (features.nodeAutoprovisioning == null) throw error;
+      throw processFeaturesError(error, clusterIdOrName, { disabling: options.disableNodeAutoprovisioning });
+    });
     Logger.printSuccess(`Cluster ${styleText('green', cluster.name)} updated`);
+
+    if (options.nodeAutoprovisioning) {
+      Logger.printInfo(NODE_AUTOPROVISIONING_HINT);
+    }
+    if (options.disableNodeAutoprovisioning) {
+      Logger.printInfo('Karpenter is being uninstalled from the cluster');
+    }
   },
 });

--- a/src/lib/k8s.js
+++ b/src/lib/k8s.js
@@ -49,6 +49,7 @@ export async function isK8sClusterActive(orgIdOrName, clusterIdOrName) {
  * @param {string} [options.description] A free-form description
  * @param {string[]} [options.tags] Semantic tags ("tag" or "key:value")
  * @param {boolean} [options.autoscaling] Enable the cluster autoscaler
+ * @param {boolean} [options.nodeAutoprovisioning] Enable node auto-provisioning (Karpenter)
  * @param {boolean} [options.persistentStorage] Enable the Ceph CSI persistent storage
  * @param {string} [options.topology] Topology kind (ALL_IN_ONE, DEDICATED_COMPUTE, DISTRIBUTED)
  * @param {string} [options.flavor] Control plane flavor
@@ -57,6 +58,7 @@ export async function isK8sClusterActive(orgIdOrName, clusterIdOrName) {
  * @returns {Promise<object>}
  */
 export async function k8sCreate(name, orgIdOrName, options = {}) {
+  const features = buildClusterFeaturesPatch(options);
   const ownerId = await getOwnerIdFromOrgIdOrName(orgIdOrName);
   const product = await k8sGetProduct();
 
@@ -71,8 +73,6 @@ export async function k8sCreate(name, orgIdOrName, options = {}) {
   if (options.description != null) body.description = options.description;
   if (options.tags?.length) body.tags = options.tags;
 
-  const features = {};
-  if (options.autoscaling) features.autoscalingEnabled = true;
   if (options.persistentStorage) features.csi = true;
   if (Object.keys(features).length > 0) body.features = features;
 
@@ -208,6 +208,107 @@ export async function k8sUpdate(orgIdOrName, clusterIdOrName, updates) {
   const clusterId = await getClusterIdFromAddonIdOrName(clusterIdOrName, ownerId);
 
   return updateK8sCluster({ ownerId, clusterId }, updates).then(sendToApi);
+}
+
+const K8S_DOC_URL = 'https://www.clever.cloud/doc/kubernetes/';
+
+/**
+ * What to tell a user who just enabled node auto-provisioning: the feature installs
+ * Karpenter, and Karpenter provisions nothing until the cluster carries their own
+ * NodePool and CleverNodeClass resources.
+ */
+export const NODE_AUTOPROVISIONING_HINT = `Karpenter only provisions nodes once you create your own NodePool and CleverNodeClass resources, see ${styleText('blue', K8S_DOC_URL)}`;
+
+/**
+ * Build the features part of a cluster update
+ *
+ * The API merges features as a RFC 7386 merge patch: an absent field is kept as is and
+ * `null` erases it. Only the features the user asked for are mentioned, so an update
+ * never touches (nor erases) the ones it doesn't name.
+ * @param {object} options
+ * @param {boolean} [options.autoscaling] Enable the cluster autoscaler
+ * @param {boolean} [options.disableAutoscaling] Disable the cluster autoscaler
+ * @param {boolean} [options.nodeAutoprovisioning] Enable node auto-provisioning
+ * @param {boolean} [options.disableNodeAutoprovisioning] Disable node auto-provisioning
+ * @returns {object} The features merge patch, empty when no feature is asked for
+ */
+export function buildClusterFeaturesPatch({
+  autoscaling,
+  disableAutoscaling,
+  nodeAutoprovisioning,
+  disableNodeAutoprovisioning,
+}) {
+  if (autoscaling && disableAutoscaling) {
+    throw new Error('--autoscaling and --disable-autoscaling are mutually exclusive');
+  }
+  if (nodeAutoprovisioning && disableNodeAutoprovisioning) {
+    throw new Error('--node-autoprovisioning and --disable-node-autoprovisioning are mutually exclusive');
+  }
+  if (autoscaling && nodeAutoprovisioning) {
+    throw new Error('--autoscaling and --node-autoprovisioning are mutually exclusive');
+  }
+
+  const features = {};
+  if (autoscaling) features.autoscalingEnabled = true;
+  if (disableAutoscaling) features.autoscalingEnabled = false;
+  if (nodeAutoprovisioning) features.nodeAutoprovisioning = true;
+  if (disableNodeAutoprovisioning) features.nodeAutoprovisioning = false;
+
+  return features;
+}
+
+/**
+ * Format the state of a cluster feature
+ *
+ * The API reports features by installation evidence, not by requested value, and it doesn't
+ * say which way a reconciling cluster is heading: an installation that hasn't landed yet and
+ * a removal that has already happened look the same. A `RECONCILING` cluster is therefore
+ * shown with the state it currently has, flagged as still moving, rather than guessed.
+ * @param {boolean} [installed] The feature value reported by the API
+ * @param {string} [clusterStatus] The cluster status
+ * @returns {string} The state to display
+ */
+export function formatFeatureState(installed, clusterStatus) {
+  const state = installed === true ? 'enabled' : 'disabled';
+
+  return clusterStatus === 'RECONCILING' ? `${state} (cluster reconciling)` : state;
+}
+
+/**
+ * Turn a rejected cluster features update into an actionable error
+ * @param {Error & {response?: {status?: number}}} error The error raised by the API
+ * @param {string|object} clusterIdOrName The cluster ID or name, as the user typed it
+ * @param {object} context
+ * @param {boolean} [context.disabling] Whether the update was disabling node auto-provisioning
+ * @returns {Error} The error to throw back
+ */
+export function processFeaturesError(error, clusterIdOrName, { disabling }) {
+  const name = getClusterDisplayName(clusterIdOrName);
+
+  switch (error.response?.status) {
+    case 400:
+      return new Error(
+        `Node auto-provisioning can't run alongside the node group autoscaler of ${styleText('red', name)}, both would provision nodes for the same workloads. Disable the autoscaler first with ${styleText('blue', `clever k8s update ${name} --disable-autoscaling`)}`,
+        { cause: error },
+      );
+    case 409:
+      return disabling
+        ? new Error(
+            `Cluster ${styleText('red', name)} still carries Karpenter resources. Delete its NodePools, NodeOverlays and CleverNodeClasses, let Karpenter drain the nodes, then try again`,
+            { cause: error },
+          )
+        : new Error(
+            `Cluster ${styleText('red', name)} already runs a Karpenter Clever Cloud didn't install, remove it before enabling node auto-provisioning`,
+            { cause: error },
+          );
+    case 412:
+      return new Error(
+        `Cluster features are locked while ${styleText('red', name)} is deploying or reconciling, check its status with ${styleText('blue', `clever k8s get ${name}`)} and try again`,
+        { cause: error },
+      );
+    default:
+      return error;
+  }
 }
 
 /**

--- a/test/k8s.test.js
+++ b/test/k8s.test.js
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { k8sCreateCommand } from '../src/commands/k8s/k8s.create.command.js';
+import { k8sNodeGroupCreateCommand } from '../src/commands/k8s/k8s.nodegroups.create.command.js';
+import { k8sNodeGroupUpdateCommand } from '../src/commands/k8s/k8s.nodegroups.update.command.js';
+import { k8sUpdateCommand } from '../src/commands/k8s/k8s.update.command.js';
+import { buildClusterFeaturesPatch, formatFeatureState, k8sCreate, processFeaturesError } from '../src/lib/k8s.js';
+
+const clusterIdOrName = { addon_name: 'myKubeCluster' };
+
+function apiError(status, message = 'Something went wrong') {
+  return Object.assign(new Error(message), { response: { status } });
+}
+
+describe('buildClusterFeaturesPatch()', () => {
+  it('updates each feature independently without touching the other autoscaler', () => {
+    assert.deepEqual(buildClusterFeaturesPatch({ autoscaling: true }), { autoscalingEnabled: true });
+    assert.deepEqual(buildClusterFeaturesPatch({ disableAutoscaling: true }), { autoscalingEnabled: false });
+    assert.deepEqual(buildClusterFeaturesPatch({ nodeAutoprovisioning: true }), { nodeAutoprovisioning: true });
+    assert.deepEqual(buildClusterFeaturesPatch({ disableNodeAutoprovisioning: true }), {
+      nodeAutoprovisioning: false,
+    });
+  });
+
+  it('mentions nothing when the update only carries metadata', () => {
+    assert.deepEqual(buildClusterFeaturesPatch({ name: 'myKubeCluster' }), {});
+  });
+
+  it('does not interpret default false options as requests to disable features', () => {
+    assert.deepEqual(
+      buildClusterFeaturesPatch({
+        autoscaling: false,
+        disableAutoscaling: false,
+        nodeAutoprovisioning: false,
+        disableNodeAutoprovisioning: false,
+      }),
+      {},
+    );
+  });
+
+  it('allows switching between autoscalers with an explicit disable', () => {
+    assert.deepEqual(buildClusterFeaturesPatch({ disableAutoscaling: true, nodeAutoprovisioning: true }), {
+      autoscalingEnabled: false,
+      nodeAutoprovisioning: true,
+    });
+    assert.deepEqual(buildClusterFeaturesPatch({ autoscaling: true, disableNodeAutoprovisioning: true }), {
+      autoscalingEnabled: true,
+      nodeAutoprovisioning: false,
+    });
+  });
+
+  it('rejects contradictory feature toggles and simultaneous autoscalers', () => {
+    const incompatibleOptions = [
+      { autoscaling: true, disableAutoscaling: true },
+      { nodeAutoprovisioning: true, disableNodeAutoprovisioning: true },
+      { autoscaling: true, nodeAutoprovisioning: true },
+    ];
+
+    incompatibleOptions.forEach((options) => {
+      assert.throws(() => buildClusterFeaturesPatch(options), /mutually exclusive/);
+    });
+  });
+});
+
+describe('k8sCreate()', () => {
+  it('rejects simultaneous autoscalers before resolving the owner or calling the API', async () => {
+    await assert.rejects(
+      k8sCreate('myKubeCluster', undefined, { autoscaling: true, nodeAutoprovisioning: true }),
+      /--autoscaling and --node-autoprovisioning are mutually exclusive/,
+    );
+  });
+});
+
+describe('formatFeatureState()', () => {
+  it('reports an installed feature as enabled', () => {
+    assert.equal(formatFeatureState(true, 'ACTIVE'), 'enabled');
+  });
+
+  it('reports a reconciling cluster with the state it currently has, still moving', () => {
+    assert.equal(formatFeatureState(false, 'RECONCILING'), 'disabled (cluster reconciling)');
+  });
+
+  it('never claims a cluster is enabling while it is really removing the feature', () => {
+    assert.equal(formatFeatureState(true, 'RECONCILING'), 'enabled (cluster reconciling)');
+  });
+
+  it('reports a settled cluster without the feature as disabled', () => {
+    assert.equal(formatFeatureState(false, 'ACTIVE'), 'disabled');
+  });
+
+  it('never reads a reported value other than true as enabled', () => {
+    assert.equal(formatFeatureState(undefined, 'ACTIVE'), 'disabled');
+    assert.equal(formatFeatureState(null, 'ACTIVE'), 'disabled');
+  });
+});
+
+describe('processFeaturesError()', () => {
+  it('points to the cluster status when the features are locked', () => {
+    const error = processFeaturesError(apiError(412), clusterIdOrName, {});
+
+    assert.match(error.message, /features are locked/);
+    assert.match(error.message, /clever k8s get/);
+  });
+
+  it('names the foreign Karpenter when enabling is refused', () => {
+    const error = processFeaturesError(apiError(409), clusterIdOrName, { disabling: false });
+
+    assert.match(error.message, /already runs a Karpenter/);
+  });
+
+  it('asks to delete the leftover resources when disabling is refused', () => {
+    const error = processFeaturesError(apiError(409), clusterIdOrName, { disabling: true });
+
+    assert.match(error.message, /still carries Karpenter resources/);
+    assert.match(error.message, /NodePools, NodeOverlays and CleverNodeClasses/);
+  });
+
+  it('explains the exclusion with the node group autoscaler', () => {
+    const error = processFeaturesError(apiError(400), clusterIdOrName, {});
+
+    assert.match(error.message, /can't run alongside the node group autoscaler/);
+    assert.match(error.message, /clever k8s update myKubeCluster --disable-autoscaling/);
+  });
+
+  it('leaves any other failure untouched', () => {
+    const error = apiError(500, 'Internal server error');
+
+    assert.equal(processFeaturesError(error, clusterIdOrName, {}), error);
+  });
+
+  it('keeps the API error as the cause, the only place its message survives', () => {
+    const statuses = [400, 409, 412];
+
+    statuses.forEach((status) => {
+      const apiFailure = apiError(status, 'Cluster name already in use');
+      const error = processFeaturesError(apiFailure, clusterIdOrName, {});
+
+      assert.equal(error.cause, apiFailure, `status ${status} dropped the cause`);
+    });
+  });
+});
+
+describe('k8s command options', () => {
+  it('exposes the node auto-provisioning toggles', () => {
+    assert.equal(k8sCreateCommand.options.nodeAutoprovisioning.name, 'node-autoprovisioning');
+    assert.equal(k8sUpdateCommand.options.nodeAutoprovisioning.name, 'node-autoprovisioning');
+    assert.equal(k8sUpdateCommand.options.disableNodeAutoprovisioning.name, 'disable-node-autoprovisioning');
+  });
+
+  it('keeps "autoscaling" in the help text, that is the word users look for', () => {
+    assert.match(k8sCreateCommand.options.nodeAutoprovisioning.description, /autoscaling/);
+    assert.match(k8sUpdateCommand.options.nodeAutoprovisioning.description, /autoscaling/);
+    assert.match(k8sUpdateCommand.options.disableNodeAutoprovisioning.description, /autoscaling/);
+  });
+
+  it('preserves the existing cluster and node group autoscaling options', () => {
+    assert.equal(k8sCreateCommand.options.autoscaling.name, 'autoscaling');
+    assert.equal(k8sUpdateCommand.options.autoscaling.name, 'autoscaling');
+    assert.equal(k8sUpdateCommand.options.disableAutoscaling.name, 'disable-autoscaling');
+    assert.equal(k8sNodeGroupCreateCommand.options.autoscaling.name, 'autoscaling');
+    assert.equal(k8sNodeGroupUpdateCommand.options.autoscaling.name, 'autoscaling');
+    assert.equal(k8sNodeGroupUpdateCommand.options.disableAutoscaling.name, 'disable-autoscaling');
+    assert.equal(k8sNodeGroupCreateCommand.options.min.name, 'min');
+    assert.equal(k8sNodeGroupCreateCommand.options.max.name, 'max');
+    assert.equal(k8sNodeGroupUpdateCommand.options.min.name, 'min');
+    assert.equal(k8sNodeGroupUpdateCommand.options.max.name, 'max');
+  });
+});


### PR DESCRIPTION
This PR adds node auto-provisioning with Karpenter to `k8s` commands. It:

- Adds `--node-autoprovisioning` to `create` and `update`
- Adds `--disable-node-autoprovisioning` to `update`
- Displays its status in `get`
 - Rejects `--autoscaling` combined with `--node-autoprovisioning` before calling the API


The previous autoscaler only considers CPU and RAM usage on existing nodes. Node auto-provisioning provisions nodes for pods that cannot be scheduled on existing capacity, based on their resource requests and scheduling constraints. The node-autoprovisioning name makes this behaviour explicit.