### PR TITLE
fix(ssh): make --identity-file actually present the requested key

### DIFF
--- a/src/commands/ssh/ssh.command.js
+++ b/src/commands/ssh/ssh.command.js
@@ -66,7 +66,10 @@ export const sshCommand = defineCommand({
       sshParams.push('-t');
     }
     if (identityFile != null) {
+      // -i adds the key to the ones ssh may offer, but doesn't guarantee it's the one used
       sshParams.push('-i', identityFile);
+      // IdentitiesOnly forces ssh to only offer this key, ignoring agent/default ones
+      sshParams.push('-o', 'IdentitiesOnly=yes');
     }
     sshParams.push(config.SSH_GATEWAY, sshTarget);
 


### PR DESCRIPTION
## Context

`clever ssh --identity-file <key>` doesn't present that key. `-i` only *adds* a file to the
identities ssh may offer, and a loaded agent usually wins the race, so the key you asked for is
never sent:

```
debug1: Offering public key: /home/user/.ssh/id_ed25519 ED25519 SHA256:… agent
debug1: Server accepts key:  /home/user/.ssh/id_ed25519 ED25519 SHA256:… agent
```

The SSH gateway identifies the account from the key it receives, not from the profile the CLI is
logged into: the same instance ID answers a shell with one key and this with another, on an account
the key is not registered on.

```
Error: Failed to choose instance: '… ApiError { id: 9017,
       message: "The specified instance does not exist." }'
```

The instance exists, is `UP`, and the CLI is logged into the right account — the key just belonged
to another one. `--identity-file` is the option that fixes this, and it had no effect.

## Change

Pass `IdentitiesOnly=yes` alongside `-i`, so ssh offers that file and nothing else. It restricts
which keys are *offered*, not how they are used: a key whose private half lives in the agent or on a
hardware token keeps working.

`-o` is the only way to set it — `IdentitiesOnly` is an `ssh_config` keyword with no short flag —
and it matches the two `-o` options the command already passes just above.

## How to review

With an agent loaded and two Clever Cloud accounts, run
`clever ssh --app <app> -i <key of the app's account>`. Before, it fails with the 9017 above; after,
the shell opens.

`ssh -v` shows which key was actually offered, if you want to see it rather than infer it.
