### PR TITLE
fix(docs): escape pipes in generated argument tables

### DIFF
--- a/scripts/lib/docs-reference.js
+++ b/scripts/lib/docs-reference.js
@@ -208,7 +208,7 @@ export function getSubCommandMarkdown(path, definition, subCommandNodes) {
       let description = arg.description;
       if (arg.enumValues) description += ` (${arg.enumValues.join(', ')})`;
       if (arg.optional) description += ` *${arg.optional}*`;
-      return `|\`${arg.name}\`|${escapeTableCell(description)}|`;
+      return `|\`${escapeTableCell(arg.name)}\`|${escapeTableCell(description)}|`;
     });
     parts.push(dedent`
       ### 📥 Arguments

--- a/src/commands/addon/addon.docs.md
+++ b/src/commands/addon/addon.docs.md
@@ -55,7 +55,7 @@ clever addon delete <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -148,7 +148,7 @@ clever addon rename <addon-id|addon-name> <addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 |`addon-name`|Add-on name|
 
 ### ⚙️ Options

--- a/src/commands/config-provider/config-provider.docs.md
+++ b/src/commands/config-provider/config-provider.docs.md
@@ -20,7 +20,7 @@ clever config-provider get <addon-id|config-provider-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`addon-id\|config-provider-id\|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
 
 ### ⚙️ Options
 
@@ -41,7 +41,7 @@ clever config-provider import <addon-id|config-provider-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`addon-id\|config-provider-id\|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
 
 ### ⚙️ Options
 
@@ -75,7 +75,7 @@ clever config-provider open <addon-id|config-provider-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`addon-id\|config-provider-id\|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
 
 ## ➡️ `clever config-provider rm` <kbd>Since 4.6.0</kbd>
 
@@ -89,7 +89,7 @@ clever config-provider rm <addon-id|config-provider-id|addon-name> <variable-nam
 
 |Name|Description|
 |---|---|
-|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`addon-id\|config-provider-id\|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
 |`variable-name`|Name of the environment variable|
 
 ## ➡️ `clever config-provider set` <kbd>Since 4.6.0</kbd>
@@ -104,6 +104,6 @@ clever config-provider set <addon-id|config-provider-id|addon-name> <variable-na
 
 |Name|Description|
 |---|---|
-|`addon-id|config-provider-id|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
+|`addon-id\|config-provider-id\|addon-name`|Add-on ID, real ID (config_xxx) or name (if unambiguous)|
 |`variable-name`|Name of the environment variable|
 |`variable-value`|Value of the environment variable|

--- a/src/commands/database/database.docs.md
+++ b/src/commands/database/database.docs.md
@@ -20,7 +20,7 @@ clever database backups <database-id|addon-id> [options]
 
 |Name|Description|
 |---|---|
-|`database-id|addon-id`|Any database ID (format: addon_UUID, postgresql_UUID, mysql_UUID, ...)|
+|`database-id\|addon-id`|Any database ID (format: addon_UUID, postgresql_UUID, mysql_UUID, ...)|
 
 ### ⚙️ Options
 
@@ -41,7 +41,7 @@ clever database backups download <database-id|addon-id> <backup-id> [options]
 
 |Name|Description|
 |---|---|
-|`database-id|addon-id`|Any database ID (format: addon_UUID, postgresql_UUID, mysql_UUID, ...)|
+|`database-id\|addon-id`|Any database ID (format: addon_UUID, postgresql_UUID, mysql_UUID, ...)|
 |`backup-id`|A Database backup ID (format: UUID)|
 
 ### ⚙️ Options

--- a/src/commands/k8s/k8s.docs.md
+++ b/src/commands/k8s/k8s.docs.md
@@ -24,7 +24,7 @@ clever k8s activity <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -46,7 +46,7 @@ clever k8s add-persistent-storage <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -97,7 +97,7 @@ clever k8s delete <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -118,7 +118,7 @@ clever k8s get <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -139,7 +139,7 @@ clever k8s get-kubeconfig <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -182,7 +182,7 @@ clever k8s nodegroups create <cluster-id|cluster-name> <nodegroup-name> <flavor:
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 |`nodegroup-name`|Node group name (lowercase RFC 1123, max 63 chars)|
 |`flavor:count`|Node group flavor and target node count (format: <flavor>:<count>, e.g.: XS:3)|
 
@@ -209,8 +209,8 @@ clever k8s nodegroups delete <cluster-id|cluster-name> <nodegroup-id|nodegroup-n
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
-|`nodegroup-id|nodegroup-name`|Kubernetes node group ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-id\|nodegroup-name`|Kubernetes node group ID or name|
 
 ### ⚙️ Options
 
@@ -231,8 +231,8 @@ clever k8s nodegroups get <cluster-id|cluster-name> <nodegroup-id|nodegroup-name
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
-|`nodegroup-id|nodegroup-name`|Kubernetes node group ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-id\|nodegroup-name`|Kubernetes node group ID or name|
 
 ### ⚙️ Options
 
@@ -253,7 +253,7 @@ clever k8s nodegroups list <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -274,8 +274,8 @@ clever k8s nodegroups update <cluster-id|cluster-name> <nodegroup-id|nodegroup-n
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
-|`nodegroup-id|nodegroup-name`|Kubernetes node group ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
+|`nodegroup-id\|nodegroup-name`|Kubernetes node group ID or name|
 
 ### ⚙️ Options
 
@@ -317,7 +317,7 @@ clever k8s update <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -342,7 +342,7 @@ clever k8s version <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -363,7 +363,7 @@ clever k8s version check <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 
@@ -384,7 +384,7 @@ clever k8s version update <cluster-id|cluster-name> [options]
 
 |Name|Description|
 |---|---|
-|`cluster-id|cluster-name`|Kubernetes cluster ID or name|
+|`cluster-id\|cluster-name`|Kubernetes cluster ID or name|
 
 ### ⚙️ Options
 

--- a/src/commands/keycloak/keycloak.docs.md
+++ b/src/commands/keycloak/keycloak.docs.md
@@ -30,7 +30,7 @@ clever keycloak disable-ng <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak enable-ng` <kbd>Since 3.13.0</kbd>
 
@@ -44,7 +44,7 @@ clever keycloak enable-ng <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak get` <kbd>Since 3.13.0</kbd>
 
@@ -58,7 +58,7 @@ clever keycloak get <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -78,7 +78,7 @@ clever keycloak open <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak open logs` <kbd>Since 3.13.0</kbd>
 
@@ -92,7 +92,7 @@ clever keycloak open logs <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak open webui` <kbd>Since 3.13.0</kbd>
 
@@ -106,7 +106,7 @@ clever keycloak open webui <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak rebuild` <kbd>Since 3.13.0</kbd>
 
@@ -120,7 +120,7 @@ clever keycloak rebuild <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak restart` <kbd>Since 3.13.0</kbd>
 
@@ -134,7 +134,7 @@ clever keycloak restart <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever keycloak version` <kbd>Since 3.13.0</kbd>
 
@@ -148,7 +148,7 @@ clever keycloak version <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -168,7 +168,7 @@ clever keycloak version check <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -188,7 +188,7 @@ clever keycloak version update <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 

--- a/src/commands/kv/kv.docs.md
+++ b/src/commands/kv/kv.docs.md
@@ -16,7 +16,7 @@ clever kv <kv-id|addon-id|addon-name> <command> [options]
 
 |Name|Description|
 |---|---|
-|`kv-id|addon-id|addon-name`|Add-on/Real ID (or name, if unambiguous) of a Materia KV or Redis® add-on|
+|`kv-id\|addon-id\|addon-name`|Add-on/Real ID (or name, if unambiguous) of a Materia KV or Redis® add-on|
 |`command`|The raw command to send to the Materia KV or Redis® add-on|
 
 ### ⚙️ Options

--- a/src/commands/link/link.docs.md
+++ b/src/commands/link/link.docs.md
@@ -12,7 +12,7 @@ clever link <app-id|app-name> [options]
 
 |Name|Description|
 |---|---|
-|`app-id|app-name`|Application ID (or name, if unambiguous)|
+|`app-id\|app-name`|Application ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 

--- a/src/commands/matomo/matomo.docs.md
+++ b/src/commands/matomo/matomo.docs.md
@@ -30,7 +30,7 @@ clever matomo get <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -50,7 +50,7 @@ clever matomo open <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever matomo open logs` <kbd>Since 3.13.0</kbd>
 
@@ -64,7 +64,7 @@ clever matomo open logs <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever matomo open webui` <kbd>Since 3.13.0</kbd>
 
@@ -78,7 +78,7 @@ clever matomo open webui <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever matomo rebuild` <kbd>Since 3.13.0</kbd>
 
@@ -92,7 +92,7 @@ clever matomo rebuild <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever matomo restart` <kbd>Since 3.13.0</kbd>
 
@@ -106,4 +106,4 @@ clever matomo restart <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|

--- a/src/commands/metabase/metabase.docs.md
+++ b/src/commands/metabase/metabase.docs.md
@@ -30,7 +30,7 @@ clever metabase get <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -50,7 +50,7 @@ clever metabase open <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever metabase open logs` <kbd>Since 3.13.0</kbd>
 
@@ -64,7 +64,7 @@ clever metabase open logs <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever metabase open webui` <kbd>Since 3.13.0</kbd>
 
@@ -78,7 +78,7 @@ clever metabase open webui <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever metabase rebuild` <kbd>Since 3.13.0</kbd>
 
@@ -92,7 +92,7 @@ clever metabase rebuild <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever metabase restart` <kbd>Since 3.13.0</kbd>
 
@@ -106,7 +106,7 @@ clever metabase restart <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever metabase version` <kbd>Since 3.13.0</kbd>
 
@@ -120,7 +120,7 @@ clever metabase version <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -140,7 +140,7 @@ clever metabase version check <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -160,7 +160,7 @@ clever metabase version update <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 

--- a/src/commands/ng/ng.docs.md
+++ b/src/commands/ng/ng.docs.md
@@ -55,7 +55,7 @@ clever ng create external <external-peer-label> <ng-id|ng-label> <public-key> [o
 |Name|Description|
 |---|---|
 |`external-peer-label`|External peer label|
-|`ng-id|ng-label`|Network Group ID or label|
+|`ng-id\|ng-label`|Network Group ID or label|
 |`public-key`|WireGuard public key of the external peer to link to a Network Group|
 
 ### ⚙️ Options
@@ -76,7 +76,7 @@ clever ng delete <ng-id|ng-label> [options]
 
 |Name|Description|
 |---|---|
-|`ng-id|ng-label`|Network Group ID or label|
+|`ng-id\|ng-label`|Network Group ID or label|
 
 ### ⚙️ Options
 
@@ -96,8 +96,8 @@ clever ng delete external <peer-id|peer-label> <ng-id|ng-label> [options]
 
 |Name|Description|
 |---|---|
-|`peer-id|peer-label`|External peer ID or label|
-|`ng-id|ng-label`|Network Group ID or label|
+|`peer-id\|peer-label`|External peer ID or label|
+|`ng-id\|ng-label`|Network Group ID or label|
 
 ### ⚙️ Options
 
@@ -117,7 +117,7 @@ clever ng get <id|label> [options]
 
 |Name|Description|
 |---|---|
-|`id|label`|ID or Label of a Network Group, a member or an (external) peer|
+|`id\|label`|ID or Label of a Network Group, a member or an (external) peer|
 
 ### ⚙️ Options
 
@@ -139,8 +139,8 @@ clever ng get-config <peer-id|peer-label> <ng-id|ng-label> [options]
 
 |Name|Description|
 |---|---|
-|`peer-id|peer-label`|External peer ID or label|
-|`ng-id|ng-label`|Network Group ID or label|
+|`peer-id\|peer-label`|External peer ID or label|
+|`ng-id\|ng-label`|Network Group ID or label|
 
 ### ⚙️ Options
 
@@ -161,7 +161,7 @@ clever ng link <id> <ng-id|ng-label> [options]
 |Name|Description|
 |---|---|
 |`id`|ID of a resource to (un)link to a Network Group|
-|`ng-id|ng-label`|Network Group ID or label|
+|`ng-id\|ng-label`|Network Group ID or label|
 
 ### ⚙️ Options
 
@@ -181,7 +181,7 @@ clever ng search <id|label> [options]
 
 |Name|Description|
 |---|---|
-|`id|label`|ID or Label of a Network Group, a member or an (external) peer|
+|`id\|label`|ID or Label of a Network Group, a member or an (external) peer|
 
 ### ⚙️ Options
 
@@ -204,7 +204,7 @@ clever ng unlink <id> <ng-id|ng-label> [options]
 |Name|Description|
 |---|---|
 |`id`|ID of a resource to (un)link to a Network Group|
-|`ng-id|ng-label`|Network Group ID or label|
+|`ng-id\|ng-label`|Network Group ID or label|
 
 ### ⚙️ Options
 

--- a/src/commands/oauth-consumers/oauth-consumers.docs.md
+++ b/src/commands/oauth-consumers/oauth-consumers.docs.md
@@ -46,7 +46,7 @@ clever oauth-consumers delete <consumer-key|consumer-name> [options]
 
 |Name|Description|
 |---|---|
-|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+|`consumer-key\|consumer-name`|OAuth consumer key (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -66,7 +66,7 @@ clever oauth-consumers get <consumer-key|consumer-name> [options]
 
 |Name|Description|
 |---|---|
-|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+|`consumer-key\|consumer-name`|OAuth consumer key (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -101,7 +101,7 @@ clever oauth-consumers open <consumer-key|consumer-name>
 
 |Name|Description|
 |---|---|
-|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+|`consumer-key\|consumer-name`|OAuth consumer key (or name, if unambiguous)|
 
 ## ➡️ `clever oauth-consumers update` <kbd>Since 4.8.0</kbd>
 
@@ -115,7 +115,7 @@ clever oauth-consumers update <consumer-key|consumer-name> [options]
 
 |Name|Description|
 |---|---|
-|`consumer-key|consumer-name`|OAuth consumer key (or name, if unambiguous)|
+|`consumer-key\|consumer-name`|OAuth consumer key (or name, if unambiguous)|
 
 ### ⚙️ Options
 

--- a/src/commands/otoroshi/otoroshi.docs.md
+++ b/src/commands/otoroshi/otoroshi.docs.md
@@ -30,7 +30,7 @@ clever otoroshi disable-ng <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi enable-ng` <kbd>Since 3.13.0</kbd>
 
@@ -44,7 +44,7 @@ clever otoroshi enable-ng <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi get` <kbd>Since 3.13.0</kbd>
 
@@ -58,7 +58,7 @@ clever otoroshi get <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -78,7 +78,7 @@ clever otoroshi get-config <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi open` <kbd>Since 3.13.0</kbd>
 
@@ -92,7 +92,7 @@ clever otoroshi open <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi open logs` <kbd>Since 3.13.0</kbd>
 
@@ -106,7 +106,7 @@ clever otoroshi open logs <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi open swaggerui` <kbd>Since 4.9.0</kbd>
 
@@ -120,7 +120,7 @@ clever otoroshi open swaggerui <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi open webui` <kbd>Since 3.13.0</kbd>
 
@@ -134,7 +134,7 @@ clever otoroshi open webui <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi rebuild` <kbd>Since 3.13.0</kbd>
 
@@ -148,7 +148,7 @@ clever otoroshi rebuild <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi restart` <kbd>Since 3.13.0</kbd>
 
@@ -162,7 +162,7 @@ clever otoroshi restart <addon-id|addon-name>
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ## ➡️ `clever otoroshi version` <kbd>Since 3.13.0</kbd>
 
@@ -176,7 +176,7 @@ clever otoroshi version <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -196,7 +196,7 @@ clever otoroshi version check <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -216,7 +216,7 @@ clever otoroshi version update <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 

--- a/src/commands/service/service.docs.md
+++ b/src/commands/service/service.docs.md
@@ -31,7 +31,7 @@ clever service link-addon <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -52,7 +52,7 @@ clever service link-app <app-id|app-name> [options]
 
 |Name|Description|
 |---|---|
-|`app-id|app-name`|Application ID (or name, if unambiguous)|
+|`app-id\|app-name`|Application ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -73,7 +73,7 @@ clever service unlink-addon <addon-id|addon-name> [options]
 
 |Name|Description|
 |---|---|
-|`addon-id|addon-name`|Add-on ID (or name, if unambiguous)|
+|`addon-id\|addon-name`|Add-on ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 
@@ -94,7 +94,7 @@ clever service unlink-app <app-id|app-name> [options]
 
 |Name|Description|
 |---|---|
-|`app-id|app-name`|Application ID (or name, if unambiguous)|
+|`app-id\|app-name`|Application ID (or name, if unambiguous)|
 
 ### ⚙️ Options
 


### PR DESCRIPTION
## Context

An argument whose placeholder holds a pipe breaks the markdown table it sits in. A bare pipe is a
column separator even inside backticks, so a command taking `<ng-id|ng-label>` produces this row:

```
|`ng-id|ng-label`|Network Group ID or label|
```

which GitHub renders as four columns instead of two, and the rest of the table goes out of
alignment with it. Thirteen command references were affected — every one taking something shaped
like `<ng-id|ng-label>` or `<app-id|app-name>`.

The generator already knew how to handle this: `escapeTableCell` was applied to the argument
description on that very line, and to the option aliases a few lines below. Only the argument name
was missed.

I ran into it while writing the `clever kv` documentation, but it has nothing to do with `kv`.

## Changes

Escape the argument name like everything else in those tables, and regenerate the references.

## How to review

The code change is one line, [`scripts/lib/docs-reference.js:211`](https://github.com/CleverCloud/clever-tools/blob/davlgd-docs-argument-tables/scripts/lib/docs-reference.js#L211).
The other thirteen files are `npm run docs` output.

The quickest check is visual — GitHub renders these tables, so the broken rows show up without
reading any code:

| Reference | Before | After |
|---|---|---|
| `src/commands/ng/ng.docs.md` | [master](https://github.com/CleverCloud/clever-tools/blob/master/src/commands/ng/ng.docs.md) | [this branch](https://github.com/CleverCloud/clever-tools/blob/davlgd-docs-argument-tables/src/commands/ng/ng.docs.md) |
| `src/commands/k8s/k8s.docs.md` | [master](https://github.com/CleverCloud/clever-tools/blob/master/src/commands/k8s/k8s.docs.md) | [this branch](https://github.com/CleverCloud/clever-tools/blob/davlgd-docs-argument-tables/src/commands/k8s/k8s.docs.md) |
| `src/commands/keycloak/keycloak.docs.md` | [master](https://github.com/CleverCloud/clever-tools/blob/master/src/commands/keycloak/keycloak.docs.md) | [this branch](https://github.com/CleverCloud/clever-tools/blob/davlgd-docs-argument-tables/src/commands/keycloak/keycloak.docs.md) |
