### PR TITLE
feat: enable system git backend by default

### DIFF
--- a/bin/clever.js
+++ b/bin/clever.js
@@ -14,7 +14,7 @@ import {
   verboseOption,
   versionOption,
 } from '../src/commands/global.options.js';
-import { EXPERIMENTAL_FEATURES, getFeatures } from '../src/config/features.js';
+import { EXPERIMENTAL_FEATURES, isFeatureEnabled } from '../src/config/features.js';
 import { cliparse } from '../src/lib/cliparse-patched.js';
 import { styleText } from '../src/lib/style-text.js';
 import { getDefault, getEnumValues, isBoolean, isRequired } from '../src/lib/zod-utils.js';
@@ -47,14 +47,10 @@ if (process.argv[2] === 'curl') {
 }
 
 async function run() {
-  // Get enabled experimental features
-  /** @type {Record<string, boolean>} */
-  const featuresFromConf = await getFeatures();
-
   // Build all commands from globalCommands
   const commands = [];
   for (const [name, entry] of /** @type {[string, CommandEntry][]} */ (Object.entries(globalCommands))) {
-    const command = buildCommand(name, entry, featuresFromConf);
+    const command = buildCommand(name, entry);
     if (command != null) {
       commands.push(command);
     }
@@ -96,10 +92,9 @@ async function run() {
  * Recursively build commands from the global commands structure
  * @param {string} name - Command name
  * @param {CommandEntry} commandEntry - Command entry (either a command object or [command, subcommands])
- * @param {Record<string, boolean>} featuresFromConf - Enabled features configuration
  * @returns {Object|null} cliparse command or null if filtered out
  */
-function buildCommand(name, commandEntry, featuresFromConf) {
+function buildCommand(name, commandEntry) {
   /** @type {CommandDefinition} */
   let commandDef;
   /** @type {Record<string, CommandEntry>} */
@@ -113,14 +108,14 @@ function buildCommand(name, commandEntry, featuresFromConf) {
   }
 
   // Check if this is an experimental feature that needs to be enabled
-  if (commandDef.featureFlag && !featuresFromConf[commandDef.featureFlag]) {
+  if (commandDef.featureFlag && !isFeatureEnabled(commandDef.featureFlag)) {
     return null;
   }
 
   // Build subcommands recursively
   const subcommands = [];
   for (const [subName, subEntry] of Object.entries(subcommandsMap)) {
-    const subcommand = buildCommand(subName, subEntry, featuresFromConf);
+    const subcommand = buildCommand(subName, subEntry);
     if (subcommand != null) {
       subcommands.push(subcommand);
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,9 +98,9 @@ clever <command>
 
 ### Git-based deployments
 
-`clever deploy` pushes over HTTPS and verifies certificates too. By default it relies on its JS git implementation (running on Node.js), so it trusts the OS certificate store and `NODE_EXTRA_CA_CERTS` exactly like API calls — nothing more to do.
+`clever deploy` pushes over HTTPS and verifies certificates too. By default it delegates to your system `git` binary, which **ignores** `NODE_EXTRA_CA_CERTS` and follows its own TLS configuration: the OS certificate store (recommended), or an explicit CA file set with `git config --global http.sslCAInfo /path/to/corporate-ca.pem` (equivalent to the `GIT_SSL_CAINFO` environment variable).
 
-If you switch to the system git backend (`clever features enable system-git`), `clever` delegates to your system `git` binary instead. That binary **ignores** `NODE_EXTRA_CA_CERTS` and follows its own TLS configuration: the OS certificate store (recommended), or an explicit CA file set with `git config --global http.sslCAInfo /path/to/corporate-ca.pem` (equivalent to the `GIT_SSL_CAINFO` environment variable).
+If you fall back to the previous JS git implementation (`clever features disable system-git`), `clever` runs on Node.js instead, so it trusts the OS certificate store and `NODE_EXTRA_CA_CERTS` exactly like API calls — nothing more to do.
 
 > [!TIP]
 > Installing your CA in the OS certificate store is the most reliable option: it covers both API calls and Git deployments, in every mode, for both binary and npm installs.
@@ -133,7 +133,7 @@ export no_proxy=localhost,127.0.0.1,.internal.example.com
 ```
 
 > [!NOTE]
-> Like the TLS variables above, proxy variables are read at startup: set them in your shell or inline before the command, not in a `.env` file. With the `system-git` feature enabled, `clever deploy` delegates to your system `git`, which follows its own proxy configuration (`git config --global http.proxy …` or the same `http_proxy`/`https_proxy` variables).
+> Like the TLS variables above, proxy variables are read at startup: set them in your shell or inline before the command, not in a `.env` file. By default, `clever deploy` delegates to your system `git`, which follows its own proxy configuration (`git config --global http.proxy …` or the same `http_proxy`/`https_proxy` variables).
 
 ## features
 

--- a/src/commands/deploy/deploy.docs.md
+++ b/src/commands/deploy/deploy.docs.md
@@ -23,21 +23,21 @@ clever deploy [options]
 
 ### 🧪 Experimental: System git backend
 
-Clever Tools uses a current JS implementation for git operations. This works without requiring git to be installed on your system, but has some limitations:
+Clever Tools uses the `git` command installed on your system for git operations (it must be in your `PATH` environment variable).
+
+If `git` is not available, or you experience an issue with this backend, you can fall back to the previous pure JS implementation. This works without requiring git to be installed on your system, but has some limitations:
 
 * **HTTP-only**: cannot use SSH-based git protocols
 * **Slow performance** on repositories with rewritten history (rebases, squashes)
 * **Connection timeouts** on large repositories or when pushing big files, due to HTTP-based transfers
-* **No git worktree support**: deploying from a linked git worktree (`git worktree add`) fails with `Could not find HEAD`. The system git backend deploys from worktrees just like from the main working tree
-
-If you experience any of these issues, you can enable the **system git backend** which uses the `git` command installed on your system (it must be in your `PATH` environment variable).
-
-```bash
-clever features enable system-git
-```
-
-To disable and return to the current JS implementation:
+* **No git worktree support**: deploying from a linked git worktree (`git worktree add`) fails with `Could not find HEAD`
 
 ```bash
 clever features disable system-git
+```
+
+To switch back to the system git backend:
+
+```bash
+clever features enable system-git
 ```

--- a/src/commands/features/features.list.command.js
+++ b/src/commands/features/features.list.command.js
@@ -1,4 +1,4 @@
-import { EXPERIMENTAL_FEATURES, getFeatures } from '../../config/features.js';
+import { getAllFeatures } from '../../config/features.js';
 import { formatTable } from '../../format-table.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { Logger } from '../../logger.js';
@@ -14,22 +14,15 @@ export const featuresListCommand = defineCommand({
   async handler(options) {
     const { format } = options;
 
-    const featuresConf = await getFeatures();
-    // Add status from configuration file and remove instructions
-    const features = Object.entries(EXPERIMENTAL_FEATURES).map(([id, feature]) => {
-      const enabled = featuresConf[id] === true;
-      return {
-        id,
-        status: feature.status,
-        description: feature.description,
-        enabled,
-      };
-    });
+    const features = getAllFeatures();
 
     // For each feature, print the object with the id, status, description and enabled
     switch (format) {
       case 'json': {
-        Logger.printJson(features);
+        // Only expose what's relevant to the user, instructions are printed by the enable/disable commands
+        Logger.printJson(
+          features.map(({ id, status, description, enabled }) => ({ id, status, description, enabled })),
+        );
         break;
       }
       case 'human':

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -7,9 +7,19 @@ import { getConfigPath } from './paths.js';
 
 const EXPERIMENTAL_FEATURES_FILEPATH = getConfigPath('clever-tools-experimental-features.json');
 
+/**
+ * @typedef {object} ExperimentalFeature
+ * @property {'beta'} status
+ * @property {boolean} defaultValue - Value used when the feature is not explicitly set by the user
+ * @property {string} description
+ * @property {string} [instructions]
+ */
+
+/** @type {Record<string, ExperimentalFeature>} */
 export const EXPERIMENTAL_FEATURES = {
   'system-git': {
     status: 'beta',
+    defaultValue: false,
     description: 'Use system git instead of current JS implementation for git operations',
     instructions: dedent`
       This feature switches from the current JS implementation to using
@@ -21,6 +31,7 @@ export const EXPERIMENTAL_FEATURES = {
   },
   k8s: {
     status: 'beta',
+    defaultValue: false,
     description: 'Deploy and manage Kubernetes clusters on Clever Cloud',
     instructions: dedent`
       - Create a Kubernetes cluster:
@@ -48,6 +59,7 @@ export const EXPERIMENTAL_FEATURES = {
   },
   kv: {
     status: 'beta',
+    defaultValue: false,
     description:
       'Send commands to databases such as Materia KV or Redis® directly from Clever Tools, without other dependencies',
     instructions: dedent`
@@ -64,6 +76,7 @@ export const EXPERIMENTAL_FEATURES = {
   },
   ng: {
     status: 'beta',
+    defaultValue: false,
     description: 'Manage Network Groups to manage applications, add-ons, external peers through a WireGuard network',
     instructions: dedent`
       - Create a Network Group:
@@ -92,6 +105,7 @@ export const EXPERIMENTAL_FEATURES = {
   },
   operators: {
     status: 'beta',
+    defaultValue: false,
     description: 'Manage operators and their features such as Keycloak, Matomo, Metabase, Otoroshi',
     instructions: dedent`
       clever keycloak
@@ -161,11 +175,12 @@ export async function setFeature(feature, value) {
 
 /**
  * Checks if an experimental feature is enabled.
+ * Falls back to the feature's `defaultValue` when the user hasn't set it explicitly.
  * @param {string} feature - The name of the feature to check
- * @returns {boolean} True if the feature is explicitly enabled, false otherwise
+ * @returns {boolean} True if the feature is enabled
  */
 export function isFeatureEnabled(feature) {
-  return userFeatures[feature] === true;
+  return userFeatures[feature] ?? EXPERIMENTAL_FEATURES[feature]?.defaultValue ?? false;
 }
 
 /**

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -1,6 +1,6 @@
 import dedent from 'dedent';
 import z from 'zod';
-import { readJson, writeJson } from '../lib/fs.js';
+import { readJsonSync, writeJson } from '../lib/fs.js';
 import { Logger } from '../logger.js';
 import { config } from './config.js';
 import { getConfigPath } from './paths.js';
@@ -116,52 +116,66 @@ const FeaturesConfigSchema = z
  */
 
 /**
- * Gets the current experimental features configuration.
- * Returns an empty object if the features file doesn't exist or is invalid.
- * @returns {Promise<FeaturesConfig>} The features configuration object
+ * The features explicitly set by the user, loaded synchronously at startup.
+ * @type {FeaturesConfig}
  */
-export async function getFeatures() {
-  Logger.debug(`Get features configuration from ${EXPERIMENTAL_FEATURES_FILEPATH}`);
-  try {
-    const rawFeatures = await readJson(EXPERIMENTAL_FEATURES_FILEPATH);
-    const parsed = FeaturesConfigSchema.safeParse(rawFeatures);
-    if (!parsed.success) {
-      Logger.info(`Invalid features format in ${EXPERIMENTAL_FEATURES_FILEPATH}`);
-      return {};
-    }
-    return parsed.data;
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw new Error(`Cannot get experimental features configuration from ${EXPERIMENTAL_FEATURES_FILEPATH}`);
-    }
+let userFeatures = loadFeatures();
+
+/**
+ * Reads and parses the features file.
+ * Returns an empty object if the file doesn't exist or is invalid.
+ * @returns {FeaturesConfig} The features configuration object
+ */
+function loadFeatures() {
+  Logger.debug(`Load features configuration from ${EXPERIMENTAL_FEATURES_FILEPATH}`);
+  const rawFeatures = readJsonSync(EXPERIMENTAL_FEATURES_FILEPATH);
+  if (rawFeatures == null) {
     return {};
   }
+  const parsed = FeaturesConfigSchema.safeParse(rawFeatures);
+  if (!parsed.success) {
+    Logger.info(`Invalid features format in ${EXPERIMENTAL_FEATURES_FILEPATH}`);
+    return {};
+  }
+  return parsed.data;
 }
 
 /**
  * Sets an experimental feature to the specified value.
- * Creates the configuration directory and features file if they don't exist.
+ * Creates the configuration directory and features file if they don't exist,
+ * then reloads the in-memory configuration.
  * @param {string} feature - The name of the feature to set
  * @param {boolean} value - The value to set for the feature
  * @returns {Promise<void>}
  * @throws {Error} If the features file cannot be written
  */
 export async function setFeature(feature, value) {
-  const currentFeatures = await getFeatures();
-  const newFeatures = { ...currentFeatures, [feature]: value };
+  const newFeatures = { ...userFeatures, [feature]: value };
   try {
     await writeJson(EXPERIMENTAL_FEATURES_FILEPATH, newFeatures, { mode: 0o700 });
   } catch (error) {
     throw new Error(`Cannot write experimental features configuration to ${EXPERIMENTAL_FEATURES_FILEPATH}`);
   }
+  userFeatures = loadFeatures();
 }
 
 /**
  * Checks if an experimental feature is enabled.
  * @param {string} feature - The name of the feature to check
- * @returns {Promise<boolean>} True if the feature is explicitly enabled, false otherwise
+ * @returns {boolean} True if the feature is explicitly enabled, false otherwise
  */
-export async function isFeatureEnabled(feature) {
-  const features = await getFeatures();
-  return features[feature] === true;
+export function isFeatureEnabled(feature) {
+  return userFeatures[feature] === true;
+}
+
+/**
+ * Lists all experimental features with their current status.
+ * @returns {Array<{ id: string, status: string, description: string, instructions?: string, enabled: boolean }>}
+ */
+export function getAllFeatures() {
+  return Object.entries(EXPERIMENTAL_FEATURES).map(([id, feature]) => ({
+    id,
+    ...feature,
+    enabled: isFeatureEnabled(id),
+  }));
 }

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -19,14 +19,17 @@ const EXPERIMENTAL_FEATURES_FILEPATH = getConfigPath('clever-tools-experimental-
 export const EXPERIMENTAL_FEATURES = {
   'system-git': {
     status: 'beta',
-    defaultValue: false,
-    description: 'Use system git instead of current JS implementation for git operations',
+    defaultValue: true,
+    description: 'Use system git instead of the pure JS implementation for git operations',
     instructions: dedent`
-      This feature switches from the current JS implementation to using
-      the git installed on your system.
+      This feature switches from the pure JS implementation to using
+      the git installed on your system. It is enabled by default since v5.0.0.
 
       Requirements:
         - git must be installed and available in your PATH
+
+      Disable it to fall back to the previous pure JS implementation:
+        clever features disable system-git
     `,
   },
   k8s: {

--- a/src/models/git-system.js
+++ b/src/models/git-system.js
@@ -167,8 +167,8 @@ export class GitSystem extends Git {
 class GitNotFoundError extends Error {
   constructor() {
     super(
-      'The system git feature requires git to be installed and available in your PATH\n' +
-        'Either install git or disable this feature with: clever features disable system-git',
+      'git was not found in your PATH\n' +
+        'Either install git, or fall back to the previous JS implementation with: clever features disable system-git',
     );
     this.name = 'GitNotFoundError';
   }

--- a/src/models/git.js
+++ b/src/models/git.js
@@ -30,7 +30,7 @@ export class Git {
    */
   static async get() {
     if (Git.#instance == null) {
-      const useSystemGit = await isFeatureEnabled('system-git');
+      const useSystemGit = isFeatureEnabled('system-git');
       if (useSystemGit) {
         const { GitSystem } = await import('./git-system.js');
         Git.#instance = new GitSystem();


### PR DESCRIPTION
## Context

The pure JS git implementation (isomorphic-git) has caused recurring issues: HTTP-only (no SSH), slow on repositories with rewritten history, connection timeouts on large repos, and no support for linked git worktrees.

`system-git`, the beta backend that delegates to the system-installed `git` binary, has been available as opt-in via `clever features enable system-git` and has proven reliable.

## Proposal

Flip `system-git`'s default to enabled. The feature flag stays around for a few more releases as a rollback path (`clever features disable system-git`) before eventual removal.

### Design decisions

- Each feature can now declare its own `defaultValue`, instead of `isFeatureEnabled()` hardcoding `false` for everyone
- Reworked `src/config/features.js`: user-set features are now loaded synchronously once at startup and cached in memory (`loadFeatures()`), so `isFeatureEnabled()` and the new `getAllFeatures()` no longer need to be async
- Added `getAllFeatures()`, which centralizes id/status/description/defaultValue/enabled resolution; `clever features list` now reuses it instead of duplicating that logic

## How to test

1. `clever features list` → `system-git` shows `enabled: true` without any config
2. Run any git-touching command (e.g. `clever deploy -v` from a repo linked to an app) and check the debug logs: `git(system): ...` confirms the system backend is used
3. `clever features disable system-git`, repeat step 2 → `git(isomorphic): ...` confirms the fallback still works