### PR TITLE
fix(git): clarify ref errors and deployment output

### DIFF
--- a/src/commands/deploy/deploy.command.js
+++ b/src/commands/deploy/deploy.command.js
@@ -131,11 +131,15 @@ export const deployCommand = defineCommand({
     if (remoteHeadCommitId == null || deployedCommitId == null) {
       Logger.println(`   ${styleText('yellow', '!')} App is brand new, no commits on remote yet`);
     } else {
-      Logger.println(`   Remote head     ${styleText('yellow', remoteHeadCommitId)} (${branchRefspec})`);
+      // No refspec here: the remote head is always `refs/heads/master` on Clever Cloud's side,
+      // whatever local branch or tag is being pushed. Labelling it with `branchRefspec` read as
+      // if that local ref existed on the remote — a tag deploy printed `(refs/tags/v2.0.0)` next
+      // to a commit that is on the remote's master. The refspec belongs to the local commit.
+      Logger.println(`   Remote head     ${styleText('yellow', remoteHeadCommitId)}`);
       Logger.println(`   Deployed commit ${styleText('yellow', deployedCommitId)}`);
     }
     Logger.println(
-      `   Local commit    ${styleText('yellow', commitIdToPush)} ${styleText('blue', '[will be deployed]')}`,
+      `   Local commit    ${styleText('yellow', commitIdToPush)} (${branchRefspec}) ${styleText('blue', '[will be deployed]')}`,
     );
 
     Logger.println();

--- a/src/models/git-system.js
+++ b/src/models/git-system.js
@@ -99,9 +99,24 @@ export class GitSystem extends Git {
   async getBranchCommit(refspec) {
     this._debug('getBranchCommit', refspec);
     const git = await this.#getSimpleGit();
-    // Use rev-parse with ^{commit} to dereference tags to their commit
-    const oid = await git.revparse([`${refspec}^{commit}`]);
-    return oid.trim();
+    // `^{commit}` dereferences an annotated tag to the commit it points at. Plain `rev-parse` used
+    // to run it bare, so on a repository with no commit the user got git's own words back — the
+    // multi-line "Use '--' to separate paths from revisions" hint, quoting the
+    // `<refspec>^{commit}` we built rather than anything they typed.
+    //
+    // `--verify --quiet` separates the two outcomes worth telling apart: a refspec that resolves
+    // to nothing exits non-zero with an empty stderr, which simple-git hands back as empty stdout
+    // rather than an error, while an unreadable repository or a malformed `.git/config` still
+    // rejects and keeps git's diagnostic, which is the one thing here worth showing verbatim.
+    //
+    // Only the ref is named. Failing to resolve `HEAD` says nothing about the repository holding
+    // commits — `git checkout --orphan` leaves HEAD unborn in a repository full of them — so
+    // there is no inference to draw beyond the ref that was asked for.
+    const oid = (await git.revparse(['--verify', '--quiet', '--end-of-options', `${refspec}^{commit}`])).trim();
+    if (oid === '') {
+      throw new Error(`Could not resolve ${refspec} to a commit`);
+    }
+    return oid;
   }
 
   async isExistingTag(tag) {

--- a/src/models/git-system.js
+++ b/src/models/git-system.js
@@ -45,15 +45,27 @@ export class GitSystem extends Git {
       return null;
     }
     const git = await this.#getSimpleGit();
-    try {
-      const fullOid = await git.revparse([commitId]);
-      return fullOid.trim();
-    } catch (e) {
-      if (e.message.includes('unknown revision') || e.message.includes('ambiguous argument')) {
-        throw new Error(`Commit id ${commitId} is ambiguous`);
-      }
-      throw e;
+    // The failure used to be recognised from git's own words ("unknown revision", "ambiguous
+    // argument"), and git translates that one — it comes from `die(_("ambiguous argument '%s':
+    // unknown revision or path not in the working tree…"))` in git's setup.c, wrapped in `_()`.
+    // On a git built with its l10n catalogs, the norm on Debian and Ubuntu which ship `git-l10n`,
+    // the match failed and the raw git error reached the user instead of a message of ours.
+    //
+    // `--verify --quiet` answers without prose instead: an id that resolves to nothing exits
+    // non-zero with an empty stderr, which simple-git hands back as empty stdout rather than an
+    // error, while a genuine failure — an unreadable repository, a malformed `.git/config` — still
+    // rejects and carries git's own diagnostic, which deserves to reach the user untouched.
+    //
+    // This resolves an id, it does not prove the object is here: a full 40-character SHA comes
+    // back as itself even when the repository holds no such object, exactly as the previous
+    // `rev-parse` call did. `restart --commit` leans on that — the commit it names lives on the
+    // remote and need not have been fetched — so do not tighten this into an existence check
+    // (`^{commit}`) without looking at that command first.
+    const fullOid = (await git.revparse(['--verify', '--quiet', '--end-of-options', commitId])).trim();
+    if (fullOid === '') {
+      throw new Error(`Could not resolve commit id ${commitId} in this repository`);
     }
+    return fullOid;
   }
 
   async getRemoteCommit(remoteUrl) {


### PR DESCRIPTION
I've tested some Git corner cases against the system Git backend, which became the default in v5. Three of them surfaced problems, one commit each.

## Context

- Unresolved Git refs print Git's revision-parsing output, including for empty repositories and missing branches.
- Resolving an unknown commit ID falls back to raw Git output when Git's error is translated. Reproduced with Debian Git 2.39.5 in `fr_FR.UTF-8`.
- Tag deployments label `Remote head` with the local tag, while the remote head is always `refs/heads/master`.

## Proposal

Return a short error naming the ref or commit ID that cannot be resolved, without matching translated text. Keep Git's diagnostic for configuration and repository errors.

Move the local ref to the `Local commit` line.

The messages below come from the system Git backend, which is the default. The JS backend has its own messages, unchanged by this pull request.

## How to test

Use Clever Tools from this branch, logged in, with the system Git backend enabled. Replace `YOUR_TEST_APP` with a test application that already has a deployed commit.

```bash
test_dir=$(mktemp -d)
cd "$test_dir" && git init -q -b main
clever link 'YOUR_TEST_APP'
```

**An empty repository**

```bash
clever deploy --quiet --exit-on deploy-start
```

Before:

```
fatal: ambiguous argument 'HEAD^{commit}': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

After: `Could not resolve HEAD to a commit`

**An unborn branch in a repository that already has a commit**

```bash
echo x > f.txt && git add -A && git commit -qm one
git checkout -q --orphan orphan
clever deploy --quiet --exit-on deploy-start
```

Before: the same three lines. After: `Could not resolve HEAD to a commit`

**An annotated tag.** This force-pushes a separate history to the application and starts a deployment.

```bash
git checkout -qf main && git tag -a demo -m demo
clever deploy --quiet --exit-on deploy-start --tag demo --force
```

Before:

```
   Remote head     46e7a70dace7225ab0186230b03dcd0c0b49d963 (refs/tags/demo)
   Deployed commit 46e7a70dace7225ab0186230b03dcd0c0b49d963
   Local commit    6d5d61c184c1fac9b43c3d1186566cc36c3eb52b [will be deployed]
```

After:

```
   Remote head     46e7a70dace7225ab0186230b03dcd0c0b49d963
   Deployed commit 46e7a70dace7225ab0186230b03dcd0c0b49d963
   Local commit    266960560ad88fc8d464835ffc4dd1979bc4e786 (refs/tags/demo) [will be deployed]
```

**An unresolved commit ID**

```bash
clever restart --commit deadbeef
```

Before: `Commit id deadbeef is ambiguous`, or raw Git output on a translated Git.
After: `Could not resolve commit id deadbeef in this repository`

**A real Git failure still reaches you**, in a fresh directory:

```bash
test_dir=$(mktemp -d)
cd "$test_dir" && git init -q -b main
clever link 'YOUR_TEST_APP'
echo x > f.txt && git add -A && git commit -qm one
printf '\n[invalid\n' >> .git/config
clever deploy --quiet --exit-on deploy-start
```

Before and after: Git's own `fatal: bad config line …` message.

## Known limitations

A full commit SHA is still accepted without checking that the object exists locally. This preserves the existing behavior for `restart --commit`, which can target a commit held by the remote.
