### PR TITLE
fix(aur): widen npm registry retry window to survive publish delay

### DIFF
--- a/scripts/lib/npm-registry.js
+++ b/scripts/lib/npm-registry.js
@@ -1,8 +1,8 @@
 import { highlight } from './terminal.js';
 
 const REGISTRY_URL = 'https://registry.npmjs.org';
-const RETRY_COUNT = 3;
-const RETRY_DELAY = 5000;
+const RETRY_COUNT = 30;
+const RETRY_DELAY = 10000;
 
 /**
  * Gets the SHA512 hash of a package tarball published on the npm registry.


### PR DESCRIPTION
## Summary

- `Publish to AUR (Node.js package)` failed on run [34587868183](https://github.com/CleverCloud/clever-tools/actions/runs/34587868183): npm published `clever-tools@5.0.0` at `10:11:55Z`, while the job's first registry read happened at `10:10:43Z`, 72s earlier and past the previous 3 attempts / 15s retry window.
- Widens `RETRY_COUNT`/`RETRY_DELAY` in `scripts/lib/npm-registry.js` to 30 attempts / 10s, giving about 5 minutes for the npm publish + CDN propagation to land before the AUR job gives up.

## Test plan

- [ ] Next AUR (nodejs) publish job on a real release succeeds without manual rerun