### PR TITLE
feat(accesslogs): display TCP and SSH access logs

### DIFF
--- a/skills/clever-tools/references/full-documentation.md
+++ b/skills/clever-tools/references/full-documentation.md
@@ -297,7 +297,7 @@ clever accesslogs [options]
 -a, --alias <alias>               Short name for the application
     --app <app-id|app-name>       Application to manage by its ID (or name, if unambiguous)
     --before, --until <before>    Fetch logs before this date/time (ISO8601 date, positive number in seconds or duration, e.g.: 1h)
--F, --format <format>             Output format (human, json, json-stream, clf) (default: human)
+-F, --format <format>             Output format (clf only outputs HTTP access logs) (human, json, json-stream, clf) (default: human)
 ```
 
 ## activity

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -28,19 +28,16 @@ function formatHuman(log) {
   const country = source.countryCode ?? '(unknown)';
   const hasSourceCity = source.city ?? '';
 
-  return formatTable(
-    [
-      [
-        styleText('grey', date.toISOString(date)),
-        source.ip,
-        `${country}${hasSourceCity ? '/' + truncateWithEllipsis(CITY_MAX_LENGTH, source.city) : ''}`,
-        colorStatusCode(http.response.statusCode),
-        http.request.method.toString().padEnd(4, ' ') + ' ' + http.request.path,
-      ],
-    ],
+  const columns = [
+    styleText('grey', date.toISOString(date)),
+    source.ip,
+    `${country}${hasSourceCity ? '/' + truncateWithEllipsis(CITY_MAX_LENGTH, source.city) : ''}`,
+    colorStatusCode(http.response.statusCode),
+    http.request.method,
+    http.request.path,
+  ];
 
-    ACCESSLOG_COLUMN_WIDTHS,
-  );
+  return formatTable([columns], ACCESSLOG_COLUMN_WIDTHS);
 }
 
 const ACCESSLOG_COLUMN_WIDTHS = [

--- a/src/commands/accesslogs/accesslogs.command.js
+++ b/src/commands/accesslogs/accesslogs.command.js
@@ -1,6 +1,7 @@
 import { ApplicationAccessLogStream } from '@clevercloud/client/esm/streams/access-logs.js';
 import { formatTable } from '../../format-table.js';
 import { formatClf } from '../../lib/access-logs-clf.js';
+import { guessAccessLogTransport } from '../../lib/access-logs-transport.js';
 import { defineCommand } from '../../lib/define-command.js';
 import { styleText } from '../../lib/style-text.js';
 import { Logger } from '../../logger.js';
@@ -23,6 +24,15 @@ const THROTTLE_PER_IN_MILLISECONDS = 100;
 
 const CITY_MAX_LENGTH = 20;
 
+/**
+ * Format an access log as a human readable table row.
+ *
+ * Non-HTTP access logs (TCP redirections, SSH connections, or HTTP connections cut before the
+ * proxy could answer) have no `http` section: their status and request columns are omitted.
+ *
+ * @param {object} log an access log, as emitted by `ApplicationAccessLogStream`
+ * @returns {string}
+ */
 function formatHuman(log) {
   const { date, http, source } = log;
   const country = source.countryCode ?? '(unknown)';
@@ -30,18 +40,24 @@ function formatHuman(log) {
 
   const columns = [
     styleText('grey', date.toISOString(date)),
+    guessAccessLogTransport(log),
     source.ip,
     `${country}${hasSourceCity ? '/' + truncateWithEllipsis(CITY_MAX_LENGTH, source.city) : ''}`,
-    colorStatusCode(http.response.statusCode),
-    http.request.method,
-    http.request.path,
   ];
+
+  if (http != null) {
+    columns.push(colorStatusCode(http.response.statusCode));
+    columns.push(http.request.method);
+    columns.push(http.request.path);
+  }
 
   return formatTable([columns], ACCESSLOG_COLUMN_WIDTHS);
 }
 
 const ACCESSLOG_COLUMN_WIDTHS = [
   '2024-06-24T08:05:43.880Z',
+  // longest transport name
+  'HTTP',
   '255.255.255.255',
   // country / city
   2 + 1 + CITY_MAX_LENGTH,
@@ -131,7 +147,7 @@ export const accesslogsCommand = defineCommand({
             Logger.printJson(log);
             break;
           case 'clf':
-            // when the connection is cut too early, or for TCP redirections, we don't have HTTP section
+            // CLF only describes HTTP requests, so logs without an HTTP section are skipped
             if (log.http == null) {
               break;
             }
@@ -140,11 +156,6 @@ export const accesslogsCommand = defineCommand({
             break;
           case 'human':
           default:
-            // when the connection is cut too early, or for TCP redirections, we don't have HTTP section
-            if (log.http == null) {
-              break;
-            }
-
             Logger.println(formatHuman(log));
             break;
         }

--- a/src/commands/accesslogs/accesslogs.docs.md
+++ b/src/commands/accesslogs/accesslogs.docs.md
@@ -17,4 +17,4 @@ clever accesslogs [options]
 |`-a`, `--alias` `<alias>`|Short name for the application|
 |`--app` `<app-id\|app-name>`|Application to manage by its ID (or name, if unambiguous)|
 |`--before`, `--until` `<before>`|Fetch logs before this date/time (ISO8601 date, positive number in seconds or duration, e.g.: 1h)|
-|`-F`, `--format` `<format>`|Output format (human, json, json-stream, clf) (default: human)|
+|`-F`, `--format` `<format>`|Output format (clf only outputs HTTP access logs) (human, json, json-stream, clf) (default: human)|

--- a/src/commands/global.options.js
+++ b/src/commands/global.options.js
@@ -31,7 +31,7 @@ export const logsFormatOption = defineOption({
 export const accessLogsFormatOption = defineOption({
   name: 'format',
   schema: z.enum(['human', 'json', 'json-stream', 'clf']).default('human'),
-  description: 'Output format',
+  description: 'Output format (clf only outputs HTTP access logs)',
   aliases: ['F'],
   placeholder: 'format',
 });

--- a/src/format-table.js
+++ b/src/format-table.js
@@ -36,16 +36,20 @@ export const formatTable = (data, columnWidth = []) => {
   return data
     .map((row) => row.map((cell) => String(cell)))
     .map((row) => {
-      return row
-        .map((cell, index) => {
-          const isLastColumn = index === row.length - 1;
-          if (isLastColumn) {
-            return cell;
-          }
-          const rightPaddingLength = columnSizes[index] - stringLength(cell) ?? 0;
-          return cell + ' '.repeat(rightPaddingLength);
-        })
-        .join(SEPARATOR);
+      return (
+        row
+          .map((cell, index) => {
+            const isLastColumn = index === row.length - 1;
+            if (isLastColumn) {
+              return cell;
+            }
+            const rightPaddingLength = columnSizes[index] - stringLength(cell) ?? 0;
+            return cell + ' '.repeat(rightPaddingLength);
+          })
+          .join(SEPARATOR)
+          // empty trailing cells would otherwise pad the line with meaningless spaces
+          .trimEnd()
+      );
     })
     .join('\n');
 };

--- a/src/lib/access-logs-transport.js
+++ b/src/lib/access-logs-transport.js
@@ -1,0 +1,29 @@
+/**
+ * Transport used by the connection an access log describes.
+ * @typedef {'HTTP'|'TCP'|'SSH'} AccessLogTransport
+ */
+
+/**
+ * Guess the transport of an access log.
+ *
+ * The v4 access log payload has no explicit transport field yet, so it is inferred from the
+ * sections the API did send:
+ *
+ * - an `http` section is only emitted for connections that went through the HTTP reverse proxy,
+ * - TCP redirections go through the TCP proxy, which assigns a `requestId` but no `http` section,
+ * - direct SSH connections to the instance go through neither, so they carry neither field.
+ *
+ * Drop this function once the API exposes the transport itself.
+ *
+ * @param {object} log an access log, as emitted by `ApplicationAccessLogStream`
+ * @returns {AccessLogTransport}
+ */
+export function guessAccessLogTransport(log) {
+  if (log.http != null) {
+    return 'HTTP';
+  }
+  if (log.requestId != null) {
+    return 'TCP';
+  }
+  return 'SSH';
+}


### PR DESCRIPTION
Replaces #979

## Context

- The access log API was designed for HTTP logs
- Some logs came in with a null `http` section, which looked like a bug, so `clever accesslogs` filtered them out to hide them
- TCP and SSH access logs have been added to the API since then, but they are not identified as such in the payload

## Proposal

Display TCP and SSH access logs, with a transport column telling which kind of connection each log describes.

### Implementation details

The transport is guessed from the sections the API sends, in `src/lib/access-logs-transport.js`, until the API exposes it. The CLF format keeps skipping non-HTTP logs, since CLF only describes HTTP requests, and the `--format` option description now says so.

This was also an opportunity to fix two table display details: paths are now aligned whatever the method length, and lines no longer end with trailing spaces coming from empty cells.

## How to test

```bash
clever accesslogs --app APP_NAME
```

- HTTP lines should keep their paths aligned whatever the method, and show `HTTP` in the transport column
- Opening an SSH connection to an instance should show SSH lines
- Hitting a TCP redirection on the application should show TCP lines
- SSH and TCP lines should be without status and request columns
- `--format clf` should still only output HTTP lines

## Known limitations

These are API-side limitations, left as-is in this PR and worth investigating later.

### IPv6 source addresses widen their line

The source IP column is sized for IPv4 (`255.255.255.255`, 15 characters). An IPv6 address is up to 39 characters, so it pushes the columns of its own line to the right. Other lines stay aligned, since each log is formatted independently.

Sizing the column for IPv6 would add 24 spaces to every IPv4 line, which is nearly all of them: over 7 days on a test application, 2244 logs contained a single `:` address, `::1` (internal healthchecks). Truncating would make the address unreadable and misleading. So the widening is kept for now.

### SSH sessions produce two logs

An SSH session emits one log on connect and one on disconnect, and nothing in the payload tells them apart:

```json
{"date":"2026-09-10T10:30:28.028Z","id":"283950630:45:0","source":{"port":56992},"bytesIn":0,"bytesOut":0,"http":null,"requestId":null,"tls":null}
{"date":"2026-09-10T10:30:28.606Z","id":"283950630:46:0","source":{"port":56992},"bytesIn":0,"bytesOut":0,"http":null,"requestId":null,"tls":null}
```

Both logs share the same `source.port`, carry zero bytes in and out, and only differ by their incrementing `id`. Pairing them by `(source.ip, source.port)` would assume the couple is never reused and would lose the session duration, so the two lines are displayed as sent.

Both limitations, along with the transport guessing in `src/lib/access-logs-transport.js`, would be solved by the API exposing the transport and an event type (connect/disconnect) explicitly.
