### PR TITLE
fix(k8s): display disabled persistent storage correctly

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -43,3 +43,5 @@ jobs:
         run: npm run typecheck
       - name: 'Check generated docs are up to date'
         run: npm run docs:check
+      - name: 'Run tests'
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "install-local:cliparse": "(cd ../cliparse-node && npm pack) && mv ../cliparse-node/cliparse-*.tgz . && npm i -f ./cliparse-*.tgz",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check",
+    "test": "node --experimental-test-module-mocks --test",
+    "validate": "npm run lint && npm run format:check && npm run typecheck && npm run docs:check && npm test",
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {

--- a/src/commands/k8s/k8s.get.command.js
+++ b/src/commands/k8s/k8s.get.command.js
@@ -32,7 +32,7 @@ export const k8sGetCommand = defineCommand({
           Version: k8sInfo.version,
           Topology: formatTopology(topo),
           Autoscaling: k8sInfo.features?.autoscalingEnabled ? 'enabled' : 'disabled',
-          'Persistent storage': k8sInfo.features?.csi != null ? 'enabled' : 'disabled',
+          'Persistent storage': k8sInfo.features?.csi ? 'enabled' : 'disabled',
         };
         if (k8sInfo.tags?.length) overview.Tags = k8sInfo.tags.join(', ');
         if (k8sInfo.description) overview.Description = k8sInfo.description;

--- a/src/commands/k8s/k8s.get.command.test.js
+++ b/src/commands/k8s/k8s.get.command.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+import { stripVTControlCharacters } from 'node:util';
+
+const getK8sCluster = mock.fn();
+mock.module('../../lib/k8s.js', { namedExports: { getK8sCluster } });
+const { k8sGetCommand } = await import('./k8s.get.command.js');
+
+const cluster = {
+  id: 'kubernetes-test',
+  name: 'clever-tools-csi-bug',
+  status: 'ACTIVE',
+  version: '1.35',
+  topologyConfig: { topology: 'ALL_IN_ONE', flavor: 'S', replicationFactor: 1 },
+  features: { autoscalingEnabled: true, csi: false },
+  tags: ['test', 'csi'],
+  description: 'Persistent storage regression test',
+  storageUsageBytes: 1024 ** 3,
+};
+
+async function captureOutput(t, k8sInfo, options = { format: 'human' }) {
+  getK8sCluster.mock.mockImplementation(async () => k8sInfo);
+  let output = '';
+  const write = t.mock.method(process.stdout, 'write', (chunk) => {
+    output += chunk;
+    return true;
+  });
+
+  try {
+    await k8sGetCommand.handler(options, cluster.id);
+  } finally {
+    write.mock.restore();
+  }
+  return stripVTControlCharacters(output);
+}
+
+const cases = [
+  { name: 'CSI is false', properties: { features: { csi: false } }, expected: 'disabled' },
+  { name: 'CSI is true', properties: { features: { csi: true } }, expected: 'enabled' },
+  { name: 'CSI is absent', properties: { features: {} }, expected: 'disabled' },
+  { name: 'CSI is null', properties: { features: { csi: null } }, expected: 'disabled' },
+  { name: 'features are absent', properties: {}, expected: 'disabled' },
+  { name: 'features are null', properties: { features: null }, expected: 'disabled' },
+];
+
+for (const { name, properties, expected } of cases) {
+  test(`human output shows persistent storage ${expected} when ${name}`, async (t) => {
+    const output = await captureOutput(t, { id: cluster.id, ...properties });
+    assert.match(output, new RegExp(`Persistent storage\\s+│\\s+'${expected}'`));
+  });
+}
+
+test('default output shows disabled persistent storage and preserves other cluster information', async (t) => {
+  const output = await captureOutput(t, cluster, { org: { orga_id: 'orga-test' } });
+
+  for (const [label, value] of Object.entries({
+    Name: cluster.name,
+    ID: cluster.id,
+    Status: cluster.status,
+    Version: cluster.version,
+    Topology: 'ALL_IN_ONE (S, rf=1)',
+    Autoscaling: 'enabled',
+    'Persistent storage': 'disabled',
+    Tags: 'test, csi',
+    Description: cluster.description,
+    Storage: '1 GB',
+  })) {
+    const row = output.split('\n').find((line) => line.includes(` ${label} `));
+    assert.ok(row?.includes(`'${value}'`), `Expected ${label} to display ${value}`);
+  }
+  assert.ok(output.includes(`clever k8s get-kubeconfig ${cluster.id} --org "orga-test"`));
+  assert.deepEqual(getK8sCluster.mock.calls.at(-1).arguments, [{ orga_id: 'orga-test' }, cluster.id]);
+});
+
+test('JSON output preserves the complete API response including CSI false', async (t) => {
+  const output = await captureOutput(t, cluster, { format: 'json' });
+  assert.equal(output, `${JSON.stringify(cluster, null, 2)}\n`);
+  assert.deepEqual(JSON.parse(output), cluster);
+});


### PR DESCRIPTION
This PR fixes persistent storage status in `k8s get`. It:

- Displays `disabled` when CSI is false, null or absent
- Keeps `enabled` when CSI is true
- Adds command output regression tests to validation and CI

The previous check treated any non-null CSI value as enabled, including `false`. The command now displays the persistent storage state instead of checking whether the field is present. The JSON output and other cluster information remain unchanged.
